### PR TITLE
UIDATIMP-443: More than one record cannot be created in Mapping Profiles Form repeatable fields :: FIXED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change history for ui-data-import
 
+## **1.9.0** (in progress)
+
+### Features added:
+
+
+### Bugs fixed:
+* More than one record cannot be created in Mapping Profiles Form repeatable fields (UIDATIMP-443)
+
 ## [1.8.1](https://github.com/folio-org/ui-data-import/tree/v1.8.1) (2020-03-31)
 
 ### Features added:

--- a/src/components/FlexibleForm/Control.js
+++ b/src/components/FlexibleForm/Control.js
@@ -341,12 +341,12 @@ export const Control = memo(props => {
           onRemove={onRemove}
           canAdd={canAdd}
           canRemove={canRemove}
-          renderField={() => (
+          renderField={(field, index) => (
             <>
               {children.map((cfg, i) => (
                 <Control
                   key={`control-${i}`}
-                  repeatableIndex={i}
+                  repeatableIndex={field?.[incrementalField] || index}
                   staticNamespace={staticNamespace}
                   editableNamespace={editableNamespace}
                   sectionNamespace={sectionNamespace}

--- a/src/settings/MappingProfiles/MappingProfilesForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm.js
@@ -108,11 +108,11 @@ export const MappingProfilesFormComponent = ({
     const isEqual = existingRecordType === prevExistingRecordType.current;
     const needsUpdate = !profile.id || (profile.id && (!isEqual || isEmpty(mappingDetails)));
 
-    if (isEqual || !needsUpdate) {
+    if (!needsUpdate) {
       return;
     }
 
-    const newInitDetails = existingRecordType === existingRecordTypeInitial
+    const newInitDetails = existingRecordType === existingRecordTypeInitial && !isEmpty(mappingDetails)
       ? mappingDetailsInitial
       : getInitialDetails(existingRecordType, true);
     const newInitials = {


### PR DESCRIPTION
Repeatable control clones the first row with all of its field names without respect of all the indexes needed.
This happens because Repeatable is designed to work with flat single-level data objects as reference tables row.