### PR TITLE
UIDATIMP 472: Line above associated action profiles has been added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Cover MCL in mapping profile details sections with tests (UIDATIMP-469)
 * Implement <ProhibitionIcon> component (UIDATIMP-477)
 * Distinguish not mapped and unmappable fields in Field mapping profile View screen (UIDATIMP-471)
+* Field mapping profile - Add line above associated action profiles (UIDATIMP-472)
 
 ### Bugs fixed:
 

--- a/test/bigtest/mocks/form-config-samples.js
+++ b/test/bigtest/mocks/form-config-samples.js
@@ -4604,7 +4604,7 @@ export const formConfigSamples = [{
       staticControlType: 'Accordion',
       id: 'mappingProfileFormAssociatedActionProfileAccordion',
       collapsed: false,
-      separator: false,
+      separator: true,
       label: 'ui-data-import.settings.associatedActionProfiles',
       dataAttributes: {},
       childControls: [{


### PR DESCRIPTION
## Description
To make clear on the field mapping profile where the mapping details sections end and the Associated action profiles section begins

## Approach
Configuration for appropriate component has been updated

**Case1**
- Navigate to field mapping profile Create/Edit screen
- Check if line between Associated action profiles section and section above is present

**Case2**
- Navigate to field mapping profile View details screen
- Check if line between Associated action profiles section and section above is present

## Task
[UIDATIMP-472](https://issues.folio.org/browse/UIDATIMP-472)

## Screenshot
![image](https://user-images.githubusercontent.com/63101175/79332382-68fab600-7f25-11ea-8ef9-a97c95d5590f.PNG)
![image](https://user-images.githubusercontent.com/63101175/79332542-aa8b6100-7f25-11ea-86b7-58f94dabf9e5.PNG)
