### PR TITLE
UIDATIMP-413: Display filled sub-sections of a match profile on linking to a job profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Set defaultMapping query param when data-import process is run with chosen JobProfile to false (UIDATIMP-418)
 * Rearrange the match profile diagram structure (UIDATIMP-411)
 * Add "profileType" query param to request for get /profileSnapshots/{profileId} (UIDATIMP-444)
+* Provide a profile snapshot with childWrappers when new profile association added to a job profile (UIDATIMP-413)
 
 ### Bugs fixed:
 * Fix broken Record Type Selection Tree in RTL mode (UIDATIMP-425)

--- a/src/components/ProfileTree/ProfileBranch.js
+++ b/src/components/ProfileTree/ProfileBranch.js
@@ -34,6 +34,7 @@ export const ProfileBranch = memo(({
   linkingRules,
   recordData,
   record,
+  okapi,
   parentRecordData,
   parentSectionKey,
   parentSectionData,
@@ -153,8 +154,7 @@ export const ProfileBranch = memo(({
                       values={{ type: <FormattedMessage id="ui-data-import.section" /> }}
                     />
                   </div>
-                )
-              }
+                )}
             </div>
             <TreeLine
               from={`#branch-${record ? 'editable' : 'static'}-${currentRecord.id}`}
@@ -177,6 +177,7 @@ export const ProfileBranch = memo(({
                 setInitialData={setMatchData}
                 reactTo={PROFILE_RELATION_TYPES.MATCH}
                 onLink={onLink}
+                okapi={okapi}
                 {...dataAttributes}
               />
             )}
@@ -213,8 +214,7 @@ export const ProfileBranch = memo(({
                       values={{ type: <FormattedMessage id="ui-data-import.section" /> }}
                     />
                   </div>
-                )
-              }
+                )}
             </div>
             <TreeLine
               from={`#branch-${record ? 'editable' : 'static'}-${currentRecord.id}`}
@@ -237,6 +237,7 @@ export const ProfileBranch = memo(({
                 setInitialData={setNonMatchData}
                 reactTo={PROFILE_RELATION_TYPES.NON_MATCH}
                 onLink={onLink}
+                okapi={okapi}
                 {...dataAttributes}
               />
             )}
@@ -255,6 +256,11 @@ ProfileBranch.propTypes = {
   parentSectionKey: PropTypes.string.isRequired,
   parentSectionData: PropTypes.arrayOf(PropTypes.object).isRequired,
   setParentSectionData: PropTypes.func.isRequired,
+  okapi: PropTypes.shape({
+    tenant: PropTypes.string.isRequired,
+    token: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
   record: PropTypes.object,
   className: PropTypes.string,
   onChange: PropTypes.func,

--- a/src/components/ProfileTree/ProfileTree.js
+++ b/src/components/ProfileTree/ProfileTree.js
@@ -31,6 +31,7 @@ export const ProfileTree = memo(({
   contentData,
   relationsToAdd,
   relationsToDelete,
+  okapi,
   onLink,
   onUnlink,
   record,
@@ -67,8 +68,8 @@ export const ProfileTree = memo(({
     profileId: item.id,
     contentType: snakeCase(currentType).slice(0, -1).toLocaleUpperCase(),
     reactTo,
-    content: item,
-    childSnapshotWrappers: [],
+    content: item.content,
+    childSnapshotWrappers: item.childSnapshotWrappers || [],
   }));
 
   const findRelIndex = (relations, masterId, line) => {
@@ -153,6 +154,7 @@ export const ProfileTree = memo(({
                 onLink={link}
                 onUnlink={unlink}
                 onDelete={remove}
+                okapi={okapi}
               />
             ))
           ) : (
@@ -175,6 +177,7 @@ export const ProfileTree = memo(({
             initialData={data}
             setInitialData={setData}
             onLink={link}
+            okapi={okapi}
             {...dataAttributes}
           />
         )}
@@ -187,6 +190,11 @@ export const ProfileTree = memo(({
 ProfileTree.propTypes = {
   linkingRules: PropTypes.object.isRequired,
   contentData: PropTypes.arrayOf(PropTypes.object).isRequired,
+  okapi: PropTypes.shape({
+    tenant: PropTypes.string.isRequired,
+    token: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
   parentId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   relationsToAdd: PropTypes.arrayOf(PropTypes.object),
   relationsToDelete: PropTypes.arrayOf(PropTypes.object),

--- a/src/settings/JobProfiles/JobProfilesForm.js
+++ b/src/settings/JobProfiles/JobProfilesForm.js
@@ -54,7 +54,9 @@ export const JobProfilesFormComponent = ({
   handleSubmit,
   onCancel,
   dispatch,
+  stripes,
 }) => {
+  const { okapi } = stripes;
   const { profile } = initialValues;
   const isEditMode = Boolean(profile.id);
   const isSubmitDisabled = pristine || submitting;
@@ -165,6 +167,7 @@ export const JobProfilesFormComponent = ({
             relationsToDelete={deletedRelations}
             onLink={setAddedRelations}
             onUnlink={setDeletedRelations}
+            okapi={okapi}
           />
         </Accordion>
       </AccordionSet>
@@ -179,6 +182,7 @@ JobProfilesFormComponent.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
   dispatch: PropTypes.func.isRequired,
+  stripes: PropTypes.object.isRequired,
   childWrappers: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,

--- a/src/utils/fetchProfileSnapshot.js
+++ b/src/utils/fetchProfileSnapshot.js
@@ -1,0 +1,28 @@
+import { createOkapiHeaders } from './createOkapiHeaders';
+
+/**
+ * Gets a profile snapshot.
+ *
+ * @param {string} profileId
+ * @param {string} profileType
+ * @param {object} okapi
+ * @returns {Promise<{}>} Returns profile snapshot.
+ */
+export const fetchProfileSnapshot = async (profileId, profileType, okapi) => {
+  const { url } = okapi;
+
+  try {
+    const response = await fetch(`${url}/data-import-profiles/profileSnapshots/${profileId}?profileType=${profileType}`,
+      { headers: { ...createOkapiHeaders(okapi) } });
+
+    if (!response.ok) {
+      throw new Error('Cannot fetch profile snapshot');
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error(error); // eslint-disable-line no-console
+
+    return {};
+  }
+};


### PR DESCRIPTION
## Description
1. When adding to a job profile a match profile with filled "For matches" or "For non-matches" sections, these sections are empty, but when saving the job profile, the linked match profile displays filled sections.
2. When linking some profile to a job profile, then unlinking and save the job profile, unlinked profile are not removed from the tree.

## Approach
1. Retrieve a profile snapshot with `childSnapshotWrappers` when linking some profile to a job profile.
2. Fill tree data with `childSnapshotWrappers` for an appropriate profile.
3. When linking some match profile to the root match profile, check if this is the same match profile, if not - allow linking, if yes - disallow linking.
4. When unlinking some profile, check if this profile is newly added and if yes - remove this profile from the `addedRelations` array, if not - add this profile to the `deletedRelations` array.
5. Adjust assigning an order value.
6. Add new tests and fix existing ones.
## Issue
[UIDATIMP-413](https://issues.folio.org/browse/UIDATIMP-413)