### PR TITLE
UIDATIMP-72: Implement deleting failed files from server feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 * Hide popover when user clicks on the link button (UIDATIMP-71)
 * Write documentation for `FileUploader` component and some code refactor (UIDATIMP-65)
 * Create UI for styling for `Completed` file uploads (UIDATIMP-38)
+* Prevent user navigation when file upload is in progress (UIDATIMP-67)
 * Add document icon to upload file items (UIDATIMP-74)
+* Setup BigTest and write tests for Jobs pane (UIDATIMP-75)
+* Implement deleting failed files from server feature (UIDATIMP-72)
 
 ## [1.0.0](https://github.com/folio-org/ui-data-import/tree/v1.0.0) (2018-11-10)
 

--- a/src/components/UploadingJobsDisplay/components/FileItem/FileItem.js
+++ b/src/components/UploadingJobsDisplay/components/FileItem/FileItem.js
@@ -17,19 +17,21 @@ class FileItem extends PureComponent {
     name: PropTypes.string.isRequired,
     size: PropTypes.number.isRequired,
     keyName: PropTypes.string.isRequired,
+    status: PropTypes.string,
+    loading: PropTypes.bool,
+    uploadedValue: PropTypes.number,
+    uploadDate: PropTypes.instanceOf(Date),
     onDelete: PropTypes.func,
     onUndoDelete: PropTypes.func,
-    uploadedValue: PropTypes.number,
-    status: PropTypes.string,
-    uploadDate: PropTypes.instanceOf(Date),
   };
 
   static defaultProps = {
-    uploadedValue: 0,
     status: fileStatuses.UPLOADING,
+    uploadedValue: 0,
+    uploadDate: null,
+    loading: false,
     onDelete: noop,
     onUndoDelete: noop,
-    uploadDate: null,
   };
 
   progressPayload = {
@@ -38,11 +40,12 @@ class FileItem extends PureComponent {
 
   deleteFile = () => {
     const {
-      onDelete,
       keyName,
+      status,
+      onDelete,
     } = this.props;
 
-    onDelete(keyName);
+    onDelete(keyName, status);
   };
 
   undoDeleteFile = () => {
@@ -61,12 +64,14 @@ class FileItem extends PureComponent {
       name,
       uploadDate,
       uploadedValue,
+      loading,
     } = this.props;
 
     const meta = getFileItemMeta({
       status,
       name,
       uploadDate,
+      loading,
       deleteFile: this.deleteFile,
       undoDeleteFile: this.undoDeleteFile,
     });

--- a/src/components/UploadingJobsDisplay/components/FileItem/fileItemStatuses.js
+++ b/src/components/UploadingJobsDisplay/components/FileItem/fileItemStatuses.js
@@ -1,4 +1,5 @@
 export const UPLOADING = 'UPLOADING';
 export const UPLOADED = 'UPLOADED';
 export const FAILED = 'FAILED';
+export const FAILED_DEFINITION = 'FAILED_DEFINITION';
 export const DELETING = 'DELETING';

--- a/src/components/UploadingJobsDisplay/components/FileItem/getFileItemMeta.js
+++ b/src/components/UploadingJobsDisplay/components/FileItem/getFileItemMeta.js
@@ -14,11 +14,26 @@ import * as fileStatuses from './fileItemStatuses';
 
 import css from './FileItem.css';
 
+const Loading = () => (
+  <FormattedMessage id="ui-data-import.loading">
+    {label => (
+      <span className={css.icon}>
+        <Icon
+          icon="spinner-ellipsis"
+          size="small"
+          ariaLabel={label}
+        />
+      </span>
+    )}
+  </FormattedMessage>
+);
+
 const getFileItemMeta = props => {
   const {
     status,
     name,
     uploadDate,
+    loading,
     deleteFile,
     undoDeleteFile,
   } = props;
@@ -68,16 +83,22 @@ const getFileItemMeta = props => {
               <FormattedMessage id="ui-data-import.uploadFileError" />
             </Icon>
           </span>
-          <FormattedMessage id="ui-data-import.delete">
-            {label => (
-              <IconButton
-                icon="times"
-                size="small"
-                ariaLabel={label}
-                className={css.icon}
-              />
-            )}
-          </FormattedMessage>
+          {!loading
+            ? (
+              <FormattedMessage id="ui-data-import.delete">
+                {label => (
+                  <IconButton
+                    icon="times"
+                    size="small"
+                    ariaLabel={label}
+                    className={css.icon}
+                    onClick={deleteFile}
+                  />
+                )}
+              </FormattedMessage>
+            )
+            : <Loading />
+          }
         </Fragment>
       ),
     },
@@ -91,17 +112,24 @@ const getFileItemMeta = props => {
               values={{ name: <strong>{name}</strong> }}
             />
           </span>
-          <button
-            type="button"
-            className={classNames(css.icon, css.undoIcon)}
-            onClick={undoDeleteFile}
-          >
-            <FormattedMessage id="ui-data-import.undo" />
-          </button>
+          {!loading
+            ? (
+              <button
+                type="button"
+                className={classNames(css.icon, css.undoIcon)}
+                onClick={undoDeleteFile}
+              >
+                <FormattedMessage id="ui-data-import.undo" />
+              </button>
+            )
+            : <Loading />
+          }
         </Fragment>
       ),
     },
   };
+
+  fileTypesMeta[fileStatuses.FAILED_DEFINITION] = fileTypesMeta[fileStatuses.FAILED];
 
   return {
     ...defaultFileMeta,

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -29,6 +29,7 @@
   "uploadingPaneTitle": "Files",
   "uploadingMessage": "Uploading",
   "uploadFileError": "Error: file upload",
+  "fileDeleteError": "Error while deleting {name} file",
   "noUploadedFiles": "No files to show",
 
   "jobFileName": "File name",

--- a/translations/ui-data-import/en_US.json
+++ b/translations/ui-data-import/en_US.json
@@ -46,6 +46,7 @@
     "uploadingMessage": "Uploading",
     "delete": "Delete",
     "uploadFileError": "Error: file upload",
+    "fileDeleteError": "Error while deleting {name} file",
     "modal.header": "Inconsistent file extensions",
     "modal.message": "You cannot upload files with {highlightedText}. Please upload files with the same extension.",
     "modal.messageHighlightedText": "different extensions",


### PR DESCRIPTION
## Purpose
Implement deleting failed files from server.

## Approach
This feature adds new behavior to the **FileItem** component to initiate the removal of the file entry on the backend and display a loading indicator while deleting is in progress. In case of the backend error, the toast shows the error message and loading indicator hides.

## Screenshots
Happy path
![happy_path](https://user-images.githubusercontent.com/40821852/51032284-15721d80-15a8-11e9-9655-47ed45a49f87.gif)

Unhappy path
![unhappy_path](https://user-images.githubusercontent.com/40821852/51032286-199e3b00-15a8-11e9-86dc-efb8a8e7dafa.gif)

