### PR TITLE
UIDATIMP-496: Implement re-order row functionality in the MARCTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Implement add new row functionality for the Field Mapping Profile details (UIDATIMP-497)
 * Change placement of repeatable decorator in the Inventory field mapping screens (UIDATIMP-518)
 * Implement delete row functionality for the Field Mapping Profile details (UIDATIMP-498)
+* Implement re-order row functionality for the Field Mapping Profile details (UIDATIMP-496)
 
 ### Bugs fixed:
 * Fix Item status list in field mapping profiles (UIDATIMP-515)

--- a/src/components/MARCTable/MARCTable.js
+++ b/src/components/MARCTable/MARCTable.js
@@ -60,6 +60,25 @@ export const MARCTable = ({
     setRows(updatedRows);
   };
 
+  const moveRow = (order, orderToSwitch) => {
+    const rowIndex = rows.findIndex(field => field.order === order);
+    const rowToSwitchIndex = rows.findIndex(field => field.order === orderToSwitch);
+    const updatedRows = [...rows];
+
+    const rowToSwitch = {
+      ...updatedRows[rowToSwitchIndex],
+      order,
+    };
+
+    updatedRows[rowToSwitchIndex] = {
+      ...updatedRows[rowIndex],
+      order: orderToSwitch,
+    };
+    updatedRows[rowIndex] = rowToSwitch;
+
+    setRows(updatedRows);
+  };
+
   const columns = ['arrows', 'action', 'field', 'indicator1', 'indicator2',
     'subfield', 'subaction', 'data', 'position', 'addRemove'];
   const columnWidths = {
@@ -90,6 +109,7 @@ export const MARCTable = ({
         columnWidths={columnWidths}
         onAddNewRow={addNewRow}
         onRemoveRow={removeRow}
+        onMoveRow={moveRow}
         onDataChange={updateRowsData}
         intl={intl}
       />

--- a/src/components/MARCTable/MARCTableRow.js
+++ b/src/components/MARCTable/MARCTableRow.js
@@ -32,6 +32,7 @@ export const MARCTableRow = ({
   isSubline,
   onAddNewRow,
   onRemoveRow,
+  onMoveRow,
   onDataChange,
   intl,
 }) => {
@@ -77,6 +78,8 @@ export const MARCTableRow = ({
   };
 
   const renderArrows = () => {
+    const { order } = field;
+
     const cellStyle = {
       width: columnWidths.arrows,
       justifyContent: isFirst ? 'flex-end' : 'flex-start',
@@ -96,6 +99,7 @@ export const MARCTableRow = ({
             data-test-marc-table-arrow-up
             icon="arrow-up"
             ariaLabel={intl.formatMessage({ id: 'ui-data-import.settings.mappingProfile.marcTable.moveUpRow' })}
+            onClick={() => onMoveRow(order, order - 1)}
           />
         )}
         {withRowDown && (
@@ -103,6 +107,7 @@ export const MARCTableRow = ({
             data-test-marc-table-arrow-down
             icon="arrow-down"
             ariaLabel={intl.formatMessage({ id: 'ui-data-import.settings.mappingProfile.marcTable.moveDownRow' })}
+            onClick={() => onMoveRow(order, order + 1)}
           />
         )}
       </div>
@@ -441,6 +446,7 @@ MARCTableRow.propTypes = {
   columnWidths: PropTypes.object.isRequired,
   onAddNewRow: PropTypes.func.isRequired,
   onRemoveRow: PropTypes.func.isRequired,
+  onMoveRow: PropTypes.func.isRequired,
   onDataChange: PropTypes.func.isRequired,
   isFirst: PropTypes.bool,
   isLast: PropTypes.bool,

--- a/src/components/MARCTable/MARCTableRowContainer.js
+++ b/src/components/MARCTable/MARCTableRowContainer.js
@@ -12,6 +12,7 @@ export const MARCTableRowContainer = ({
   columnWidths,
   onAddNewRow,
   onRemoveRow,
+  onMoveRow,
   onDataChange,
   intl,
 }) => {
@@ -20,7 +21,7 @@ export const MARCTableRowContainer = ({
 
     return (
       <div
-        data-test-marc-table-row
+        data-test-marc-table-row={field.order}
         key={i}
         className={css.tableRowContainer}
       >
@@ -31,6 +32,7 @@ export const MARCTableRowContainer = ({
           isLast={i === (fields.length - 1)}
           onAddNewRow={onAddNewRow}
           onRemoveRow={onRemoveRow}
+          onMoveRow={onMoveRow}
           onDataChange={onDataChange}
           intl={intl}
         />
@@ -59,6 +61,7 @@ MARCTableRowContainer.propTypes = {
   fields: PropTypes.arrayOf(PropTypes.object.isRequired),
   onAddNewRow: PropTypes.func.isRequired,
   onRemoveRow: PropTypes.func.isRequired,
+  onMoveRow: PropTypes.func.isRequired,
   onDataChange: PropTypes.func.isRequired,
   columnWidths: PropTypes.object,
 };

--- a/test/bigtest/interactors/marc-table-interactor.js
+++ b/test/bigtest/interactors/marc-table-interactor.js
@@ -5,10 +5,12 @@ import {
   collection,
   text,
   property,
+  scoped,
 } from '@bigtest/interactor';
 
 import IconButtonInteractor from '@folio/stripes-components/lib/IconButton/tests/interactor';
 import SelectInteractor from '@folio/stripes-components/lib/Select/tests/interactor';
+import TextFielInteractor from '@folio/stripes-components/lib/TextField/tests/interactor';
 import TextAreaInteractor from '@folio/stripes-components/lib/TextArea/tests/interactor';
 
 @interactor
@@ -18,20 +20,6 @@ class MARCTableHeaderInteractor {
 
 @interactor
 class MARCTableCellInteractor {
-  arrowUp = new IconButtonInteractor('[data-test-marc-table-arrow-up]');
-  arrowDown = new IconButtonInteractor('[data-test-marc-table-arrow-down]');
-  action = new SelectInteractor('[data-test-marc-table-action]');
-  tag = new SelectInteractor('[data-test-marc-table-tag]');
-  indicator1 = new SelectInteractor('[data-test-marc-table-indicator1]');
-  indicator2 = new SelectInteractor('[data-test-marc-table-indicator2]');
-  subfield = new SelectInteractor('[data-test-marc-table-subfield]');
-  subaction = new SelectInteractor('[data-test-marc-table-subaction]');
-  position = new SelectInteractor('[data-test-marc-table-position]');
-  dataFindField = new TextAreaInteractor('[data-test-marc-table-data-find]');
-  dataReplaceField = new TextAreaInteractor('[data-test-marc-table-data-replace]');
-  addRow = new IconButtonInteractor('[data-test-marc-table-add]');
-  removeRow = new IconButtonInteractor('[data-test-marc-table-remove]');
-
   hasContent() {
     return this.$root?.childNodes?.length !== 0;
   }
@@ -40,9 +28,20 @@ class MARCTableCellInteractor {
 @interactor
 class MARCTableRowInteractor {
   cells = collection('[data-test-marc-table-cell]', MARCTableCellInteractor);
-  addRow = new IconButtonInteractor('[data-test-marc-table-add]');
-  removeRow = new IconButtonInteractor('[data-test-marc-table-remove]');
+  addRow = scoped('[data-test-marc-table-add]', IconButtonInteractor);
+  removeRow = scoped('[data-test-marc-table-remove]', IconButtonInteractor);
   isTrashDisabled = property('[data-test-marc-table-remove]', 'disabled');
+  moveRowUp = scoped('[data-test-marc-table-arrow-up]', IconButtonInteractor);
+  moveRowDown = scoped('[data-test-marc-table-arrow-down]', IconButtonInteractor);
+  action = scoped('[data-test-marc-table-action]', SelectInteractor);
+  tag = scoped('[data-test-marc-table-tag]', TextFielInteractor);
+  indicator1 = scoped('[data-test-marc-table-indicator1]', TextFielInteractor);
+  indicator2 = scoped('[data-test-marc-table-indicator2]', TextFielInteractor);
+  subfield = scoped('[data-test-marc-table-subfield]', TextFielInteractor);
+  subaction = scoped('[data-test-marc-table-subaction]', SelectInteractor);
+  dataFindField = scoped('[data-test-marc-table-data-find]', TextAreaInteractor);
+  dataReplaceField = scoped('[data-test-marc-table-data-replace]', TextAreaInteractor);
+  position = scoped('[data-test-marc-table-position]', SelectInteractor);
 }
 
 @interactor

--- a/test/bigtest/tests/mapping-profiles/new-mapping-profiles-test.js
+++ b/test/bigtest/tests/mapping-profiles/new-mapping-profiles-test.js
@@ -101,16 +101,16 @@ describe('Mapping profile form', () => {
             });
 
             it('row does not have re-order arrows', () => {
-              expect(mappingProfileForm.marcDetailsTable.rows(0).cells(0).arrowUp.isPresent).to.be.false;
-              expect(mappingProfileForm.marcDetailsTable.rows(0).cells(0).arrowDown.isPresent).to.be.false;
+              expect(mappingProfileForm.marcDetailsTable.rows(0).moveRowUp.isPresent).to.be.false;
+              expect(mappingProfileForm.marcDetailsTable.rows(0).moveRowDown.isPresent).to.be.false;
             });
 
             it('row has add button', () => {
-              expect(mappingProfileForm.marcDetailsTable.rows(0).cells(9).addRow.isPresent).to.be.true;
+              expect(mappingProfileForm.marcDetailsTable.rows(0).addRow.isPresent).to.be.true;
             });
 
             it('row has remove button', () => {
-              expect(mappingProfileForm.marcDetailsTable.rows(0).cells(9).removeRow.isPresent).to.be.true;
+              expect(mappingProfileForm.marcDetailsTable.rows(0).removeRow.isPresent).to.be.true;
             });
 
             it('action column has content', () => {
@@ -118,7 +118,7 @@ describe('Mapping profile form', () => {
             });
 
             it('and action is not selected', () => {
-              expect(mappingProfileForm.marcDetailsTable.rows(0).cells(1).action.val).to.equal('');
+              expect(mappingProfileForm.marcDetailsTable.rows(0).action.val).to.equal('');
             });
 
             it('field column has content', () => {
@@ -156,11 +156,11 @@ describe('Mapping profile form', () => {
             describe('when Action is selected', () => {
               describe('and equal to Add', () => {
                 beforeEach(async () => {
-                  await mappingProfileForm.marcDetailsTable.rows(0).cells(1).action.selectAndBlur('Add');
+                  await mappingProfileForm.marcDetailsTable.rows(0).action.selectAndBlur('Add');
                 });
 
                 it('then action value is equal to Add', () => {
-                  expect(mappingProfileForm.marcDetailsTable.rows(0).cells(1).action.val).to.equal('ADD');
+                  expect(mappingProfileForm.marcDetailsTable.rows(0).action.val).to.equal('ADD');
                 });
 
                 it('subaction column has content', () => {
@@ -178,11 +178,11 @@ describe('Mapping profile form', () => {
 
               describe('and equal to Delete', () => {
                 beforeEach(async () => {
-                  await mappingProfileForm.marcDetailsTable.rows(0).cells(1).action.selectAndBlur('Delete');
+                  await mappingProfileForm.marcDetailsTable.rows(0).action.selectAndBlur('Delete');
                 });
 
                 it('then action value is equal to Delete', () => {
-                  expect(mappingProfileForm.marcDetailsTable.rows(0).cells(1).action.val).to.equal('DELETE');
+                  expect(mappingProfileForm.marcDetailsTable.rows(0).action.val).to.equal('DELETE');
                 });
 
                 it('subaction column does not have content', () => {
@@ -200,11 +200,11 @@ describe('Mapping profile form', () => {
 
               describe('and equal to Edit', () => {
                 beforeEach(async () => {
-                  await mappingProfileForm.marcDetailsTable.rows(0).cells(1).action.selectAndBlur('Edit');
+                  await mappingProfileForm.marcDetailsTable.rows(0).action.selectAndBlur('Edit');
                 });
 
                 it('then action value is equal to Edit', () => {
-                  expect(mappingProfileForm.marcDetailsTable.rows(0).cells(1).action.val).to.equal('EDIT');
+                  expect(mappingProfileForm.marcDetailsTable.rows(0).action.val).to.equal('EDIT');
                 });
 
                 it('subaction column has content', () => {
@@ -221,7 +221,7 @@ describe('Mapping profile form', () => {
 
                 describe('when Insert subaction selected', () => {
                   beforeEach(async () => {
-                    await mappingProfileForm.marcDetailsTable.rows(0).cells(6).subaction.selectAndBlur('Insert');
+                    await mappingProfileForm.marcDetailsTable.rows(0).subaction.selectAndBlur('Insert');
                   });
 
                   it('position column has content', () => {
@@ -231,23 +231,23 @@ describe('Mapping profile form', () => {
 
                 describe('when Replace subaction selected', () => {
                   beforeEach(async () => {
-                    await mappingProfileForm.marcDetailsTable.rows(0).cells(6).subaction.selectAndBlur('Replace');
+                    await mappingProfileForm.marcDetailsTable.rows(0).subaction.selectAndBlur('Replace');
                   });
 
                   it('data column has 2 fields', () => {
-                    expect(mappingProfileForm.marcDetailsTable.rows(0).cells(7).dataFindField.isPresent).to.be.true;
-                    expect(mappingProfileForm.marcDetailsTable.rows(0).cells(7).dataReplaceField.isPresent).to.be.true;
+                    expect(mappingProfileForm.marcDetailsTable.rows(0).dataFindField.isPresent).to.be.true;
+                    expect(mappingProfileForm.marcDetailsTable.rows(0).dataReplaceField.isPresent).to.be.true;
                   });
                 });
               });
 
               describe('and equal to Move', () => {
                 beforeEach(async () => {
-                  await mappingProfileForm.marcDetailsTable.rows(0).cells(1).action.selectAndBlur('Move');
+                  await mappingProfileForm.marcDetailsTable.rows(0).action.selectAndBlur('Move');
                 });
 
                 it('then action value is equal to Edit', () => {
-                  expect(mappingProfileForm.marcDetailsTable.rows(0).cells(1).action.val).to.equal('MOVE');
+                  expect(mappingProfileForm.marcDetailsTable.rows(0).action.val).to.equal('MOVE');
                 });
 
                 it('subaction column has content', () => {
@@ -282,6 +282,36 @@ describe('Mapping profile form', () => {
 
               it('should remove row', () => {
                 expect(mappingProfileForm.marcDetailsTable.rowCount).to.be.equal(1);
+              });
+            });
+
+            describe('Move buttons', () => {
+              beforeEach(async () => {
+                await mappingProfileForm.marcDetailsTable.rows(0).addRow.clickIconButton();
+                await mappingProfileForm.marcDetailsTable.rows(0).action.selectAndBlur('Add');
+                await mappingProfileForm.marcDetailsTable.rows(1).action.selectAndBlur('Delete');
+              });
+
+              describe('when move up button is clicked', () => {
+                beforeEach(async () => {
+                  await mappingProfileForm.marcDetailsTable.rows(1).moveRowUp.clickIconButton();
+                });
+
+                it('then row should move up', () => {
+                  expect(mappingProfileForm.marcDetailsTable.rows(0).action.val).to.be.equal('DELETE');
+                  expect(mappingProfileForm.marcDetailsTable.rows(1).action.val).to.be.equal('ADD');
+                });
+              });
+
+              describe('when move down button is clicked', () => {
+                beforeEach(async () => {
+                  await mappingProfileForm.marcDetailsTable.rows(0).moveRowDown.clickIconButton();
+                });
+
+                it('then row should move down', () => {
+                  expect(mappingProfileForm.marcDetailsTable.rows(0).action.val).to.be.equal('DELETE');
+                  expect(mappingProfileForm.marcDetailsTable.rows(1).action.val).to.be.equal('ADD');
+                });
               });
             });
           });


### PR DESCRIPTION
## Purpose
To create the up/down arrows that resequence rows in the table of the Field Mapping profile details for MARC modifications

## Approach
* Add `moveRow` method to the `MARCTable` component
* Add test

## Ticket
[UIDATIMP-496](https://issues.folio.org/browse/UIDATIMP-496)

## Screenshot
![reorder](https://user-images.githubusercontent.com/55138456/82678473-583f0d80-9c52-11ea-9a13-5069cc370734.gif)
