### PR TITLE
UIDATIMP-425: Fix broken Record Type Selection Tree in RTL mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Data import settings Match Profiles: Changes for Static value Number, Date submatches (UIDATIMP-414)
 
 ### Bugs fixed:
+* Fix broken Record Type Selection Tree in RTL mode (UIDATIMP-425)
 
 ## [1.8.0](https://github.com/folio-org/ui-data-import/tree/v1.8.0) (2020-03-13)
 

--- a/src/components/RecordTypesSelect/RecordTypesSelect.css
+++ b/src/components/RecordTypesSelect/RecordTypesSelect.css
@@ -28,8 +28,12 @@
   text-align: center;
 }
 
-.treeView {
+.treeViewLTR {
   padding-right: 20px;
+}
+
+.treeViewRTL {
+  padding-left: 20px;
 }
 
 .item {
@@ -70,6 +74,10 @@
   border-left: 1px solid var(--color-border);
 }
 
+.borderRight {
+  border-right: 1px solid var(--color-border);
+}
+
 .contentContainer {
   position: relative;
   flex-wrap: nowrap;
@@ -106,7 +114,6 @@
   border-radius: .5rem;
   color: #fff;
   margin: 4px;
-  margin-left: 0;
   white-space: pre-line;
   align-self: stretch;
 }
@@ -131,7 +138,6 @@
   composes: display-flex flex-align-items-center from "@folio/stripes-components/lib/Layout/Layout.css";
   position: absolute;
   top: 9px;
-  right: 0px;
   transform: translate(50%);
 }
 

--- a/src/components/RecordTypesSelect/RecordTypesSelect.js
+++ b/src/components/RecordTypesSelect/RecordTypesSelect.js
@@ -15,6 +15,7 @@ import {
   FOLIO_RECORD_TYPES,
   INCOMING_RECORD_TYPES,
 } from '../ListTemplate';
+import { HTML_LANG_DIRECTIONS } from '../../utils/constants';
 
 const useForceUpdate = () => useState()[1];
 
