### PR TITLE
UIDATIMP-398: Remove extra action buttons in File extension Settings …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Add caret to the incoming record select dropdown in match profile
 * Upgrade Stripes and all the dependencies to version 3.0.0 (UIDATIMP-422)
 * Rename renewal.json to ongoing.json (UIDATIMP-428)
+* Remove extra action buttons in File extension Settings screens after central component update (UIDATIMP-398)
 
 ### Bugs fixed:
 * Profile Associator lists are empty when the user reloads the page with Profile Edit Form open (UIDATIMP-338)

--- a/src/settings/FileExtensions/FileExtensions.js
+++ b/src/settings/FileExtensions/FileExtensions.js
@@ -118,7 +118,10 @@ export class FileExtensions extends Component {
     ENTITY_KEY: ENTITY_KEYS.FILE_EXTENSIONS,
     INITIAL_RESULT_COUNT,
     RESULT_COUNT_INCREMENT,
-    actionMenuItems: ['restoreDefaults'],
+    actionMenuItems: [
+      'addNew',
+      'restoreDefaults',
+    ],
     visibleColumns: [
       'extension',
       'importBlocked',

--- a/src/settings/FileExtensions/ViewFileExtension.js
+++ b/src/settings/FileExtensions/ViewFileExtension.js
@@ -13,22 +13,20 @@ import {
   Col,
   KeyValue,
   ConfirmationModal,
+  PaneHeader,
 } from '@folio/stripes/components';
 import { ViewMetaData } from '@folio/stripes/smart-components';
 
 import {
-  LAYER_TYPES,
   ENTITY_KEYS,
   SYSTEM_USER_ID,
   SYSTEM_USER_NAME,
 } from '../../utils/constants';
-import { createLayerURL } from '../../utils';
 import {
   ActionMenu,
   EndOfItem,
   Spinner,
 } from '../../components';
-import { LastMenu } from '../../components/ActionMenu/ItemTemplates/LastMenu';
 
 import sharedCss from '../../shared.css';
 
@@ -65,13 +63,6 @@ export class ViewFileExtension extends Component {
         id: PropTypes.string,
       }).isRequired,
     }).isRequired,
-    location: PropTypes.oneOfType([
-      PropTypes.shape({
-        search: PropTypes.string.isRequired,
-        pathname: PropTypes.string.isRequired,
-      }).isRequired,
-      PropTypes.string.isRequired,
-    ]),
     onClose: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
     paneId: PropTypes.string, // eslint-disable-line
@@ -137,17 +128,23 @@ export class ViewFileExtension extends Component {
     />
   );
 
