### PR TITLE
FOLIO-1549 Use stripes-framework v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 * New app created with stripes-cli
 * Adjust skeleton application (UIDATIMP-2)
 * Add app icon (UIDATIMP-19)
+* Update stripes-* dependencies and imports to use stripes framework 1.0 (FOLIO-1549)

--- a/package.json
+++ b/package.json
@@ -19,25 +19,21 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes-core": "^2.13.0",
-    "@folio/stripes-connect": "^3.2.1",
-    "@folio/stripes-cli": "^1.4.0",
-    "@folio/stripes-logger": "^1.0.0",
+    "@folio/stripes": "^1.0.0",
+    "@folio/stripes-cli": "^1.5.0",
     "babel-eslint": "^9.0.0",
     "eslint": "^5.5.0",
-    "webpack": "^4.10.2",
     "react": "^16.5.0",
     "react-dom": "^16.5.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^3.0.0",
-    "@folio/stripes-smart-components": "^1.8.0",
     "prop-types": "^15.6.0",
     "react-intl": "^2.3.0",
     "react-router-dom": "^4.1.1",
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
+    "@folio/stripes": "^1.0.0",
     "react": "*"
   },
   "stripes": {

--- a/src/components/Report/Report.js
+++ b/src/components/Report/Report.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Accordion, AccordionSet } from '@folio/stripes-components';
-import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
+import { Accordion, AccordionSet, Row, Col } from '@folio/stripes/components';
 
 import RecordItem from './components/RecordItem';
 import RecordPreview from './components/RecordPreview';

--- a/src/components/Report/components/RecordItem/RecordItem.js
+++ b/src/components/Report/components/RecordItem/RecordItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { Icon } from '@folio/stripes-components';
+import { Icon } from '@folio/stripes/components';
 
 import css from './RecordItem.css';
 

--- a/src/components/Report/components/RecordPreview/RecordPreview.js
+++ b/src/components/Report/components/RecordPreview/RecordPreview.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Row, Col } from '@folio/stripes-components';
+import { Row, Col } from '@folio/stripes/components';
 
 import css from './RecordPreview.css';
 

--- a/src/components/ResultPanel/ResultPanel.js
+++ b/src/components/ResultPanel/ResultPanel.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import { AccordionSet, Accordion, FilterAccordionHeader } from '@folio/stripes-components/lib/Accordion';
-import { Icon } from '@folio/stripes-components';
+import { AccordionSet, Accordion, FilterAccordionHeader, Icon } from '@folio/stripes/components';
 import PropTypes from 'prop-types';
 
 import css from './ResultPanel.css';

--- a/src/components/SearchPanel/SearchPanel.js
+++ b/src/components/SearchPanel/SearchPanel.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
-import { AccordionSet, Accordion, FilterAccordionHeader } from '@folio/stripes-components/lib/Accordion';
-import Checkbox from '@folio/stripes-components/lib/Checkbox';
-import { SearchField } from '@folio/stripes-components';
+import { 
+  AccordionSet,
+  Accordion,
+  FilterAccordionHeader,
+  Checkbox,
+  SearchField,
+} from '@folio/stripes/components';
 
 import css from './SearchPanel.css';
 

--- a/src/components/SearchPanel/SearchPanel.js
+++ b/src/components/SearchPanel/SearchPanel.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import { 
+import {
   AccordionSet,
   Accordion,
   FilterAccordionHeader,

--- a/src/routes/Application.js
+++ b/src/routes/Application.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Icon, Pane, Paneset, PaneMenu, IconButton } from '@folio/stripes-components';
+import { Button, Icon, Pane, Paneset, PaneMenu, IconButton } from '@folio/stripes/components';
 import SearchPanel from '../components/SearchPanel';
 import ResultPanel from '../components/ResultPanel';
 import Report from '../components/Report/Report';

--- a/src/settings/general-settings.js
+++ b/src/settings/general-settings.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Pane from '@folio/stripes-components/lib/Pane';
+import { Pane } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 
 export default class GeneralSettings extends React.Component {

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Settings } from '@folio/stripes-smart-components';
-import { stripesShape } from '@folio/stripes-core/src/Stripes';
+import { Settings } from '@folio/stripes/smart-components';
+import { stripesShape } from '@folio/stripes/core';
 
 import GeneralSettings from './general-settings';
 import SomeFeatureSettings from './some-feature-settings';

--- a/src/settings/some-feature-settings.js
+++ b/src/settings/some-feature-settings.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Pane from '@folio/stripes-components/lib/Pane';
+import { Pane } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 
 export default class FeatureSettings extends React.Component {


### PR DESCRIPTION
This updates `stripes-*` dependencies and their corresponding imports to make use of stripes framework v1.0.0.