### PR TITLE
Replace formatMessage() with FormattedMessage

### DIFF
--- a/src/components/ImportJobs/ImportJobs.js
+++ b/src/components/ImportJobs/ImportJobs.js
@@ -1,18 +1,11 @@
 import React, { Component } from 'react';
-import {
-  injectIntl,
-  intlShape,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import FileUpload from './components/FileUpload';
 
 import css from './components/FileUpload/FileUpload.css';
 
-class ImportJobs extends Component {
-  static propTypes = {
-    intl: intlShape.isRequired,
-  };
-
+export default class ImportJobs extends Component {
   state = {
     isDropZoneActive: false,
   };
@@ -38,7 +31,7 @@ class ImportJobs extends Component {
   getMessageById = (idEnding, moduleName = 'ui-data-import') => {
     const id = `${moduleName}.${idEnding}`;
 
-    return this.props.intl.formatMessage({ id });
+    return <FormattedMessage id={id} />;
   };
 
   render() {
@@ -60,5 +53,3 @@ class ImportJobs extends Component {
     );
   }
 }
-
-export default injectIntl(ImportJobs);

--- a/src/components/ImportJobs/components/FileUpload/FileUpload.js
+++ b/src/components/ImportJobs/components/FileUpload/FileUpload.js
@@ -82,8 +82,8 @@ const FileUpload = (props) => {
 };
 
 FileUpload.propTypes = {
-  title: PropTypes.string.isRequired,
-  uploadBtnText: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
+  uploadBtnText: PropTypes.node.isRequired,
   isDropZoneActive: PropTypes.bool.isRequired,
   onDrop: PropTypes.func.isRequired,
   onDragEnter: PropTypes.func,

--- a/src/components/JobLogs/JobLogs.js
+++ b/src/components/JobLogs/JobLogs.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import {
   MultiColumnList,
@@ -13,7 +13,6 @@ import withJobLogsSort from './withJobLogsSort';
 
 class JobLogs extends Component {
   static propTypes = {
-    intl: intlShape.isRequired,
     sortField: PropTypes.string.isRequired,
     sortDirection: PropTypes.string.isRequired,
     formatter: PropTypes.object.isRequired,
@@ -40,14 +39,12 @@ class JobLogs extends Component {
   constructor(props) {
     super(props);
 
-    const { intl: { formatMessage } } = props;
-
     this.columnMapping = {
-      fileName: formatMessage({ id: 'ui-data-import.jobFileName' }),
-      jobProfileName: formatMessage({ id: 'ui-data-import.jobProfileName' }),
-      jobExecutionHrId: formatMessage({ id: 'ui-data-import.jobExecutionHrId' }),
-      completedDate: formatMessage({ id: 'ui-data-import.jobCompletedDate' }),
-      runBy: formatMessage({ id: 'ui-data-import.jobRunBy' }),
+      fileName: <FormattedMessage id="ui-data-import.jobFileName" />,
+      jobProfileName: <FormattedMessage id="ui-data-import.jobProfileName" />,
+      jobExecutionHrId: <FormattedMessage id="ui-data-import.jobExecutionHrId" />,
+      completedDate: <FormattedMessage id="ui-data-import.jobCompletedDate" />,
+      runBy: <FormattedMessage id="ui-data-import.jobRunBy" />,
     };
 
     this.visibleColumns = [

--- a/src/components/JobLogs/withJobLogsCellsFormatter.js
+++ b/src/components/JobLogs/withJobLogsCellsFormatter.js
@@ -1,16 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {
-  injectIntl,
-  intlShape,
-} from 'react-intl';
-
-import { compose } from '../../utils';
+import { FormattedTime } from 'react-intl';
 
 const withJobLogsCellsFormatter = WrappedComponent => {
   return class extends Component {
     static propTypes = {
-      intl: intlShape.isRequired,
       formatter: PropTypes.object,
     };
 
@@ -41,12 +35,15 @@ const withJobLogsCellsFormatter = WrappedComponent => {
 
     formatEndedRunningDate = record => {
       const { completedDate } = record;
-      const {
-        formatDate,
-        formatTime,
-      } = this.props.intl;
 
-      return `${formatDate(completedDate)} ${formatTime(completedDate)}`;
+      return (
+        <FormattedTime
+          value={completedDate}
+          day="numeric"
+          month="numeric"
+          year="numeric"
+        />
+      );
     };
 
     render() {
@@ -60,7 +57,4 @@ const withJobLogsCellsFormatter = WrappedComponent => {
   };
 };
 
-export default compose(
-  injectIntl,
-  withJobLogsCellsFormatter,
-);
+export default withJobLogsCellsFormatter;

--- a/src/components/JobLogs/withJobLogsSort.js
+++ b/src/components/JobLogs/withJobLogsSort.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import qs from 'qs';
 import get from 'lodash/get';
-import { intlShape } from 'react-intl';
 import { withRouter } from 'react-router';
 
 import { compose } from '../../utils';
@@ -15,7 +14,6 @@ import {
 const withJobLogsSort = WrappedComponent => {
   return class extends Component {
     static propTypes = {
-      intl: intlShape.isRequired,
       formatter: PropTypes.object,
       resource: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.shape({

--- a/src/components/Jobs/Jobs.js
+++ b/src/components/Jobs/Jobs.js
@@ -1,6 +1,6 @@
 import React from 'react';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 
-import { stripesShape } from '@folio/stripes/core';
 import {
   AccordionSet,
   Accordion,
@@ -12,13 +12,13 @@ import jobsMocks from './jobsMocks'; // TODO: to be replaced with real data in f
 
 import css from './Jobs.css';
 
-export default class Jobs extends React.Component {
+class Jobs extends React.Component {
   static propTypes = {
-    stripes: stripesShape.isRequired,
+    intl: intlShape.isRequired,
   };
 
   checkDateIsToday = date => {
-    const { formatDate } = this.props.stripes.intl;
+    const { formatDate } = this.props.intl;
 
     return formatDate(new Date()) === formatDate(date);
   };
@@ -56,13 +56,11 @@ export default class Jobs extends React.Component {
   }
 
   render() {
-    const { formatMessage } = this.props.stripes.intl;
-
     return (
       <div className={css.jobsPane}>
         <AccordionSet>
           <Accordion
-            label={formatMessage({ id: 'ui-data-import.previewJobs' })}
+            label={<FormattedMessage id="ui-data-import.previewJobs" />}
             separator={false}
           >
             <div className={css.jobList}>
@@ -71,7 +69,7 @@ export default class Jobs extends React.Component {
             <EndOfList />
           </Accordion>
           <Accordion
-            label={formatMessage({ id: 'ui-data-import.runningJobs' })}
+            label={<FormattedMessage id="ui-data-import.runningJobs" />}
             separator={false}
           >
             <div className={css.jobList}>
@@ -84,3 +82,5 @@ export default class Jobs extends React.Component {
     );
   }
 }
+
+export default injectIntl(Jobs);

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -1,12 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {
-  FormattedMessage,
-  injectIntl,
-  intlShape,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
-import { stripesShape } from '@folio/stripes/core';
 import {
   Button,
   Pane,
@@ -19,11 +14,9 @@ import ImportJobs from '../components/ImportJobs';
 
 class Home extends Component {
   static propTypes = {
-    stripes: stripesShape.isRequired,
     resources: PropTypes.shape({
       logs: PropTypes.object,
     }),
-    intl: intlShape.isRequired,
   };
 
   static defaultProps = {
@@ -74,36 +67,34 @@ class Home extends Component {
 
   render() {
     const {
-      stripes,
       resources: { logs },
-      intl: { formatMessage },
     } = this.props;
 
     return (
       <Paneset>
         <Pane
           defaultWidth="320px"
-          paneTitle={formatMessage({ id: 'ui-data-import.jobsPaneTitle' })}
+          paneTitle={<FormattedMessage id="ui-data-import.jobsPaneTitle" />}
           lastMenu={this.addManageJobs()}
         >
-          <Jobs stripes={stripes} />
+          <Jobs />
         </Pane>
         <Pane
           defaultWidth="fill"
-          paneTitle={formatMessage({ id: 'ui-data-import.logsPaneTitle' })}
+          paneTitle={<FormattedMessage id="ui-data-import.logsPaneTitle" />}
           lastMenu={this.addViewAllLogs()}
         >
           <JobLogs resource={logs} />
         </Pane>
         <Pane
           defaultWidth="fill"
-          paneTitle={formatMessage({ id: 'ui-data-import.importPaneTitle' })}
+          paneTitle={<FormattedMessage id="ui-data-import.importPaneTitle" />}
         >
-          <ImportJobs stripes={stripes} />
+          <ImportJobs />
         </Pane>
       </Paneset>
     );
   }
 }
 
-export default injectIntl(Home);
+export default Home;

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,30 +1,21 @@
 import React from 'react';
-import {
-  injectIntl,
-  intlShape,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
-import { stripesShape } from '@folio/stripes/core';
 import { Settings } from '@folio/stripes/smart-components';
 
 import GeneralSettings from './general-settings';
 import SomeFeatureSettings from './some-feature-settings';
 
 class DataImportSettings extends React.Component {
-  static propTypes = {
-    stripes: stripesShape.isRequired,
-    intl: intlShape.isRequired,
-  };
-
   pages = [
     {
       route: 'general',
-      label: this.props.intl.formatMessage({ id: 'ui-data-import.settings.general' }),
+      label: <FormattedMessage id="ui-data-import.settings.general" />,
       component: GeneralSettings,
     },
     {
       route: 'somefeature',
-      label: this.props.intl.formatMessage({ id: 'ui-data-import.settings.some-feature' }),
+      label: <FormattedMessage id="ui-data-import.settings.some-feature" />,
       component: SomeFeatureSettings,
     },
   ];
@@ -34,10 +25,10 @@ class DataImportSettings extends React.Component {
       <Settings
         {...this.props}
         pages={this.pages}
-        paneTitle={this.props.intl.formatMessage({ id: 'ui-data-import.settings.index.paneTitle' })}
+        paneTitle={<FormattedMessage id="ui-data-import.settings.index.paneTitle" />}
       />
     );
   }
 }
 
-export default injectIntl(DataImportSettings);
+export default DataImportSettings;


### PR DESCRIPTION
Related to https://github.com/folio-org/ui-circulation/pull/124

`stripes.intl` is deprecated. Preferred approach:
Use `<FormattedMessage>`, `<FormattedDate>`, and `<FormattedTime>` as often as possible, only falling back to `formatMessage()`, `formatDate()`, and `formatTime()` (accompanied by `injectIntl`) when a bare string is absolutely necessary.

I left one instance of `formatDate()` where a date comparison was happening, but that function should be re-evaluated - the date comparison can probably take place without localizing the date strings.