### PR TITLE
UIDATIMP-517 update to react-intl v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Update dependency on stripes-smart-components to version 3.1.1 (UIDATIMP-485)
 * Implement date picker decorator (UIDATIMP-407)
 * Add validation for field mapping profile fields (UIDATIMP-405)
+* Purge "intlShape" in prep for "react-intl" "v4" migration. (UIDATIMP-517)
 
 ### Bugs fixed:
 * When returned to search results screen after profile save, wrong profile details show (UIDATIMP-424)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "query-string": "^5.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-intl": "^2.9.0",
+    "react-intl": "^4.5.1",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "sinon": "^7.2.2"
@@ -58,7 +58,7 @@
   "peerDependencies": {
     "@folio/stripes": "^3.0.0",
     "react": "*",
-    "react-intl": "^2.9.0",
+    "react-intl": "^4.5.1",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1"
   },

--- a/src/components/FlexibleForm/Control.js
+++ b/src/components/FlexibleForm/Control.js
@@ -2,10 +2,7 @@ import React, {
   Fragment,
   memo,
 } from 'react';
-import {
-  FormattedMessage,
-  intlShape,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 
@@ -566,7 +563,7 @@ Control.propTypes = {
   wrapperLabel: PropTypes.string,
   wrapperSourceLink: PropTypes.string,
   placeholder: PropTypes.string,
-  intl: intlShape,
+  intl: PropTypes.object,
   okapi: PropTypes.object,
   styles: PropTypes.shape(PropTypes.string),
   classNames: PropTypes.arrayOf(PropTypes.string),

--- a/src/components/FlexibleForm/ControlDecorators/partials/TextDate.js
+++ b/src/components/FlexibleForm/ControlDecorators/partials/TextDate.js
@@ -46,6 +46,7 @@ const propTypes = {
   id: PropTypes.string,
   input: PropTypes.object,
   inputRef: PropTypes.object,
+  intl: PropTypes.object,
   label: PropTypes.node,
   locale: PropTypes.string,
   meta: PropTypes.object,
@@ -64,8 +65,6 @@ const propTypes = {
   value: PropTypes.string,
 };
 
-const contextTypes = { intl: PropTypes.object };
-
 const defaultProps = {
   autoFocus: false,
   backendDateStandard: 'ISO8601',
@@ -83,10 +82,9 @@ const defaultProps = {
  */
 export class TextDate extends React.Component {
   static propTypes = propTypes;
-  static contextTypes = contextTypes;
   static defaultProps = defaultProps;
 
-  constructor(props, context) {
+  constructor(props) {
     super(props);
 
     this.picker = null;
@@ -96,8 +94,8 @@ export class TextDate extends React.Component {
 
     this.dbhideCalendar = debounce(this.hideCalendar, 10);
 
-    const timeZone = props.timeZone || context.intl.timeZone;
-    const locale = props.locale || context.intl.locale;
+    const timeZone = props.timeZone || props.intl.timeZone;
+    const locale = props.locale || props.intl.locale;
 
     moment.locale(locale);
 

--- a/src/components/FlexibleForm/ControlDecorators/withBooleanActions/withBooleanActions.js
+++ b/src/components/FlexibleForm/ControlDecorators/withBooleanActions/withBooleanActions.js
@@ -7,7 +7,6 @@ import { PropTypes } from 'prop-types';
 import {
   FormattedMessage,
   injectIntl,
-  intlShape,
 } from 'react-intl';
 
 import { get } from 'lodash';
@@ -100,7 +99,7 @@ WithBooleanActionsControl.propTypes = {
   WrappedComponent: PropTypes.oneOfType([React.Component, PropTypes.func]).isRequired,
   id: PropTypes.string,
   wrapperLabel: PropTypes.oneOfType([PropTypes.string, Node]),
-  intl: intlShape,
+  intl: PropTypes.object,
   label: PropTypes.oneOfType([PropTypes.string, Node]),
 };
 

--- a/src/components/FlexibleForm/ControlDecorators/withRepeatableActions/withRepeatableActions.js
+++ b/src/components/FlexibleForm/ControlDecorators/withRepeatableActions/withRepeatableActions.js
@@ -1,9 +1,6 @@
 import React, { memo } from 'react';
 import { PropTypes } from 'prop-types';
-import {
-  intlShape,
-  FormattedMessage,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Field } from 'redux-form';
 import classNames from 'classnames';
 
@@ -77,7 +74,7 @@ export const withRepeatableActions = memo(props => {
 });
 
 withRepeatableActions.propTypes = {
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
   enabled: PropTypes.bool.isRequired,
   referenceTable: PropTypes.arrayOf(PropTypes.object).isRequired,
   children: Node.isRequired,

--- a/src/components/JobLogs/withJobLogsCellsFormatter.js
+++ b/src/components/JobLogs/withJobLogsCellsFormatter.js
@@ -1,9 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {
-  injectIntl,
-  intlShape,
-} from 'react-intl';
+import { injectIntl } from 'react-intl';
 
 import { Button } from '@folio/stripes/components';
 
@@ -14,7 +11,7 @@ import sharedCss from '../../shared.css';
 export const withJobLogsCellsFormatter = WrappedComponent => {
   return injectIntl(class extends Component {
     static propTypes = {
-      intl: intlShape.isRequired,
+      intl: PropTypes.object.isRequired,
       formatter: PropTypes.object,
     };
 

--- a/src/components/Jobs/components/Job/Job.js
+++ b/src/components/Jobs/components/Job/Job.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   injectIntl,
-  intlShape,
   FormattedDate,
   FormattedTime,
   FormattedMessage,
@@ -22,7 +21,7 @@ import css from './Job.css';
 export class Job extends Component {
   static propTypes = {
     job: jobExecutionPropTypes.isRequired,
-    intl: intlShape.isRequired,
+    intl: PropTypes.object.isRequired,
     handlePreview: PropTypes.func,
   };
 

--- a/src/routes/ViewAllLogs/ViewAllLogs.js
+++ b/src/routes/ViewAllLogs/ViewAllLogs.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import {
   FormattedMessage,
   injectIntl,
-  intlShape,
 } from 'react-intl';
 
 import {
@@ -69,7 +68,7 @@ class ViewAllLogs extends Component {
     browseOnly: PropTypes.bool,
     packageInfo: PropTypes.object,
     history: PropTypes.shape({ push: PropTypes.func.isRequired }),
-    intl: intlShape.isRequired,
+    intl: PropTypes.object.isRequired,
   };
 
   static defaultProps = { browseOnly: false };

--- a/src/settings/ActionProfiles/ActionProfilesForm.js
+++ b/src/settings/ActionProfiles/ActionProfilesForm.js
@@ -6,7 +6,6 @@ import React, {
 import {
   FormattedMessage,
   injectIntl,
-  intlShape,
 } from 'react-intl';
 import {
   Field,
@@ -308,7 +307,7 @@ export const ActionProfilesFormComponent = ({
 };
 
 ActionProfilesFormComponent.propTypes = {
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
   initialValues: PropTypes.object.isRequired,
   pristine: PropTypes.bool.isRequired,
   submitting: PropTypes.bool.isRequired,

--- a/src/settings/JobProfiles/ViewJobProfile.js
+++ b/src/settings/JobProfiles/ViewJobProfile.js
@@ -31,6 +31,7 @@ import {
   stripesConnect,
   stripesShape,
 } from '@folio/stripes/core';
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import {
   ENTITY_KEYS,
@@ -480,7 +481,7 @@ export class ViewJobProfile extends Component {
           open={this.state.showRunConfirmation}
           heading={<FormattedMessage id="ui-data-import.modal.jobProfile.run.header" />}
           message={(
-            <FormattedMessage
+            <SafeHTMLMessage
               id="ui-data-import.modal.jobProfile.run.message"
               values={{ name: record.name }}
             />

--- a/src/settings/JobProfiles/ViewJobProfile.js
+++ b/src/settings/JobProfiles/ViewJobProfile.js
@@ -4,7 +4,6 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import {
-  intlShape,
   injectIntl,
   FormattedMessage,
 } from 'react-intl';
@@ -32,7 +31,6 @@ import {
   stripesConnect,
   stripesShape,
 } from '@folio/stripes/core';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import {
   ENTITY_KEYS,
@@ -104,7 +102,7 @@ export class ViewJobProfile extends Component {
       push: PropTypes.func.isRequired,
       replace: PropTypes.func.isRequired,
     }).isRequired,
-    intl: intlShape.isRequired,
+    intl: PropTypes.object.isRequired,
     resources: PropTypes.shape({
       jobProfile: PropTypes.shape({
         hasLoaded: PropTypes.bool.isRequired,
@@ -482,7 +480,7 @@ export class ViewJobProfile extends Component {
           open={this.state.showRunConfirmation}
           heading={<FormattedMessage id="ui-data-import.modal.jobProfile.run.header" />}
           message={(
-            <SafeHTMLMessage
+            <FormattedMessage
               id="ui-data-import.modal.jobProfile.run.message"
               values={{ name: record.name }}
             />


### PR DESCRIPTION
react-intl no longer uses the legacy `contextTypes` API, so we're back to `injectIntl`.