### PR TITLE
Replace <IconButton> with <PaneHeaderIconButton>

### DIFF
--- a/src/components/FileExtensionForm/FileExtensionForm.js
+++ b/src/components/FileExtensionForm/FileExtensionForm.js
@@ -13,7 +13,7 @@ import {
   Pane,
   PaneMenu,
   Icon,
-  IconButton,
+  PaneHeaderIconButton,
   Button,
   Headline,
   TextArea,
@@ -79,7 +79,7 @@ export class FileExtensionForm extends Component {
       <PaneMenu>
         <FormattedMessage id="ui-data-import.close">
           {ariaLabel => (
-            <IconButton
+            <PaneHeaderIconButton
               id="clickable-close-file-extension-dialog"
               ariaLabel={ariaLabel}
               icon="times"

--- a/src/routes/Results.js
+++ b/src/routes/Results.js
@@ -7,7 +7,7 @@ import {
   Pane,
   Paneset,
   PaneMenu,
-  IconButton,
+  PaneHeaderIconButton,
 } from '@folio/stripes/components';
 
 import { SearchPanel } from '../components/SearchPanel';
@@ -35,7 +35,7 @@ export class Results extends Component {
   addFirstMenu() {
     return (
       <PaneMenu>
-        <IconButton
+        <PaneHeaderIconButton
           icon="times"
           onClick={this.toggleFilterPane}
         />
@@ -46,7 +46,7 @@ export class Results extends Component {
   addResultsFirstMenu() {
     return (
       <PaneMenu>
-        <IconButton
+        <PaneHeaderIconButton
           icon="search"
           onClick={this.toggleFilterPane}
         />
@@ -71,7 +71,7 @@ export class Results extends Component {
   addRecordDetailsMenu() {
     return (
       <PaneMenu>
-        <IconButton
+        <PaneHeaderIconButton
           icon="times"
           onClick={this.toggleRecordDetailsPane}
         />


### PR DESCRIPTION
We updated stripes-components with an IconButton component that's made specifically for PaneHeaders.

In this PR I replaced the existing IconButton's inside PaneHeaders with the new PaneHeaderIconButton component.