-  renderLastMenu = record => (
-    <LastMenu
-      caption="ui-data-import.edit"
-      location={createLayerURL(this.props.location, LAYER_TYPES.EDIT)}
-      style={{ visibility: !record ? 'hidden' : 'visible' }}
-      dataAttributes={{ 'data-test-edit-item-button': '' }}
-    />
-  );
+  renderPaneHeader = renderProps => {
+    const { onClose } = this.props;
+    const { record } = this.fileExtensionData;
+
+    return (
+      <PaneHeader
+        {...renderProps}
+        paneTitle={record.extension}
+        paneSub={<FormattedMessage id="ui-data-import.settings.fileExtension.title" />}
+        actionMenu={this.renderActionMenu}
+        dismissible
+        onClose={onClose}
+      />
+    );
+  };
 
   renderFileExtension(record) {
-    const { onClose } = this.props;
     const { showDeleteConfirmation } = this.state;
 
     return (
@@ -155,12 +152,7 @@ export class ViewFileExtension extends Component {
         id="pane-file-extension-details"
         defaultWidth="fill"
         fluidContentWidth
-        paneTitle={record.extension}
-        paneSub={<FormattedMessage id="ui-data-import.settings.fileExtension.title" />}
-        actionMenu={this.renderActionMenu}
-        lastMenu={this.renderLastMenu(record)}
-        dismissible
-        onClose={onClose}
+        renderHeader={this.renderPaneHeader}
       >
         <TitleManager record={record.extension} />
         <Headline

--- a/test/bigtest/interactors/action-menu-interactor.js
+++ b/test/bigtest/interactors/action-menu-interactor.js
@@ -13,6 +13,7 @@ export class ActionMenuInteractor {
   selectAllButton = new ButtonInteractor('[data-test-select-all-items-menu-button]');
   deselectAllButton = new ButtonInteractor('[data-test-deselect-all-items-menu-button]');
   loadRecordsButton = new ButtonInteractor('[data-test-load-records]');
+  restoreDefaultButton = new ButtonInteractor('[data-test-restore-default-file-extensions-button]');
   editProfile = new ButtonInteractor('[data-test-edit-item-menu-button]');
   duplicateProfile = new ButtonInteractor('[data-test-duplicate-item-menu-button]');
   deleteProfile = new ButtonInteractor('[data-test-delete-item-menu-button]');

--- a/test/bigtest/interactors/file-extensions/file-extension-details.js
+++ b/test/bigtest/interactors/file-extensions/file-extension-details.js
@@ -3,26 +3,17 @@ import {
   scoped,
 } from '@bigtest/interactor';
 
-import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor';
 import ConfirmationModalInteractor from '@folio/stripes-components/lib/ConfirmationModal/tests/interactor';
+import { ActionMenuInteractor } from '../action-menu-interactor';
 
 @interactor class FileExtensionDetailsInteractor {
-  paneHeaderDropdown = scoped('[class*="paneHeaderCenterButton"]');
-  dropdownEditButton = new ButtonInteractor('[data-test-edit-item-menu-button]');
-  editButton = new ButtonInteractor('[data-test-edit-item-button]');
-  deleteButton = new ButtonInteractor('[data-test-delete-item-menu-button]');
+  actionMenu = new ActionMenuInteractor();
   headline = scoped('[data-test-headline]');
   extension = scoped('[data-test-extension]');
   description = scoped('[data-test-description]');
   dataTypes = scoped('[data-test-data-types]');
   importBlocked = scoped('[data-test-import-blocked]');
   confirmationModal = new ConfirmationModalInteractor('#delete-file-extension-modal');
-
-  expandPaneHeaderDropdown() {
-    return this
-      .paneHeaderDropdown
-      .click();
-  }
 }
 
 export const fileExtensionDetails = new FileExtensionDetailsInteractor('#pane-file-extension-details');

--- a/test/bigtest/interactors/file-extensions/file-extensions.js
+++ b/test/bigtest/interactors/file-extensions/file-extensions.js
@@ -1,27 +1,19 @@
-import {
-  interactor,
-  scoped,
-} from '@bigtest/interactor';
+import { interactor } from '@bigtest/interactor';
 
 import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor';
 import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/interactor';
 import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumnList/tests/interactor';
 import ConfirmationModalInteractor from '@folio/stripes-components/lib/ConfirmationModal/tests/interactor';
 import TextFieldInteractor from '@folio/stripes-components/lib/TextField/tests/interactor';
+import { ActionMenuInteractor } from '../action-menu-interactor';
 
 @interactor class FileExtensionsInteractor {
-  paneHeaderDropdown = scoped('[class*="paneHeaderCenterButton"]');
-  restoreDefaultFileExtensionsButton = new ButtonInteractor('[data-test-restore-default-file-extensions-button]');
-  newFileExtensionButton = new ButtonInteractor('[data-test-new-button]');
+  actionMenu = new ActionMenuInteractor();
   list = new MultiColumnListInteractor('#file-extensions-list');
   confirmationModal = new ConfirmationModalInteractor('#restore-default-records-modal');
   callout = new CalloutInteractor();
   searchFiled = new TextFieldInteractor('#input-file-extensions-search');
   searchSubmitButton = new ButtonInteractor('[data-test-search-and-sort-submit]');
-
-  expandPaneHeaderDropdown() {
-    return this.paneHeaderDropdown.click();
-  }
 }
 
 export const fileExtensions = new FileExtensionsInteractor();

--- a/test/bigtest/tests/file-extensions/file-extension-details-test.js
+++ b/test/bigtest/tests/file-extensions/file-extension-details-test.js
@@ -30,7 +30,7 @@ async function setupFormSubmitErrorScenario(server, responseData = {}) {
 describe('File extensions table', () => {
   setupApplication({ scenarios: ['fetch-file-extensions-success', 'fetch-users'] });
 
-  beforeEach(() => {
+  beforeEach(function () {
     this.visit('/settings/data-import/file-extensions');
   });
 
@@ -51,27 +51,15 @@ describe('File extensions table', () => {
       expect(fileExtensionDetails.isPresent).to.be.true;
     });
 
-    // TODO: Fix it in UIDATIMP-398
-    describe.skip('edit button', () => {
-      beforeEach(async () => {
-        await fileExtensionDetails.expandPaneHeaderDropdown();
-      });
-
-      it('when pane dropdown is opened', () => {
-        expect(fileExtensionDetails.dropdownEditButton.isVisible).to.be.true;
-      });
-    });
-
     describe('delete confirmation modal', () => {
       it('is not visible when pane header dropdown is closed', () => {
         expect(fileExtensionDetails.confirmationModal.isPresent).to.be.false;
       });
 
-      // TODO: Fix it in UIDATIMP-398
-      describe.skip('is visible', () => {
+      describe('is visible', () => {
         beforeEach(async () => {
-          await fileExtensionDetails.expandPaneHeaderDropdown();
-          await fileExtensionDetails.deleteButton.click();
+          await fileExtensionDetails.actionMenu.click();
+          await fileExtensionDetails.actionMenu.deleteProfile.click();
         });
 
         it('when pane header dropdown is opened', () => {
@@ -79,11 +67,10 @@ describe('File extensions table', () => {
         });
       });
 
-      // TODO: Fix it in UIDATIMP-398
-      describe.skip('disappears', () => {
+      describe('disappears', () => {
         beforeEach(async () => {
-          await fileExtensionDetails.expandPaneHeaderDropdown();
-          await fileExtensionDetails.deleteButton.click();
+          await fileExtensionDetails.actionMenu.click();
+          await fileExtensionDetails.actionMenu.deleteProfile.click();
           await fileExtensionDetails.confirmationModal.cancelButton.click();
         });
 
@@ -92,11 +79,10 @@ describe('File extensions table', () => {
         });
       });
 
-      // TODO: Fix it in UIDATIMP-398
-      describe.skip('upon click on confirm button initiates the deletion process of file extension and in case of success', () => {
+      describe('upon click on confirm button initiates the deletion process of file extension and in case of success', () => {
         beforeEach(async () => {
-          await fileExtensionDetails.expandPaneHeaderDropdown();
-          await fileExtensionDetails.deleteButton.click();
+          await fileExtensionDetails.actionMenu.click();
+          await fileExtensionDetails.actionMenu.deleteProfile.click();
           await fileExtensionDetails.confirmationModal.confirmButton.click();
         });
 
@@ -109,11 +95,10 @@ describe('File extensions table', () => {
         });
       });
 
-      // TODO: Fix it in UIDATIMP-398
-      describe.skip('upon click on confirm button twice initiates the deletion process only once file extension and in case of success', () => {
+      describe('upon click on confirm button twice initiates the deletion process only once file extension and in case of success', () => {
         beforeEach(async () => {
-          await fileExtensionDetails.expandPaneHeaderDropdown();
-          await fileExtensionDetails.deleteButton.click();
+          await fileExtensionDetails.actionMenu.click();
+          await fileExtensionDetails.actionMenu.deleteProfile.click();
           await fileExtensionDetails.confirmationModal.confirmButton.click();
           await fileExtensionDetails.confirmationModal.confirmButton.click();
         });
@@ -131,12 +116,11 @@ describe('File extensions table', () => {
         });
       });
 
-      // TODO: Fix it in UIDATIMP-398
-      describe.skip('upon click on confirm button twice initiates the deletion process only once file extension and in case of error', () => {
+      describe('upon click on confirm button twice initiates the deletion process only once file extension and in case of error', () => {
         beforeEach(async function () {
           this.server.delete('/data-import/fileExtensions/:id', () => new Response(500, {}));
-          await fileExtensionDetails.expandPaneHeaderDropdown();
-          await fileExtensionDetails.deleteButton.click();
+          await fileExtensionDetails.actionMenu.click();
+          await fileExtensionDetails.actionMenu.deleteProfile.click();
           await fileExtensionDetails.confirmationModal.confirmButton.click();
           await fileExtensionDetails.confirmationModal.confirmButton.click();
         });
@@ -156,24 +140,13 @@ describe('File extensions table', () => {
     });
 
     describe('file extension form', () => {
-      // TODO: Fix it in UIDATIMP-398
-      describe.skip('appears', () => {
-        beforeEach(async () => {
-          await fileExtensionDetails.expandPaneHeaderDropdown();
-          await fileExtensionDetails.dropdownEditButton.click();
-        });
-
-        it('upon click on pane header menu edit button', () => {
-          expect(fileExtensionForm.isPresent).to.be.true;
-        });
-      });
-
       describe('appears', () => {
         beforeEach(async () => {
-          await fileExtensionDetails.editButton.click();
+          await fileExtensionDetails.actionMenu.click();
+          await fileExtensionDetails.actionMenu.editProfile.click();
         });
 
-        it('upon click on edit button', () => {
+        it('upon click on pane header actions edit button', () => {
           expect(fileExtensionForm.isPresent).to.be.true;
         });
       });
@@ -181,7 +154,8 @@ describe('File extensions table', () => {
 
     describe('file extension form', () => {
       beforeEach(async () => {
-        await fileExtensionDetails.editButton.click();
+        await fileExtensionDetails.actionMenu.click();
+        await fileExtensionDetails.actionMenu.editProfile.click();
       });
 
       describe('when form is submitted', () => {

--- a/test/bigtest/tests/file-extensions/file-extensions-test.js
+++ b/test/bigtest/tests/file-extensions/file-extensions-test.js
@@ -53,20 +53,17 @@ describe('File extensions', () => {
     });
   });
 
-  describe('restore default file extensions button', () => {
-    it('is not visible when pane dropdown is closed', () => {
-      expect(fileExtensions.restoreDefaultFileExtensionsButton.isVisible).to.be.false;
+  describe('action menu', () => {
+    it('is present', () => {
+      expect(fileExtensions.actionMenu.isMenuPresent).to.be.true;
     });
 
-    // TODO: Fix it in UIDATIMP-398
-    describe.skip('is visible', () => {
-      beforeEach(async () => {
-        await fileExtensions.expandPaneHeaderDropdown();
-      });
+    it('contains restore default file extensions button', () => {
+      expect(fileExtensions.actionMenu.restoreDefaultButton.isPresent).to.be.true;
+    });
 
-      it('when pane dropdown is opened', () => {
-        expect(fileExtensions.restoreDefaultFileExtensionsButton.isVisible).to.be.true;
-      });
+    it('contains new file extensions button', () => {
+      expect(fileExtensions.actionMenu.newProfileButton.isPresent).to.be.true;
     });
   });
 
@@ -75,11 +72,10 @@ describe('File extensions', () => {
       expect(fileExtensions.confirmationModal.isPresent).to.be.false;
     });
 
-    // TODO: Fix it in UIDATIMP-398
-    describe.skip('is visible', () => {
+    describe('is visible', () => {
       beforeEach(async () => {
-        await fileExtensions.expandPaneHeaderDropdown();
-        await fileExtensions.restoreDefaultFileExtensionsButton.click();
+        await fileExtensions.actionMenu.click();
+        await fileExtensions.actionMenu.restoreDefaultButton.click();
       });
 
       it('when restore default file extensions button is clicked', () => {
@@ -87,11 +83,10 @@ describe('File extensions', () => {
       });
     });
 
-    // TODO: Fix it in UIDATIMP-398
-    describe.skip('disappears', () => {
+    describe('disappears', () => {
       beforeEach(async () => {
-        await fileExtensions.expandPaneHeaderDropdown();
-        await fileExtensions.restoreDefaultFileExtensionsButton.click();
+        await fileExtensions.actionMenu.click();
+        await fileExtensions.actionMenu.restoreDefaultButton.click();
         await fileExtensions.confirmationModal.cancelButton.click();
       });
 
@@ -100,12 +95,11 @@ describe('File extensions', () => {
       });
     });
 
-    // TODO: Fix it in UIDATIMP-398
-    describe.skip('upon click on confirm button initiate the restoring process and in case of network error', () => {
+    describe('upon click on confirm button initiate the restoring process and in case of network error', () => {
       beforeEach(async function () {
         this.server.post('/data-import/fileExtensions/restore/default', {}, 500);
-        await fileExtensions.expandPaneHeaderDropdown();
-        await fileExtensions.restoreDefaultFileExtensionsButton.click();
+        await fileExtensions.actionMenu.click();
+        await fileExtensions.actionMenu.restoreDefaultButton.click();
         await fileExtensions.confirmationModal.confirmButton.click();
       });
 
@@ -120,11 +114,10 @@ describe('File extensions', () => {
   });
 
   describe('restore default file extension confirmation modal', () => {
-    // TODO: Fix it in UIDATIMP-398
-    describe.skip('upon click on confirm button initiate the restoring process and in case of success', () => {
+    describe('upon click on confirm button initiate the restoring process and in case of success', () => {
       beforeEach(async () => {
-        await fileExtensions.expandPaneHeaderDropdown();
-        await fileExtensions.restoreDefaultFileExtensionsButton.click();
+        await fileExtensions.actionMenu.click();
+        await fileExtensions.actionMenu.restoreDefaultButton.click();
         await fileExtensions.confirmationModal.confirmButton.click();
       });
 
@@ -143,11 +136,10 @@ describe('File extensions', () => {
   });
 
   describe('restore default file extensions confirmation modal', () => {
-    // TODO: Fix it in UIDATIMP-398
-    describe.skip('upon click on confirm button twice only initiate the restoring process once and in case of success', () => {
+    describe('upon click on confirm button twice only initiate the restoring process once and in case of success', () => {
       beforeEach(async () => {
-        await fileExtensions.expandPaneHeaderDropdown();
-        await fileExtensions.restoreDefaultFileExtensionsButton.click();
+        await fileExtensions.actionMenu.click();
+        await fileExtensions.actionMenu.restoreDefaultButton.click();
         await fileExtensions.confirmationModal.confirmButton.click();
         await fileExtensions.confirmationModal.confirmButton.click();
       });

--- a/test/bigtest/tests/file-extensions/new-file-extensions-test.js
+++ b/test/bigtest/tests/file-extensions/new-file-extensions-test.js
@@ -26,8 +26,7 @@ async function setupFormSubmitErrorScenario(server, responseData = {}) {
   await fileExtensionForm.submitFormButton.click();
 }
 
-// TODO: Fix it in UIDATIMP-398
-describe.skip('File extension form', () => {
+describe('File extension form', () => {
   setupApplication();
 
   beforeEach(function () {
@@ -36,7 +35,8 @@ describe.skip('File extension form', () => {
 
   describe('appears', () => {
     beforeEach(async () => {
-      await fileExtensions.newFileExtensionButton.click();
+      await fileExtensions.actionMenu.click();
+      await fileExtensions.actionMenu.newProfileButton.click();
     });
 
     it('upon click on new file extension button', () => {

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -170,6 +170,7 @@
   "settings.reset.error": "Instance reset to defaults failure:",
   "settings.save.error.network": "Record not saved:",
   "settings.fileExtensions.title": "File extensions",
+  "settings.fileExtensions.new": "New file extension",
   "settings.fileExtensions.reset": "Reset all extension mappings to system defaults",
   "settings.fileExtensions.count": "{count, number} file {count, plural, one {extension} other {extensions}}",
   "filter.errors": "Errors in import",


### PR DESCRIPTION
## Purpose

- Update pane header after [PR](https://github.com/folio-org/stripes-components/pull/1112) since buttons with the same functions are duplicated

## Approach

- Add renderHeader prop to `<Pane>` component
- Move props from  `<Pane>` to `<PaneHeader>` component
- Remove lastMenu prop from `<Pane>` component
- Update tests according to changes

## Issues
[UIDATIMP-398](https://issues.folio.org/browse/UIDATIMP-398)