### PR TITLE
Fix unreadable error message when duplicating job profile

### DIFF
--- a/src/components/SearchAndSort/SearchAndSort.js
+++ b/src/components/SearchAndSort/SearchAndSort.js
@@ -635,6 +635,8 @@ export class SearchAndSort extends Component {
       handleEditSuccess,
     } = this.props;
 
+    const duplicateRecordInitialValues = { ...editRecordInitialValues, id: '' };
+
     switch (layer) {
       case LAYER_TYPES.CREATE: {
         return {
@@ -652,7 +654,7 @@ export class SearchAndSort extends Component {
       }
       case LAYER_TYPES.DUPLICATE: {
         return {
-          initialValues: editRecordInitialValues,
+          initialValues: duplicateRecordInitialValues,
           onSubmit: this.createNewRecord,
           onSubmitSuccess: handleCreateSuccess,
         };

--- a/src/components/SearchAndSort/SearchAndSort.js
+++ b/src/components/SearchAndSort/SearchAndSort.js
@@ -634,7 +634,6 @@ export class SearchAndSort extends Component {
       handleCreateSuccess,
       handleEditSuccess,
     } = this.props;
-
     const duplicateRecordInitialValues = { ...editRecordInitialValues, id: '' };
 
     switch (layer) {

--- a/src/components/SearchAndSort/SearchAndSort.js
+++ b/src/components/SearchAndSort/SearchAndSort.js
@@ -634,6 +634,7 @@ export class SearchAndSort extends Component {
       handleCreateSuccess,
       handleEditSuccess,
     } = this.props;
+
     const duplicateRecordInitialValues = { ...editRecordInitialValues, id: '' };
 
     switch (layer) {


### PR DESCRIPTION
When duplicating a job profile and changing only data type, an human unreadable error message appears.