### PR TITLE
When returned to search results screen after profile save, wrong prof…

### DIFF
--- a/src/settings/ActionProfiles/ViewActionProfile.js
+++ b/src/settings/ActionProfiles/ViewActionProfile.js
@@ -52,6 +52,15 @@ export class ViewActionProfile extends Component {
       path: 'data-import-profiles/actionProfiles/:{id}',
       params: { withRelations: true },
       throwErrors: false,
+
+      // Next two parameters added as a workaround to fix UIDATIMP-424,
+      // but it's not optimal from network side and produces extra GET requests.
+      // Should be checked and reworked in the future
+
+      // should resource be refreshed again on mount
+      resourceShouldRefresh: true,
+      // should resource be refreshed on POST/PUT/DELETE mutation
+      shouldRefresh: () => false,
     },
   });
 


### PR DESCRIPTION
## Screenshot
![image](https://user-images.githubusercontent.com/40805351/78999642-bb1d8f00-7b53-11ea-88c9-d8bb1b3472f5.png)

## Description
When saving a duplicated profile and returning to the search results screen, the wrong View details screen shows in the 4th pane

## Approach
1. Added additional parameters as a workaround to refresh resource again on the mount

## Issue
[UIDATIMP-424](https://issues.folio.org/browse/UIDATIMP-424)