### PR TITLE
Release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-data-import
 
-## **1.8.0** (in progress)
+## [1.8.0](https://github.com/folio-org/ui-data-import/tree/v1.8.0) (2020-03-13)
 
 ### Features added:
 * Attach a field mapping profile to an action profile that does not have one (UIDATIMP-269)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/data-import",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "description": "Data Import manager",
   "main": "src/index.js",
   "repository": "folio-org/ui-data-import",
@@ -143,7 +143,7 @@
     "okapiInterfaces": {
       "data-import": "3.0",
       "source-manager-job-executions": "1.0",
-      "data-import-converter-storage": "1.0"
+      "data-import-converter-storage": "1.2"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
## [1.8.0](https://github.com/folio-org/ui-data-import/tree/v1.8.0) (2020-03-13)

### Features added:
* Attach a field mapping profile to an action profile that does not have one (UIDATIMP-269)
* Attach one or more action profiles to a field mapping profile (UIDATIMP-279)
* Create ProfileTree Component (UIDATIMP-326)
* Job profile details, part 1: adding match profiles (UIDATIMP-312)
* Job profile details, part 2: adding secondary match/action profiles (UIDATIMP-313)
* Add rules for prohibited profile siblings for the ProfileTree component (UIDATIMP-314)
* Job profile details, part 4: unlinking match or action profiles (UIDATIMP-315)
* Create FOLIO records' field lists (UIDATIMP-330)
* Connect Profile Associator Component to unified data source (UIDATIMP-341)
* Update field naming for mapping profiles (UIDATIMP-349)
* Data import settings page's 4th pane for Match Profiles: Changes needed to support Static value submatches (UIDATIMP-352)
* Connect Profile Tree Component to unified data source (UIDATIMP-357)
* Rework ProfileLinker Component (UIDATIMP-358)
* Data import settings page's 4th pane for Match Profiles: Create MARC records' match-to section (UIDATIMP-373)
* Convert Match Profiles form Existing Record Field name to JSONPath format (UIDATIMP-375)
* Define API Contract for MappingProfile field mapping definitions (UIDATIMP-377)
* Remove extra action buttons in profiles Settings screens (UIDATIMP-394 - UIDATIMP-397)
* Augment RecordTypeSelector component with Incoming Record Type selection dropdown (UIDATIMP-386)
* Job profile details: suppress the delete/trash can icon (UIDATIMP-390)
* Job Profile Tree: Changes needed to support Static value submatches (UIPFIMP-11)
* Add "defaultMapping" query param to "/processFiles" path (UIDATIMP-417)
* Add caret to the incoming record select dropdown in match profile
* Upgrade Stripes and all the dependencies to version 3.0.0 (UIDATIMP-422)
* Rename renewal.json to ongoing.json (UIDATIMP-428)

### Bugs fixed:
* Profile Associator lists are empty when the user reloads the page with Profile Edit Form open (UIDATIMP-338)
* ProfileTree component TreeLines re-renders are late by one tick from state updates (UIDATIMP-343)
* ProfileTree component ProfileLinker dropdown doesn't close automatically after list option has chosen (UIDATIMP-345)
* Associated profiles not clearing out after viewing, like they should (UIDATIMP-354)
* Search and Sort don't work in Profile Associator Component in view mode (UIDATIMP-374)
* Fix wording of unlink confirmation modal (UIDATIMP-378)
* Fix wording of profile create/update confirmation toast (UIDATIMP-379)
* Page unstable error when trying to save match profile (UIDATIMP-380)
* Unlink action profile from field mapping profile is not working (UIDATIMP-381)
* ProfileAssociator Component lists are empty (UIDATIMP-399)
* Fix UI tests (UIDATIMP-399)
* Fix action profiles' sequence in job profiles (UIDATIMP-412)
* Wipe out linked profiles when duplicate a profile (UIDATIMP-410)
* Fix unlinking associated profiles from job profile (UIDATIMP-420)
* Fix Match Profile regressions (UIDATIMP-421)
* Fix existing record field name displaying on match profiles (UIDATIMP-427)