### PR TITLE
Release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-data-import
 
-## 1.7.0 (IN PROGRESS)
+## [1.7.0](https://github.com/folio-org/ui-data-import/tree/v1.7.0) (2019-12-04)
 * Add action options to choose jobs screen (UIDATIMP-268)
 * Add non-editable mode feature for RecordTypesSelect component (UIDATIMP-323)
 * Add match details to the View match profile details pane (UIDATIMP-239)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/data-import",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Data Import manager",
   "main": "src/index.js",
   "repository": "folio-org/ui-data-import",

--- a/src/settings/MappingProfiles/MappingProfilesForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm.js
@@ -155,7 +155,7 @@ export const MappingProfilesFormComponent = ({
         >
           <ActionsAssociator.current
             isMultiSelect
-            isMultiLink={false}
+            isMultiLink
           />
         </Accordion>
       </AccordionSet>

--- a/src/settings/MappingProfiles/ViewMappingProfile.js
+++ b/src/settings/MappingProfiles/ViewMappingProfile.js
@@ -251,7 +251,7 @@ export class ViewMappingProfile extends Component {
           >
             <ActionsAssociator
               record={mappingProfile}
-              isMultiSelect={false}
+              isMultiSelect
               isMultiLink
             />
           </Accordion>


### PR DESCRIPTION
* Add action options to choose jobs screen (UIDATIMP-268)
* Add non-editable mode feature for RecordTypesSelect component (UIDATIMP-323)
* Add match details to the View match profile details pane (UIDATIMP-239)
* Create Match Profiles Form renderer (UIDATIMP-325)
* Increase the width of the View details pane for Match profiles (UIDATIMP-332)
* Create Associator Component (UIDATIMP-275)
* Attach a field mapping profile to an action profile that does not have one (UIDATIMP-269)
* Attach one or more action profiles to a field mapping profile (UIDATIMP-279)