### PR TITLE
UIDATIMP-410: Wipe out linked profiles when duplicate a profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Unlink action profile from field mapping profile is not working (UIDATIMP-381)
 * ProfileAssociator Component lists are empty (UIDATIMP-399)
 * Fix UI tests (UIDATIMP-399)
+* Wipe out linked profiles when duplicate a profile (UIDATIMP-410)
 
 ## [1.7.3](https://github.com/folio-org/ui-data-import/tree/v1.7.3) (2019-12-04)
 * Update sorting query for jobs (UIDATIMP-346)

--- a/src/components/SearchAndSort/SearchAndSort.js
+++ b/src/components/SearchAndSort/SearchAndSort.js
@@ -637,7 +637,7 @@ export class SearchAndSort extends Component {
       }
       case LAYER_TYPES.DUPLICATE: {
         return {
-          initialValues: omit(editRecordInitialValues, 'id'),
+          initialValues: omit(editRecordInitialValues, ['id', 'parentProfiles', 'childProfiles']),
           onSubmit: this.createNewRecord,
           onSubmitSuccess: handleCreateSuccess,
         };


### PR DESCRIPTION
## Description
When duplicating matching, action, and field mapping profiles, any linked profiles should be removed.
## Approach
Omit parent and child profiles when the duplicate form renders.
## Issue
[UIDATIMP-410](https://issues.folio.org/browse/UIDATIMP-410)