### PR TITLE
UIDATIMP-315: Job profile details, part 4: unlinking match or action profiles :: DONE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Job profile details, part 1: adding match profiles (UIDATIMP-312)
 * Job profile details, part 2: adding secondary match/action profiles (UIDATIMP-313)
 * Add rules for prohibited profile siblings for the ProfileTree component (UIDATIMP-314)
+* Job profile details, part 4: unlinking match or action profiles (UIDATIMP-315)
 * Create FOLIO records' field lists (UIDATIMP-330)
 * Connect Profile Associator Component to unified data source (UIDATIMP-341)
 * Update field naming for mapping profiles (UIDATIMP-349)

--- a/src/components/ProfileAssociator/AssociatedList.js
+++ b/src/components/ProfileAssociator/AssociatedList.js
@@ -124,8 +124,6 @@ export const AssociatedList = memo(({
     onRemove,
   });
 
-  console.log('New Data: ', currentSortOrder, currentSortDirection, currentData);
-
   return (
     <MultiColumnList
       id={`associated-${entityKey}-list`}

--- a/src/components/ProfileTree/ProfileLinker/ProfileLinker.js
+++ b/src/components/ProfileTree/ProfileLinker/ProfileLinker.js
@@ -18,6 +18,7 @@ import {
   LinkerMenu,
   LinkerTrigger,
 } from '.';
+import { PROFILE_RELATION_TYPES } from '../../../utils/constants';
 
 import css from '../ProfileTree.css';
 
@@ -130,6 +131,6 @@ ProfileLinker.propTypes = {
 ProfileLinker.defaultProps = {
   title: '',
   className: '',
-  reactTo: null,
+  reactTo: PROFILE_RELATION_TYPES.NONE,
   disabledOptions: [],
 };

--- a/src/components/ProfileTree/ProfileTree.js
+++ b/src/components/ProfileTree/ProfileTree.js
@@ -8,12 +8,15 @@ import PropTypes from 'prop-types';
 
 import {
   noop,
-  camelCase,
   snakeCase,
 } from 'lodash';
 import classNames from 'classnames';
 
-import { ENTITY_KEYS } from '../../utils/constants';
+import {
+  ENTITY_KEYS,
+  PROFILE_TYPES,
+  PROFILE_RELATION_TYPES,
+} from '../../utils/constants';
 import {
   ProfileBranch,
   ProfileLinker,
@@ -35,7 +38,12 @@ export const ProfileTree = memo(({
   dataAttributes,
 }) => {
   const { siblingsProhibited } = linkingRules;
+
   const dataKey = 'jobProfiles.current';
+  const parentRecordData = {
+    id: parentId,
+    contentType: PROFILE_TYPES.JOB_PROFILE,
+  };
 
   const [changesCount, setChangesCount] = useState(0);
   const [data, setData] = useState([]);
@@ -46,7 +54,13 @@ export const ProfileTree = memo(({
     setData(getData);
   }, [contentData]);
 
+  /**
+   * Disabled due to UIDATIMP-357 and UIDATIMP-358 conflict with context solution
+   * @TODO return this to action or substitute with new solution to fix TreeLine rendering
+   */
   // const ChangesContext = React.createContext(changesCount);
+
+  const isSnakeCase = str => str && str.includes('_');
 
   const getLines = (lines, currentType, reactTo = null) => lines.map(item => ({
     profileId: item.id,
@@ -60,13 +74,19 @@ export const ProfileTree = memo(({
     return relations.findIndex(rel => rel.masterProfileId === masterId && rel.detailProfileId === line.id);
   };
 
-  const composeRelations = (lines, masterId, masterType, detailType, reactTo) => lines.map(item => ({
-    masterProfileId: masterId,
-    masterProfileType: snakeCase(masterType).slice(0, -1).toLocaleUpperCase(),
-    detailProfileId: item.id,
-    detailProfileType: snakeCase(detailType).slice(0, -1).toLocaleUpperCase(),
-    reactTo,
-  }));
+  const composeRelations = (lines, masterId, masterType, detailType, reactTo) => lines.map(item => {
+    const rel = {
+      masterProfileId: masterId,
+      masterProfileType: isSnakeCase(masterType) ? masterType : snakeCase(masterType).slice(0, -1).toLocaleUpperCase(),
+      detailProfileId: item.id,
+      detailProfileType: isSnakeCase(detailType) ? detailType : snakeCase(detailType).slice(0, -1).toLocaleUpperCase(),
+    };
+
+    return reactTo ? {
+      ...rel,
+      reactTo,
+    } : rel;
+  });
 
   const link = (initialData, setInitialData, lines, masterId, masterType, detailType, reactTo, localDataKey) => {
     const uniqueLines = lines.filter(line => initialData.findIndex(item => item.id === line.id) === -1);
@@ -83,33 +103,26 @@ export const ProfileTree = memo(({
     setInitialData(newData);
   };
 
-  const unlink = row => {
-    const index = data.findIndex(item => item.id === row.id);
-    const newIdx = findRelIndex(relationsToAdd, row);
+  const unlink = (parentData, setParentData, line, masterId, masterType, detailType, reactTo, localDataKey) => {
+    const index = parentData.findIndex(item => item.id === line.id);
+    const newIdx = findRelIndex(relationsToAdd, line);
 
     if (newIdx < 0) {
-      const relsToDel = [...relationsToDelete, ...composeRelations([row])];
+      const newRels = composeRelations([line], masterId, masterType, detailType, reactTo);
+      const relsToDel = [...relationsToDelete, ...newRels];
 
       onUnlink(relsToDel);
     }
 
-    data.splice(index, 1);
-    setData(data);
-    sessionStorage.setItem(dataKey, JSON.stringify(data));
+    const newData = [...parentData];
+
+    newData.splice(index, 1);
+    setParentData(newData);
+    sessionStorage.setItem(localDataKey, JSON.stringify(newData));
   };
 
-  const remove = row => {
-    const index = data.findIndex(item => item.id === row.id);
-    const newIdx = findRelIndex(relationsToAdd, row);
-
-    if (newIdx < 0) {
-      const relsToDel = [...relationsToDelete, ...composeRelations([row])];
-
-      onUnlink(relsToDel);
-    }
-
-    data.splice(index, 1);
-    setData(data);
+  const remove = (parentData, setParentData, line, masterId, masterType, detailType, reactTo, localDataKey) => {
+    unlink(parentData, setParentData, line, masterId, masterType, detailType, reactTo, localDataKey);
   };
 
   return (
@@ -119,18 +132,20 @@ export const ProfileTree = memo(({
      */
     /* <ChangesContext.Provider value={changesCount}> */
     <div>
-      {/* <div>{changesCount}</div> */}
       <div className={classNames(css['profile-tree'], className)}>
         <div className={css['profile-tree-container']}>
           {data && data.length ? (
             data.map((item, i) => (
               <ProfileBranch
                 key={`profile-branch-${item.profileId}-${i}`}
-                entityKey={`${camelCase(item.contentType)}s`}
-                recordData={item.content}
-                contentData={item.childSnapshotWrappers}
-                record={record}
+                reactTo={PROFILE_RELATION_TYPES.NONE}
                 linkingRules={linkingRules}
+                recordData={item}
+                record={record}
+                parentRecordData={parentRecordData}
+                parentSectionKey={dataKey}
+                parentSectionData={data}
+                setParentSectionData={setData}
                 onChange={setChangesCount}
                 onLink={link}
                 onUnlink={unlink}

--- a/src/settings/JobProfiles/JobProfilesForm.js
+++ b/src/settings/JobProfiles/JobProfilesForm.js
@@ -191,7 +191,7 @@ JobProfilesFormComponent.propTypes = {
         tags: PropTypes.shape({ tagList: PropTypes.arrayOf(PropTypes.string) }),
         match: PropTypes.string,
       }),
-    })
+    }),
   ).isRequired,
 };
 
@@ -212,5 +212,5 @@ export const JobProfilesForm = compose(
     navigationCheck: true,
     enableReinitialize: true,
   }),
-  connect(mapStateToProps)
+  connect(mapStateToProps),
 )(JobProfilesFormComponent);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -225,6 +225,12 @@ export const PROFILE_LINKING_RULES = {
   siblingsProhibited: { [ENTITY_KEYS.ACTION_PROFILES]: [ENTITY_KEYS.MATCH_PROFILES] },
 };
 
+export const PROFILE_RELATION_TYPES = {
+  NONE: null,
+  MATCH: 'MATCH',
+  NON_MATCH: 'NON_MATCH',
+};
+
 export const INSTANCE_RESOURCE_PATHS = [
   'raml-util/schemas/metadata.schema',
   'instance.json',

--- a/test/bigtest/mocks/field-mapping-rules-samples.js
+++ b/test/bigtest/mocks/field-mapping-rules-samples.js
@@ -7,11 +7,16 @@
 export const fieldMappingRulesOption1 = {
   instances: [{
     name: 'instanceName1',
+    mapActions: {
+      fieldTypeBool: ['ALL_TRUE', 'ALL_FALSE', 'AS_IS', 'IGNORE'],
+      fieldTypeRepeateble: ['EXTEND_EXISTING', 'DELETE_EXISTING', 'EXCHANGE_EXISTING', 'DELETE_INCOMING'],
+    },
     fields: [{
       name: 'fieldName1',
       enabled: true,
       path: 'instanceName1.fieldName1',
       value: '$010',
+      mapAction: '',
       acceptedValues: [],
       subfields: [],
     }, {


### PR DESCRIPTION
## Purpose:
- Implement `Profiles` removal from any `<ProfileTree>` node.
- Implement `deletedRelations` pool composition for `PUT` HTTP request
- Validate removed items on whether they are really need to be removed server-side or just removed from tree nodes.

## Approach:
- Implement common `unlink` and `remove` methods inside `<ProfileTree>` component.
- Push those method refs into all the appropriate `<ProfileTree>` children (`<ProfileBranch>` and `<ProfileLabel>`) as props.

## Issues:
[UIDATIMP-315](https://issues.folio.org/browse/UIDATIMP-315)