### PR TITLE
UIDATIMP-63: Add UI for file uploading fail.

### DIFF
--- a/src/components/ImportJobs/ImportJobs.js
+++ b/src/components/ImportJobs/ImportJobs.js
@@ -24,11 +24,11 @@ class ImportJobs extends Component {
 
   onDragEnter = () => {
     this.setState({ isDropZoneActive: true });
-  }
+  };
 
   onDragLeave = () => {
     this.setState({ isDropZoneActive: false });
-  }
+  };
 
   /**
    * @param  {Array<File>} acceptedFiles
@@ -67,7 +67,7 @@ class ImportJobs extends Component {
 
   hideModal = () => {
     this.setState({ isModalOpen: false });
-  }
+  };
 
   getMessageById(idEnding, moduleName = 'ui-data-import') {
     const id = `${moduleName}.${idEnding}`;

--- a/src/components/UploadingJobsDisplay/components/FileItem/FileItem.css
+++ b/src/components/UploadingJobsDisplay/components/FileItem/FileItem.css
@@ -1,10 +1,32 @@
 @import "@folio/stripes-components/lib/variables.css";
 
 .fileItem {
+  position: relative;
   margin-bottom: .7rem;
-  padding: .5rem;
+  padding: .5rem 35px .5rem .5rem;
   border: 2px solid var(--color-border);
   border-radius: var(--radius);
+}
+
+.fileItemFailed {
+  border-color: var(--danger);
+  background-color: color(var(--error) alpha(-90%));
+  color: var(--danger);
+}
+
+.fileItemHeader {
+  display: inline-block;
+  overflow-wrap: break-word;
+}
+
+.fileItemHeaderName {
+  margin-right: 2rem;
+}
+
+.icon {
+  position: absolute;
+  top: 0.5rem;
+  right: 10px;
 }
 
 .progress {

--- a/src/components/UploadingJobsDisplay/components/FileItem/FileItem.js
+++ b/src/components/UploadingJobsDisplay/components/FileItem/FileItem.js
@@ -1,20 +1,94 @@
-import React, { PureComponent } from 'react';
+import React, {
+  PureComponent,
+  Fragment,
+} from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import classNames from 'classnames';
 
+import {
+  Icon,
+  IconButton,
+} from '@folio/stripes/components';
+
+import {
+  UPLOADED,
+  UPLOADING,
+  FAILED,
+} from './fileItemStatuses';
 import Progress from '../../../Progress';
 
 import css from './FileItem.css';
+
+const getFileItemMeta = (props) => {
+  const {
+    uploadStatus,
+    name,
+  } = props;
+
+  const defaultFileMeta = {
+    showProgress: false,
+    renderHeading: () => (
+      <Fragment>
+        <span>{name}</span>
+      </Fragment>
+    ),
+  };
+
+  const fileTypesMeta = {
+    [UPLOADING]: {
+      showProgress: true,
+      renderHeading: () => (
+        <Fragment>
+          <span>{name}</span>
+        </Fragment>
+      ),
+    },
+    [UPLOADED]: {
+      renderHeading: () => (
+        <Fragment>
+          <span>{name}</span>
+        </Fragment>
+      ),
+    },
+    [FAILED]: {
+      fileWrapperClassName: css.fileItemFailed,
+      renderHeading: () => (
+        <Fragment>
+          <span className={css.fileItemHeaderName}>{name}</span>
+          <span>
+            <Icon icon="exclamation-circle">
+              <FormattedMessage id="ui-data-import.uploadFileError" />
+            </Icon>
+          </span>
+          <IconButton
+            icon="times"
+            title={<FormattedMessage id="ui-data-import.delete" />}
+            size="small"
+            className={css.icon}
+          />
+        </Fragment>
+      ),
+    },
+  };
+
+  return {
+    ...defaultFileMeta,
+    ...fileTypesMeta[uploadStatus],
+  };
+};
 
 class FileItem extends PureComponent {
   static propTypes = {
     name: PropTypes.string.isRequired,
     size: PropTypes.number.isRequired,
     uploadedValue: PropTypes.number,
+    uploadStatus: PropTypes.string,
   };
 
   static defaultProps = {
     uploadedValue: 0,
+    uploadStatus: UPLOADING,
   };
 
   progressPayload = {
@@ -23,23 +97,34 @@ class FileItem extends PureComponent {
 
   render() {
     const {
-      name,
       uploadedValue,
       size,
+      uploadStatus,
+      name,
     } = this.props;
 
+    const meta = getFileItemMeta({
+      uploadStatus,
+      name,
+    });
+
     return (
-      <div className={css.fileItem}>
-        <span>{name}</span>
-        <Progress
-          payload={this.progressPayload}
-          progressInfoType="messagedPercentage"
-          progressClassName={css.progress}
-          progressWrapperClassName={css.progressWrapper}
-          progressInfoClassName={css.progressInfo}
-          total={size}
-          current={uploadedValue}
-        />
+      <div className={classNames(css.fileItem, meta.fileWrapperClassName)}>
+        <div className={css.fileItemHeader}>
+          {meta.renderHeading()}
+        </div>
+
+        {meta.showProgress && (
+          <Progress
+            payload={this.progressPayload}
+            progressInfoType="messagedPercentage"
+            progressClassName={css.progress}
+            progressWrapperClassName={css.progressWrapper}
+            progressInfoClassName={css.progressInfo}
+            total={size}
+            current={uploadedValue}
+          />
+        )}
       </div>
     );
   }

--- a/src/components/UploadingJobsDisplay/components/FileItem/fileItemStatuses.js
+++ b/src/components/UploadingJobsDisplay/components/FileItem/fileItemStatuses.js
@@ -1,0 +1,3 @@
+export const UPLOADING = '[FileItem] Uploading';
+export const UPLOADED = '[FileItem] Uploaded';
+export const FAILED = '[FileItem] Failed upload';

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -20,13 +20,15 @@
   "today": "today",
   "loading": "Loading",
   "undo": "Undo",
+  "delete": "Delete",
 
   "uploadTitle": "Drag and drop to start a new data import job",
   "activeUploadTitle": "Drop to start import",
   "uploadBtnText": "or choose files",
   "uploadingPaneTitle": "Files",
   "uploadingMessage": "Uploading",
-  
+  "uploadFileError": "Error: file upload",
+
   "jobFileName": "File name",
   "jobProfileName": "Job profile",
   "jobExecutionHrId": "Import ID",


### PR DESCRIPTION
## Purpose
To have UI for error handling, when something goes wrong while files are uploading (e.g. timeout, communication problem)

## Approach
Extend `FileItem` component to support multiple states like `uploading`, `uploaded` and `failed` and differentiate behavior based on that. Additionally, cover both error cases: either error during posting upload definition or error on individual file error.

## Screenshots
<img width="296" alt="screen shot 2018-12-10 at 12 18 14 am" src="https://user-images.githubusercontent.com/40821852/49703714-2cbc9480-fc11-11e8-9403-464d76880faa.png">
