### PR TITLE
Remove explicit fake-xml-http-request in advance for the stripes-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-no-only-tests": "^2.3.1",
     "eslint-plugin-react-hooks": "^1.7.0",
-    "fake-xml-http-request": "2.0.0",
     "mocha": "^5.2.0",
     "query-string": "^5.0.0",
     "react": "^16.5.0",
@@ -54,9 +53,6 @@
     "react-router": "^4.3.1",
     "react-router-dom": "^4.1.1",
     "redux-form": "^7.0.3"
-  },
-  "resolutions": {
-    "fake-xml-http-request": "2.0.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^2.7.0",


### PR DESCRIPTION
Having multiple versions of the fake-xml-http-request can prevent patching.