@@ -39,6 +40,8 @@ export const RecordTypesSelect = memo(({
   onIncomingSelect,
   isEditable,
 }) => {
+  const IS_LOCALE_LTR = document.dir === HTML_LANG_DIRECTIONS.LEFT_TO_RIGHT;
+
   useUpdateOnResize();
   const [existingRecord, setExistingRecord] = useState(undefined);
   const [incomingRecord, setIncomingRecord] = useState(undefined);
@@ -70,6 +73,7 @@ export const RecordTypesSelect = memo(({
             setExistingRecord={handleSelect}
             setIncomingRecord={onIncomingSelect}
             isEditable={isEditable}
+            isLocalLTR={IS_LOCALE_LTR}
           />
         )
         : (
@@ -77,9 +81,9 @@ export const RecordTypesSelect = memo(({
             id={id}
             onItemSelect={handleSelect}
             isEditable={isEditable}
+            isLocalLTR={IS_LOCALE_LTR}
           />
-        )
-      }
+        )}
     </div>
   );
 });

--- a/src/components/RecordTypesSelect/components/CompareRecordSelect.js
+++ b/src/components/RecordTypesSelect/components/CompareRecordSelect.js
@@ -39,6 +39,7 @@ export const CompareRecordSelect = memo(({
   setExistingRecord,
   setIncomingRecord,
   isEditable,
+  isLocalLTR,
 }) => {
   const [top, setTop] = useState();
   const [height, setHeight] = useState();
@@ -92,7 +93,7 @@ export const CompareRecordSelect = memo(({
         </Col>
         <Col
           xs
-          className={classNames(css.headingCell, css.borderLeft)}
+          className={classNames(css.headingCell, { [css.borderLeft]: isLocalLTR }, { [css.borderRight]: !isLocalLTR })}
         >
           <Headline
             size="large"
@@ -118,10 +119,13 @@ export const CompareRecordSelect = memo(({
           >
             <Triangle
               size={hintTriangleSize}
-              direction="left"
+              direction={isLocalLTR ? 'left' : 'right'}
               color="#616161"
             />
-            <div className={css.hintMessage}>
+            <div
+              className={css.hintMessage}
+              style={{ [isLocalLTR ? 'marginLeft' : 'marginRight']: 0 }}
+            >
               <FormattedMessage id="ui-data-import.compareHint" />
             </div>
           </div>
@@ -132,7 +136,7 @@ export const CompareRecordSelect = memo(({
           style={{
             visibility: renderSelectedLine ? null : 'hidden',
             marginTop: top,
-            paddingRight: spaceForCompareElem,
+            [isLocalLTR ? 'paddingRight' : 'paddingLeft']: spaceForCompareElem,
           }}
         >
           <RecordItem
@@ -148,21 +152,23 @@ export const CompareRecordSelect = memo(({
             style={{
               width: compareElemWidth,
               height: `calc(${height}px + ${css.cellPadding} - ${css.selectedLineBorderWidth} - ${css.selectedLineBorderWidth})`,
+              right: isLocalLTR ? 0 : null,
+              left: !isLocalLTR ? `-${compareElemWidth}px` : null,
             }}
           >
-            <Triangle />
+            <Triangle direction={isLocalLTR ? 'right' : 'left'} />
             <span className={css.compareMessage}>
               <FormattedMessage id="ui-data-import.compare" />
             </span>
-            <Triangle direction="left" />
+            <Triangle direction={isLocalLTR ? 'left' : 'right'} />
           </div>
         </Col>
         <Col
           xs
-          className={classNames(css.cell, css.borderLeft)}
+          className={classNames(css.cell, { [css.borderLeft]: isLocalLTR }, { [css.borderRight]: !isLocalLTR })}
           style={{
-            paddingLeft: spaceForCompareElem,
-            paddingRight: spaceForHintElement,
+            paddingLeft: isLocalLTR ? spaceForCompareElem : spaceForHintElement,
+            paddingRight: isLocalLTR ? spaceForHintElement : spaceForCompareElem,
           }}
         >
           <div ref={existingRecordsElemRef}>
@@ -171,6 +177,7 @@ export const CompareRecordSelect = memo(({
                 id={id}
                 onSelect={setExistingRecord}
                 isEditable={isEditable}
+                isLocalLTR={isLocalLTR}
               />
             )}
           </div>
@@ -187,6 +194,7 @@ CompareRecordSelect.propTypes = {
   incomingRecord: PropTypes.object,
   existingRecord: PropTypes.object,
   isEditable: PropTypes.bool,
+  isLocalLTR: PropTypes.bool,
 };
 
 CompareRecordSelect.defaultProps = {
@@ -195,4 +203,5 @@ CompareRecordSelect.defaultProps = {
   incomingRecord: null,
   existingRecord: null,
   isEditable: true,
+  isLocalLTR: true,
 };

--- a/src/components/RecordTypesSelect/components/InitialRecordSelect.js
+++ b/src/components/RecordTypesSelect/components/InitialRecordSelect.js
@@ -13,6 +13,7 @@ export const InitialRecordSelect = ({
   id,
   onItemSelect,
   isEditable,
+  isLocalLTR,
 }) => {
   return (
     <section
@@ -34,6 +35,7 @@ export const InitialRecordSelect = ({
         id={id}
         onSelect={onItemSelect}
         isEditable={isEditable}
+        isLocalLTR={isLocalLTR}
       />
     </section>
   );
@@ -43,6 +45,10 @@ InitialRecordSelect.propTypes = {
   onItemSelect: PropTypes.func.isRequired,
   id: PropTypes.string,
   isEditable: PropTypes.bool,
+  isLocalLTR: PropTypes.bool,
 };
 
-InitialRecordSelect.defaultProps = { isEditable: true };
+InitialRecordSelect.defaultProps = {
+  isEditable: true,
+  isLocalLTR: true,
+};

--- a/src/components/RecordTypesSelect/components/RecordSelect.js
+++ b/src/components/RecordTypesSelect/components/RecordSelect.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import { TreeLine } from '../../TreeLine';
 import { TreeView } from '../../TreeView';
 import { RecordItem } from './RecordItem';
-import { FOLIO_RECORD_TYPES } from '../../ListTemplate';
 
+import { FOLIO_RECORD_TYPES } from '../../ListTemplate';
 import { rootList } from '../../TreeView/TreeView.css';
 import css from '../RecordTypesSelect.css';
 
@@ -45,12 +45,14 @@ export const RecordSelect = ({
   container = `#${id} .${rootList}`,
   treeData = recordsData,
   isEditable,
+  isLocalLTR,
 }) => (
   <>
     <TreeView
       data={treeData}
-      className={css.treeView}
+      className={isLocalLTR ? css.treeViewLTR : css.treeViewRTL}
       container={container}
+      isLocalLTR={isLocalLTR}
       renderItem={item => (
         <RecordItem
           item={item.itemMeta}
@@ -64,10 +66,11 @@ export const RecordSelect = ({
         key={element}
         from={element}
         to={treeData.connections[0]}
-        fromAnchor="right"
-        toAnchor="right"
+        fromAnchor={isLocalLTR ? 'right' : 'left'}
+        toAnchor={isLocalLTR ? 'right' : 'left'}
         toAnchorOffset="20px"
         container={container}
+        isLocalLTR={isLocalLTR}
       />
     ))}
   </>
@@ -79,6 +82,10 @@ RecordSelect.propTypes = {
   container: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Element)]),
   treeData: PropTypes.object,
   isEditable: PropTypes.bool,
+  isLocalLTR: PropTypes.bool,
 };
 
-RecordSelect.defaultProps = { isEditable: true };
+RecordSelect.defaultProps = {
+  isEditable: true,
+  isLocalLTR: true,
+};

--- a/src/components/TreeLine/TreeLine.js
+++ b/src/components/TreeLine/TreeLine.js
@@ -5,8 +5,8 @@ import React, {
 import PropTypes from 'prop-types';
 import { isNil } from 'lodash';
 
-import { getElement } from './utils';
 import { Line } from './Line';
+import { getElement } from './utils';
 
 const anchorTextValues = {
   x: {
@@ -36,6 +36,7 @@ export const TreeLine = props => {
     fromAnchorOffset = '',
     toAnchorOffset = '',
     orientation = ORIENTATIONS.VERTICAL,
+    isLocalLTR = true,
   } = props;
   const [fromElement, setFromElement] = useState(undefined);
   const [toElement, setToElement] = useState(undefined);
@@ -131,10 +132,23 @@ export const TreeLine = props => {
       offsetY -= containerElementDimensions.top + (window.pageYOffset || document.documentElement.scrollTop);
     }
 
-    const x0 = fromElementDimensions.left + (fromElementDimensions.width * fromAnchorCoordinates.x) + offsetX + fromAnchorOffsetValue.x;
     const y0 = fromElementDimensions.top + (fromElementDimensions.height * fromAnchorCoordinates.y) + offsetY + fromAnchorOffsetValue.y;
-    const x1 = toElementDimensions.left + (toElementDimensions.width * toAnchorCoordinates.x) + offsetX + toAnchorOffsetValue.x;
     const y1 = toElementDimensions.top + (toElementDimensions.height * toAnchorCoordinates.y) + offsetY + toAnchorOffsetValue.y;
+
+    if (!isLocalLTR) {
+      const x0 = fromElementDimensions.left + (fromElementDimensions.width * fromAnchorCoordinates.x) + offsetX - fromAnchorOffsetValue.x;
+      const x1 = toElementDimensions.left + (toElementDimensions.width * toAnchorCoordinates.x) + offsetX - toAnchorOffsetValue.x;
+
+      return {
+        x0,
+        y0,
+        x1,
+        y1,
+      };
+    }
+
+    const x0 = fromElementDimensions.left + (fromElementDimensions.width * fromAnchorCoordinates.x) + offsetX + fromAnchorOffsetValue.x;
+    const x1 = toElementDimensions.left + (toElementDimensions.width * toAnchorCoordinates.x) + offsetX + toAnchorOffsetValue.x;
 
     return {
       x0,
@@ -221,4 +235,5 @@ TreeLine.propTypes = {
   borderWidth: PropTypes.number,
   className: PropTypes.string,
   zIndex: PropTypes.number,
+  isLocalLTR: PropTypes.bool,
 };

--- a/src/components/TreeView/TreeView.css
+++ b/src/components/TreeView/TreeView.css
@@ -6,7 +6,7 @@
 
 .rootList {
   position: relative;
-  padding-left: 0;
+  padding: 0;
 }
 
 .listItem {

--- a/src/components/TreeView/TreeView.js
+++ b/src/components/TreeView/TreeView.js
@@ -12,6 +12,7 @@ export const TreeView = ({
   indentation = 40,
   spacing = '1rem',
   container = `.${css.rootList}`,
+  isLocalLTR = true,
   className,
   renderItem = noop,
 }) => {
@@ -22,7 +23,7 @@ export const TreeView = ({
   }) => Array.isArray(items) && (
     <ul
       className={classNames(css.list, { [css.rootList]: root })}
-      style={root ? null : { paddingLeft: indentation }}
+      style={root ? null : { [isLocalLTR ? 'paddingLeft' : 'paddingRight']: indentation }}
     >
       {items.map((item, index) => {
         const itemKey = item.itemMeta.type;
@@ -41,10 +42,11 @@ export const TreeView = ({
                 from={parent}
                 to={itemSelector}
                 container={container}
-                fromAnchor="left bottom"
-                toAnchor="left"
+                fromAnchor={isLocalLTR ? 'left bottom' : 'right bottom'}
+                toAnchor={isLocalLTR ? 'left' : 'right'}
                 fromAnchorOffset={`${indentation / 2}px`}
                 orientation="horizontal"
+                isLocalLTR={isLocalLTR}
               />
             )}
             {renderList({
@@ -77,4 +79,5 @@ TreeView.propTypes = {
   container: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Element)]),
   className: PropTypes.string,
   renderItem: PropTypes.func,
+  isLocalLTR: PropTypes.bool,
 };


### PR DESCRIPTION
## Description
Record Type Selection Tree looks broken with RTL locales such as Hebrew and Arabian

## Approach
Check document.dir and apply appropriate styles

## Issue
[UIDATIMP-425](https://issues.folio.org/browse/UIDATIMP-425)

## Screenshot
![record-selector-rtl](https://user-images.githubusercontent.com/55138456/77178957-811b1900-6ad0-11ea-9be4-d08402632e7d.png)
