### PR TITLE
UIDATIMP-465: Fix hardcoded tenant value for the modules retrieving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix broken Record Type Selection Tree in RTL mode (UIDATIMP-425)
 * Fix broken Match criterion section in RTL mode (UIDATIMP-426)
 * Mapping Profiles Form existing record type recognition behavior is wrong (UIDATIMP-456)
+* Fix hardcoded tenant value for the modules retrieving (UIDATIMP-465)
 
 ## [1.8.0](https://github.com/folio-org/ui-data-import/tree/v1.8.0) (2020-03-13)
 

--- a/src/settings/MatchProfiles/MatchProfiles.js
+++ b/src/settings/MatchProfiles/MatchProfiles.js
@@ -283,7 +283,11 @@ export class MatchProfiles extends Component {
     },
     modules: {
       type: 'okapi',
-      path: '_/proxy/tenants/diku/modules',
+      path: (queryParams, pathComponents, resourceData, logger, props) => {
+        const { stripes: { okapi: { tenant } } } = props;
+
+        return `_/proxy/tenants/${tenant}/modules`;
+      },
       throwErrors: false,
       GET: { params: { full: true } },
     },


### PR DESCRIPTION
## Description
GET request to '_/proxy/tenants/diku/modules' returns 404

## Approach
Pass correct tenant value to the request

## Issue
[UIDATIMP-465](https://issues.folio.org/browse/UIDATIMP-465)