### PR TITLE
UIDATIMP-456 Fix Mapping Profile existing record type recognition behavior :: DONE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Bugs fixed:
 * Fix broken Record Type Selection Tree in RTL mode (UIDATIMP-425)
 * Fix broken Match criterion section in RTL mode (UIDATIMP-426)
+* Mapping Profiles Form existing record type recognition behavior is wrong (UIDATIMP-456)
 
 ## [1.8.0](https://github.com/folio-org/ui-data-import/tree/v1.8.0) (2020-03-13)
 

--- a/src/settings/MappingProfiles/MappingProfilesForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm.js
@@ -1,7 +1,9 @@
 import React, {
   useMemo,
+  useRef,
   useState,
   useEffect,
+  useLayoutEffect,
 } from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
@@ -22,7 +24,6 @@ import stripesForm from '@folio/stripes/form';
 
 import {
   compose,
-  usePrevious,
   withProfileWrapper,
 } from '../../utils';
 import {
@@ -53,6 +54,8 @@ export const MappingProfilesFormComponent = ({
   pristine,
   submitting,
   initialValues,
+  existingRecordTypeInitial,
+  mappingDetailsInitial,
   mappingDetails,
   location: { search },
   handleSubmit,
@@ -92,25 +95,26 @@ export const MappingProfilesFormComponent = ({
   ) : <FormattedMessage id="ui-data-import.settings.mappingProfiles.new" />;
   const headLine = isEditMode ? profile.name : <FormattedMessage id="ui-data-import.settings.mappingProfiles.new" />;
 
-  const prevExistingRecordType = usePrevious(get(profile, 'existingRecordType', null));
+  const prevExistingRecordType = useRef(existingRecordTypeInitial);
   const [existingRecordType, setExistingRecordType] = useState(get(profile, 'existingRecordType', null));
-
   const [initials, setInitials] = useState({
     ...profile,
-    mappingDetails: isEmpty(mappingDetails) ? getInitialDetails(existingRecordType, true) : mappingDetails,
+    mappingDetails: isEmpty(mappingDetails) ? getInitialDetails(prevExistingRecordType.current, true) : mappingDetails,
   });
   const [addedRelations, setAddedRelations] = useState([]);
   const [deletedRelations, setDeletedRelations] = useState([]);
 
-  useEffect(() => {
-    const isEqual = existingRecordType === prevExistingRecordType;
+  useLayoutEffect(() => {
+    const isEqual = existingRecordType === prevExistingRecordType.current;
     const needsUpdate = !profile.id || (profile.id && (!isEqual || isEmpty(mappingDetails)));
 
     if (isEqual || !needsUpdate) {
       return;
     }
 
-    const newInitDetails = getInitialDetails(existingRecordType, true);
+    const newInitDetails = existingRecordType === existingRecordTypeInitial
+      ? mappingDetailsInitial
+      : getInitialDetails(existingRecordType, true);
     const newInitials = {
       ...initials,
       mappingDetails: newInitDetails,
@@ -118,6 +122,9 @@ export const MappingProfilesFormComponent = ({
 
     setInitials(newInitials);
     dispatch(change(formName, 'profile.mappingDetails', newInitDetails));
+    if (!isEqual) {
+      prevExistingRecordType.current = existingRecordType;
+    }
   }, [existingRecordType]); // eslint-disable-line react-hooks/exhaustive-deps
   useEffect(() => {
     dispatch(change(formName, 'addedRelations', addedRelations));
@@ -193,6 +200,8 @@ MappingProfilesFormComponent.propTypes = {
     }).isRequired,
     PropTypes.string.isRequired,
   ]),
+  existingRecordTypeInitial: PropTypes.string.isRequired,
+  mappingDetailsInitial: PropTypes.object.isRequired,
   mappingDetails: PropTypes.object.isRequired,
   onCancel: PropTypes.func.isRequired,
   dispatch: PropTypes.func.isRequired,
@@ -200,9 +209,15 @@ MappingProfilesFormComponent.propTypes = {
 
 const mapStateToProps = state => {
   // @TODO: Remove this when FlexibleForm internal state mamagement will be implemented.
+  const mappingDetailsInitial = get(state, ['form', formName, 'initial', 'profile', 'mappingDetails'], null);
   const mappingDetails = get(state, ['form', formName, 'values', 'profile', 'mappingDetails'], null);
+  const existingRecordTypeInitial = get(state, ['form', formName, 'initial', 'profile', 'existingRecordType'], null);
 
-  return { mappingDetails };
+  return {
+    existingRecordTypeInitial,
+    mappingDetailsInitial,
+    mappingDetails,
+  };
 };
 
 export const MappingProfilesForm = compose(


### PR DESCRIPTION
## Problem:
- Mapping Profiles Form existing record type recognition behavior is wrong

## Symptoms:
- Form loads with empty mapping details section when it loads for existing record edit mode.
- When the user changes existing record type for already existing mapping profile and then returns to original existing record type, form believes nothing has changed and leaves the previous section type initial data that prevents the form from correct work behavior.

## Root causes:
- When the form loads with existing record in edit mode it first persists null as previous (initial) existing record type value and then loads the form data with actual value from the form state. This pushes the form logic to believe existing record type has changed and empty initial data load is needed