### PR TITLE
UIDATIMP-418: Set defaultMapping query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features added:
 * Data import settings Match Profiles: Changes for Static value Number, Date submatches (UIDATIMP-414)
+* Set defaultMapping query param when data-import process is run with chosen JobProfile to false (UIDATIMP-418)
 
 ### Bugs fixed:
 * Fix broken Record Type Selection Tree in RTL mode (UIDATIMP-425)

--- a/src/components/UploadingJobsDisplay/UploadingJobsDisplay.js
+++ b/src/components/UploadingJobsDisplay/UploadingJobsDisplay.js
@@ -501,6 +501,7 @@ export class UploadingJobsDisplay extends Component {
         okapi,
         uploadDefinitionId: uploadDefinition.id,
         jobProfileInfo,
+        defaultMapping: true,
       });
 
       history.push('/data-import');

--- a/src/settings/JobProfiles/ViewJobProfile.js
+++ b/src/settings/JobProfiles/ViewJobProfile.js
@@ -257,6 +257,7 @@ export class ViewJobProfile extends Component {
         okapi,
         uploadDefinitionId: uploadDefinition.id,
         jobProfileInfo,
+        defaultMapping: false,
       });
 
       history.push('/data-import');

--- a/src/utils/loadRecords.js
+++ b/src/utils/loadRecords.js
@@ -32,6 +32,7 @@ export const loadRecords = async ({
   okapi,
   uploadDefinitionId,
   jobProfileInfo,
+  defaultMapping,
 }) => {
   const { url: host } = okapi;
 
@@ -41,7 +42,7 @@ export const loadRecords = async ({
   });
 
   const uploadDefinitionsURL = createUrl(`${host}/data-import/uploadDefinitions/${uploadDefinitionId}/processFiles`,
-    { defaultMapping: true }, false);
+    { defaultMapping }, false);
 
   const response = await fetch(uploadDefinitionsURL, {
     method: 'POST',


### PR DESCRIPTION
## Description
Remove or set to false `defaultMapping` query param when data-import process is run with chosen JobProfile.

## Approach

- Add defaultMapping arg to loadRecords method
- Set defaultMapping value false for running process with jobProfile
- Set defaultMapping value true for the default running process
- Put defaultMapping value to the request

## Ticket
[UIDATIMP-418](https://issues.folio.org/browse/UIDATIMP-418)