### PR TITLE
Removed padding from results pane

### DIFF
--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -77,6 +77,7 @@ class Home extends Component {
             defaultWidth="fill"
             paneTitle={<FormattedMessage id="ui-data-import.logsPaneTitle" />}
             lastMenu={this.addViewAllLogs()}
+            padContent={false}
           >
             <JobLogs />
           </Pane>


### PR DESCRIPTION
It's a consistent pattern across all modules with a results-pane to remove the padding from the pane (since it's applied inside the MultiColumnList anyway).

## Before
<img width="792" alt="screenshot 2019-02-12 15 31 45" src="https://user-images.githubusercontent.com/640976/52642896-2336fd80-2edc-11e9-9a5c-9641be6dfa0b.png">

## After
<img width="766" alt="screenshot 2019-02-12 15 36 05" src="https://user-images.githubusercontent.com/640976/52642889-203c0d00-2edc-11e9-807b-1e4bbb3a63b4.png">
