### PR TITLE
UIDATIMP-134: Fix unreadable error message when duplicating job profile

### DIFF
--- a/src/components/SearchAndSort/SearchAndSort.js
+++ b/src/components/SearchAndSort/SearchAndSort.js
@@ -12,6 +12,7 @@ import {
   get,
   upperFirst,
   noop,
+  omit,
 } from 'lodash';
 
 import {
@@ -652,7 +653,7 @@ export class SearchAndSort extends Component {
       }
       case LAYER_TYPES.DUPLICATE: {
         return {
-          initialValues: editRecordInitialValues,
+          initialValues: omit(editRecordInitialValues, 'id'),
           onSubmit: this.createNewRecord,
           onSubmitSuccess: handleCreateSuccess,
         };


### PR DESCRIPTION
## Purpose
When duplicating a job profile and changing only data type, an human unreadable error message appears in the [story](https://issues.folio.org/browse/UIDATIMP-134).

## Screenshots

### Error message
![Error message](https://issues.folio.org/secure/attachment/18147/Unique%20profile%20name%20error%20toast.PNG)


