### PR TITLE
UIDATIMP-427: Fix existing record field name displaying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Wipe out linked profiles when duplicate a profile (UIDATIMP-410)
 * Fix unlinking associated profiles from job profile (UIDATIMP-420)
 * Fix Match Profile regressions (UIDATIMP-421)
+* Fix existing record field name displaying on match profiles (UIDATIMP-427)
 
 ## [1.7.3](https://github.com/folio-org/ui-data-import/tree/v1.7.3) (2019-12-04)
 * Update sorting query for jobs (UIDATIMP-346)

--- a/src/settings/MatchProfiles/ViewMatchProfile.js
+++ b/src/settings/MatchProfiles/ViewMatchProfile.js
@@ -20,6 +20,7 @@ import {
   AccordionSet,
   ConfirmationModal,
   PaneHeader,
+  NoValue,
 } from '@folio/stripes/components';
 import {
   ViewMetaData,
@@ -27,6 +28,7 @@ import {
   TagsAccordion,
 } from '@folio/stripes/smart-components';
 
+import { getFieldMatched } from '../../utils';
 import {
   ENTITY_KEYS,
   SYSTEM_USER_ID,
@@ -210,6 +212,7 @@ export class ViewMatchProfile extends Component {
 
     const record = JSON.parse(JSON.stringify({ ...matchProfile }));
     const staticValueType = get(record, ['matchDetails', '0', 'incomingMatchExpression', 'staticValueDetails', 'staticValueType'], null);
+    const existingRecordField = get(record, ['matchDetails', '0', 'existingMatchExpression', 'fields', '0', 'value'], null);
 
     const tagsEntityLink = `data-import-profiles/matchProfiles/${matchProfile.id}`;
     // Here is mocked config file with mocked values, it should be replaced/rewritten once BE will be ready
@@ -267,6 +270,7 @@ export class ViewMatchProfile extends Component {
           />
         ),
       },
+      'criterion-value-type': { value: getFieldMatched(existingRecordField, matchProfile.existingRecordType) || <NoValue /> },
     };
 
     return (


### PR DESCRIPTION
## Description
The existing record field name is showing the backend field name instead of the label.
## Approach
Get back `getFieldMatched` method for displaying existing record field name correctly
## Issue 
[UIDATIMP-427](https://issues.folio.org/browse/UIDATIMP-427)