### PR TITLE
UIDATIMP-285: Create "view all" log screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@folio/stripes": "^2.7.0",
     "@folio/stripes-cli": "^1.13.0",
     "@folio/stripes-core": "^3.3.0",
+    "@folio/stripes-acq-components": "^1.1.0",
+    "@folio/stripes-smart-components": "^2.12.0",
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import {
   JobProfile,
   ViewJobLog,
 } from './routes';
+import ViewAllLogs from './routes/ViewAllLogs';
 import { DataImportSettings } from './settings';
 import { UploadingJobsContextProvider } from './components';
 
@@ -50,6 +51,10 @@ class DataImport extends Component {
             path={`${path}/log/:id`}
             exact
             component={ViewJobLog}
+          />
+          <Route
+            path={`${path}/job-logs`}
+            component={ViewAllLogs}
           />
         </Switch>
       </UploadingJobsContextProvider>

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -19,10 +19,6 @@ export class Home extends Component {
     // TODO: to be implemented in further stories
   };
 
-  handleViewAllLogs = () => {
-    // TODO: to be implemented in further stories
-  };
-
   addManageJobs() {
     return (
       <Button
@@ -40,7 +36,7 @@ export class Home extends Component {
       <Button
         buttonStyle="primary paneHeaderNewButton"
         marginBottom0
-        onClick={this.handleViewAllLogs}
+        to="/data-import/job-logs"
       >
         <FormattedMessage id="ui-data-import.viewAllLogs" />
       </Button>

--- a/src/routes/ViewAllLogs/ViewAllLogs.js
+++ b/src/routes/ViewAllLogs/ViewAllLogs.js
@@ -10,16 +10,16 @@ import {
 import {
   makeQueryFunction,
   SearchAndSort,
-} from '@folio/stripes-smart-components';
+} from '@folio/stripes/smart-components';
 import {
   changeSearchIndex,
   getActiveFilters,
   handleFilterChange,
 } from '@folio/stripes-acq-components';
 
-import packageInfo from '@folio/data-import/package';
 import { stripesConnect } from '@folio/stripes-core';
 import { Button } from '@folio/stripes-components';
+import packageInfo from '../../../package';
 import { FILE_STATUSES } from '../../utils/constants';
 import { Job } from '../../components/Jobs/components/Job';
 import { filterConfig } from './ViewAllLogsFilterConfig';

--- a/src/routes/ViewAllLogs/ViewAllLogs.js
+++ b/src/routes/ViewAllLogs/ViewAllLogs.js
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import {
   FormattedMessage,
-  FormattedTime,
-  injectIntl,
+  injectIntl, intlShape,
 } from 'react-intl';
 
 import {
@@ -25,6 +24,7 @@ import { Job } from '../../components/Jobs/components/Job';
 import { filterConfig } from './ViewAllLogsFilterConfig';
 import { logsSearchTemplate } from './ViewAllLogsSearchConfig';
 import sharedCss from '../../shared.css';
+import { listTemplate } from '../../components/ListTemplate';
 
 const {
   COMMITTED,
@@ -64,6 +64,7 @@ class ViewAllLogs extends Component {
     browseOnly: PropTypes.bool,
     packageInfo: PropTypes.object,
     history: PropTypes.shape({ push: PropTypes.func.isRequired }),
+    intl: intlShape.isRequired,
   };
 
   static defaultProps = {
@@ -132,6 +133,7 @@ class ViewAllLogs extends Component {
       resources,
       showSingleResult,
       stripes,
+      intl,
     } = this.props;
 
     const resultsFormatter = {
@@ -145,38 +147,10 @@ class ViewAllLogs extends Component {
           {record.fileName}
         </Button>
       ),
-      runBy: record => {
-        const {
-          runBy: {
-            firstName,
-            lastName,
-          },
-        } = record;
-
-        return `${firstName} ${lastName}`;
-      },
-      completedDate: record => {
-        const { completedDate } = record;
-
-        return (
-          <FormattedTime
-            value={completedDate}
-            day="numeric"
-            month="numeric"
-            year="numeric"
-          />
-        );
-      },
-      jobProfileName: record => {
-        const { jobProfileInfo: { name } } = record;
-
-        return name;
-      },
-      totalRecords: record => {
-        const { progress: { total } } = record;
-
-        return total;
-      },
+      runBy: listTemplate({ intl }).runBy,
+      completedDate: listTemplate({ intl }).completedDate,
+      jobProfileName: listTemplate({ intl }).jobProfileName,
+      totalRecords: listTemplate({ intl }).totalRecords,
     };
 
     return (

--- a/src/routes/ViewAllLogs/ViewAllLogs.js
+++ b/src/routes/ViewAllLogs/ViewAllLogs.js
@@ -1,0 +1,213 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router-dom';
+import {
+  FormattedMessage,
+  FormattedTime,
+  injectIntl,
+} from 'react-intl';
+
+import {
+  makeQueryFunction,
+  SearchAndSort,
+} from '@folio/stripes-smart-components';
+import {
+  changeSearchIndex,
+  getActiveFilters,
+  handleFilterChange,
+} from '@folio/stripes-acq-components';
+
+import packageInfo from '@folio/data-import/package';
+import { stripesConnect } from '@folio/stripes-core';
+import { Button } from '@folio/stripes-components';
+import { FILE_STATUSES } from '../../utils/constants';
+import { Job } from '../../components/Jobs/components/Job';
+import { filterConfig } from './ViewAllLogsFilterConfig';
+import { logsSearchTemplate } from './ViewAllLogsSearchConfig';
+import sharedCss from '../../shared.css';
+
+const {
+  COMMITTED,
+  ERROR,
+} = FILE_STATUSES;
+
+const columnMapping = {
+  fileName: <FormattedMessage id="ui-data-import.fileName" />,
+  hrId: <FormattedMessage id="ui-data-import.jobExecutionHrId" />,
+  jobProfileName: <FormattedMessage id="ui-data-import.jobProfileName" />,
+  totalRecords: <FormattedMessage id="ui-data-import.records" />,
+  completedDate: <FormattedMessage id="ui-data-import.jobCompletedDate" />,
+  runBy: <FormattedMessage id="ui-data-import.runBy" />,
+};
+
+const visibleColumns = [
+  'fileName',
+  'hrId',
+  'jobProfileName',
+  'totalRecords',
+  'completedDate',
+  'runBy',
+];
+
+const INITIAL_RESULT_COUNT = 25;
+const RESULT_COUNT_INCREMENT = 25;
+
+@withRouter
+@stripesConnect
+class ViewAllLogs extends Component {
+  static propTypes = {
+    mutator: PropTypes.object.isRequired,
+    resources: PropTypes.object.isRequired,
+    stripes: PropTypes.object,
+    disableRecordCreation: PropTypes.bool,
+    showSingleResult: PropTypes.bool,
+    browseOnly: PropTypes.bool,
+    packageInfo: PropTypes.object,
+    history: PropTypes.shape({ push: PropTypes.func.isRequired }),
+  };
+
+  static defaultProps = {
+    showSingleResult: true,
+    browseOnly: false,
+  };
+
+  static manifest = Object.freeze({
+    initializedFilterConfig: { initialValue: false },
+    query: {
+      initialValue: {
+        query: '',
+        filters: '',
+        sort: '-completedDate',
+      },
+    },
+    resultCount: { initialValue: INITIAL_RESULT_COUNT },
+    records: {
+      type: 'okapi',
+      clear: true,
+      records: 'jobExecutions',
+      recordsRequired: '%{resultCount}',
+      path: 'metadata-provider/jobExecutions',
+      perRequest: RESULT_COUNT_INCREMENT,
+      throwErrors: false,
+      GET: {
+        params: {
+          query: makeQueryFunction(
+            `(status any "${COMMITTED} ${ERROR}")`,
+            logsSearchTemplate,
+            {
+              fileName: 'fileName',
+              hrId: 'hrId',
+              jobProfileName: 'jobProfileInfo.name',
+              totalRecords: 'progress.total',
+              completedDate: 'completedDate',
+              runBy: 'runBy.firstName runBy.lastName',
+            },
+            filterConfig,
+          ),
+        },
+        staticFallback: { params: {} },
+      },
+    },
+  });
+
+  constructor(props) {
+    super(props);
+    this.getActiveFilters = getActiveFilters.bind(this);
+    this.handleFilterChange = handleFilterChange.bind(this);
+    this.changeSearchIndex = changeSearchIndex.bind(this);
+    this.onRowClick = this.onRowClick.bind(this);
+  }
+
+  onRowClick(e, meta) {
+    const path = `/data-import/log/${meta.id}`;
+
+    window.open(path, '_blank').focus();
+  }
+
+  render() {
+    const {
+      browseOnly,
+      disableRecordCreation,
+      mutator,
+      resources,
+      showSingleResult,
+      stripes,
+    } = this.props;
+
+    const resultsFormatter = {
+      fileName: record => (
+        <Button
+          buttonStyle="link"
+          marginBottom0
+          buttonClass={sharedCss.cellLink}
+          target="_blank"
+        >
+          {record.fileName}
+        </Button>
+      ),
+      runBy: record => {
+        const {
+          runBy: {
+            firstName,
+            lastName,
+          },
+        } = record;
+
+        return `${firstName} ${lastName}`;
+      },
+      completedDate: record => {
+        const { completedDate } = record;
+
+        return (
+          <FormattedTime
+            value={completedDate}
+            day="numeric"
+            month="numeric"
+            year="numeric"
+          />
+        );
+      },
+      jobProfileName: record => {
+        const { jobProfileInfo: { name } } = record;
+
+        return name;
+      },
+      totalRecords: record => {
+        const { progress: { total } } = record;
+
+        return total;
+      },
+    };
+
+    return (
+      <div data-test-logs-list>
+        <SearchAndSort
+          packageInfo={this.props.packageInfo || packageInfo}
+          objectName="job-logs"
+          baseRoute={packageInfo.stripes.route}
+          initialResultCount={INITIAL_RESULT_COUNT}
+          resultCountIncrement={RESULT_COUNT_INCREMENT}
+          visibleColumns={visibleColumns}
+          columnMapping={columnMapping}
+          resultsFormatter={resultsFormatter}
+          viewRecordComponent={Job}
+          onSelectRow={this.onRowClick}
+          viewRecordPerms="metadata-provider.jobexecutions.get"
+          parentResources={resources}
+          parentMutator={mutator}
+          stripes={stripes}
+          disableRecordCreation={disableRecordCreation}
+          browseOnly={browseOnly}
+          showSingleResult={showSingleResult}
+          renderFilters={this.renderFilters}
+          filterConfig={filterConfig}
+          onFilterChange={this.handleFilterChange}
+          onChangeIndex={this.changeSearchIndex}
+          title={<FormattedMessage id="ui-data-import.logsPaneTitle" />}
+        />
+      </div>
+    );
+  }
+}
+
+export default injectIntl(ViewAllLogs);

--- a/src/routes/ViewAllLogs/ViewAllLogsFilterConfig.js
+++ b/src/routes/ViewAllLogs/ViewAllLogsFilterConfig.js
@@ -1,0 +1,1 @@
+export const filterConfig = [];

--- a/src/routes/ViewAllLogs/ViewAllLogsSearchConfig.js
+++ b/src/routes/ViewAllLogs/ViewAllLogsSearchConfig.js
@@ -1,0 +1,5 @@
+import { generateQueryTemplate } from '@folio/stripes-acq-components';
+
+const indexes = [];
+
+export const logsSearchTemplate = generateQueryTemplate(indexes);

--- a/src/routes/ViewAllLogs/index.js
+++ b/src/routes/ViewAllLogs/index.js
@@ -1,0 +1,1 @@
+export { default } from './ViewAllLogs';

--- a/test/bigtest/interactors/search-and-sort-pane.js
+++ b/test/bigtest/interactors/search-and-sort-pane.js
@@ -1,0 +1,19 @@
+import {
+  interactor,
+  property,
+} from '@bigtest/interactor';
+
+import SearchAndSortInteractor from '@folio/stripes-smart-components/lib/SearchAndSort/tests/interactor';
+import SearchFieldInteractor from '@folio/stripes-components/lib/SearchField/tests/interactor';
+
+@interactor
+class ResetAllButton {
+  isDisabled = property('disabled');
+}
+
+class SearchAndSortPane extends SearchAndSortInteractor {
+  resetButton = new ResetAllButton('#clickable-reset-all');
+  searchInput = new SearchFieldInteractor();
+}
+
+export const searchAndSort = new SearchAndSortPane('[data-test-logs-list]');

--- a/test/bigtest/tests/view-all-logs-test.js
+++ b/test/bigtest/tests/view-all-logs-test.js
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+import {
+  describe,
+  beforeEach,
+  it,
+} from '@bigtest/mocha';
+
+import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumnList/tests/interactor';
+import { searchAndSort } from '../interactors/search-and-sort-pane';
+import { setupApplication } from '../helpers';
+
+const logsList = new MultiColumnListInteractor('#list-data-import');
+const getCellContent = (row, cell) => logsList.rows(row).cells(cell).content;
+
+const LOGS_COUNT = 3;
+
+describe('View all logs', () => {
+  setupApplication({ scenarios: ['fetch-jobs-logs-success'] });
+
+  beforeEach(function () {
+    this.visit('/data-import/job-logs');
+  });
+
+  it('should render logs list', () => {
+    expect(logsList.isPresent).to.be.true;
+  });
+
+  it('should render the correct number of rows', () => {
+    expect(logsList.rowCount).to.equal(LOGS_COUNT);
+  });
+
+  it('sorted default by "completedDate" descending', () => {
+    expect(getCellContent(0, 4)).to.equal('11/11/2018, 2:10 PM');
+    expect(getCellContent(1, 4)).to.equal('11/5/2018, 2:21 PM');
+    expect(getCellContent(2, 4)).to.equal('11/5/2018, 1:08 PM');
+  });
+
+  describe('SearchAndSort pane', () => {
+    it('renders', () => {
+      expect(searchAndSort.isPresent).to.be.true;
+    });
+
+    it('has a collapse button', () => {
+      expect(searchAndSort.collapseFilterPaneButton.isPresent).to.be.true;
+    });
+
+    it('has a resetAll button', () => {
+      expect(searchAndSort.resetButton.isPresent).to.be.true;
+    });
+
+    it('resetAll button is disable by default', () => {
+      expect(searchAndSort.resetButton.isDisabled).to.be.true;
+    });
+
+    describe('fill search input', () => {
+      beforeEach(async () => {
+        await searchAndSort.searchInput.fillInput('Valid name');
+      });
+
+      it('resetAll button is active', () => {
+        expect(searchAndSort.resetButton.isDisabled).to.be.false;
+      });
+    });
+  });
+});


### PR DESCRIPTION
In the scope of this story was implemented "view all" log screen:
1. First pane - Search & filter pane (there are no filters and search options in this story);
2. Second pane is similar to Logs pane at the landing page