### PR TITLE
UIDATIMP-516 Reference dropdowns. Replace previously-selected referen…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Change placement of repeatable decorator in the Inventory field mapping screens (UIDATIMP-518)
 * Implement delete row functionality for the Field Mapping Profile details (UIDATIMP-498)
 * Implement re-order row functionality for the Field Mapping Profile details (UIDATIMP-496)
+* Update logic for reference dropdowns (UIDATIMP-516)
 
 ### Bugs fixed:
 * Fix Item status list in field mapping profiles (UIDATIMP-515)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@
 * Change placement of repeatable decorator in the Inventory field mapping screens (UIDATIMP-518)
 * Implement delete row functionality for the Field Mapping Profile details (UIDATIMP-498)
 * Implement re-order row functionality for the Field Mapping Profile details (UIDATIMP-496)
-* Update logic for reference dropdowns (UIDATIMP-516)
 
 ### Bugs fixed:
 * Fix Item status list in field mapping profiles (UIDATIMP-515)
 * Initial data doesn't show up for checkbox decorator for existing profiles (UIDATIMP-500)
+* Update logic for reference dropdowns (UIDATIMP-516)
 
 ## [1.8.3](https://github.com/folio-org/ui-data-import/tree/v1.8.3) (2020-04-27)
 

--- a/src/components/AcceptedValuesField/AcceptedValuesField.js
+++ b/src/components/AcceptedValuesField/AcceptedValuesField.js
@@ -28,7 +28,6 @@ export const AcceptedValuesField = ({
   acceptedValuesList,
   wrapperSourceLink,
   wrapperSourcePath,
-  wrapperExplicitInsert,
   dataAttributes,
 }) => {
   const [listOptions, setListOptions] = useState(acceptedValuesList);
@@ -56,7 +55,6 @@ export const AcceptedValuesField = ({
       optionLabel={optionLabel}
       WrappedComponent={component}
       wrapperLabel={wrapperLabel}
-      wrapperExplicitInsert={wrapperExplicitInsert}
       validate={[validateMARCWithElse, memoizedValidation]}
       {...dataAttributes}
     />
@@ -77,7 +75,6 @@ AcceptedValuesField.propTypes = {
   wrapperSourceLink: PropTypes.string,
   wrapperSourcePath: PropTypes.string,
   wrapperLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  wrapperExplicitInsert: PropTypes.bool,
   label: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.node,

--- a/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.css
+++ b/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.css
@@ -6,11 +6,12 @@
   & .options-dropdown {
     display: flex;
     height: 100%;
-    margin: 25.5px 0 0 -1px;
+    margin: 25px 0 0 -1px;
     & button {
       min-width: 143px;
       height: 23px;
       padding: 0 5px 0 10px;
+      margin: 0 0 -1px;
       border-top: 1px solid rgba(0, 0, 0, 0.42);
       border-right: 1px solid rgba(0, 0, 0, 0.42);
       border-bottom: 1px solid rgba(0, 0, 0, 0.42);

--- a/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.css
+++ b/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.css
@@ -5,9 +5,8 @@
   align-items: flex-start;
   & .options-dropdown {
     display: flex;
-    align-self: flex-end;
     height: 100%;
-    margin: 0 0 1rem;
+    margin: 25.5px 0 0 -1px;
     & button {
       min-width: 143px;
       height: 23px;

--- a/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.css
+++ b/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.css
@@ -5,13 +5,13 @@
   align-items: flex-start;
   & .options-dropdown {
     display: flex;
+    align-self: flex-end;
     height: 100%;
-    margin: 25px 0 0 -1px;
+    margin: 0 0 1rem;
     & button {
       min-width: 143px;
       height: 23px;
       padding: 0 5px 0 10px;
-      margin: 0 0 -1px;
       border-top: 1px solid rgba(0, 0, 0, 0.42);
       border-right: 1px solid rgba(0, 0, 0, 0.42);
       border-bottom: 1px solid rgba(0, 0, 0, 0.42);

--- a/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.js
+++ b/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.js
@@ -45,16 +45,9 @@ export const withReferenceValues = memo(props => {
     input.onChange(e);
   };
   const updateDecoratorFieldValue = (curVal, newVal) => {
-    let newValue;
     const containQuotedText = curVal.match(decoratorValueRegExp);
 
-    if (containQuotedText) {
-      newValue = `${curVal.replace(containQuotedText, `"${newVal}"`)}`;
-    } else {
-      newValue = `${curVal} "${newVal}"`;
-    }
-
-    return newValue;
+    return containQuotedText ? `${curVal.replace(containQuotedText, `"${newVal}"`)}` : `${curVal} "${newVal}"`;
   };
 
   useEffect(() => {

--- a/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.js
+++ b/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.js
@@ -28,7 +28,6 @@ export const withReferenceValues = memo(props => {
     optionLabel,
     WrappedComponent,
     wrapperLabel,
-    wrapperExplicitInsert,
     ...rest
   } = props;
 
@@ -37,11 +36,25 @@ export const withReferenceValues = memo(props => {
   const [currentValue, setCurrentValue] = useState(input?.value || '');
   const [wrapperValue, setWrapperValue] = useState(null);
 
+  const decoratorValueRegExp = /"(\\.|[^"\\])*"/g;
+
   const handleChange = e => {
     const val = e.target ? e.target.value : e;
 
     setCurrentValue(val);
     input.onChange(e);
+  };
+  const updateDecoratorFieldValue = (curVal, newVal) => {
+    let newValue;
+    const containQuotedText = curVal.match(decoratorValueRegExp);
+
+    if (containQuotedText) {
+      newValue = `${curVal.replace(containQuotedText, `"${newVal}"`)}`;
+    } else {
+      newValue = `${curVal} "${newVal}"`;
+    }
+
+    return newValue;
   };
 
   useEffect(() => {
@@ -53,10 +66,10 @@ export const withReferenceValues = memo(props => {
     let newValue = '';
 
     if (wrapperValue) {
-      if (wrapperExplicitInsert || !currentValue) {
+      if (!currentValue) {
         newValue = `"${wrapperValue}"`;
       } else {
-        newValue = `${currentValue} "${wrapperValue}"`;
+        newValue = updateDecoratorFieldValue(currentValue, wrapperValue);
       }
     }
 
@@ -133,7 +146,6 @@ withReferenceValues.propTypes = {
   optionValue: PropTypes.string.isRequired,
   optionLabel: PropTypes.string.isRequired,
   WrappedComponent: PropTypes.oneOfType([React.Component, PropTypes.func]).isRequired,
-  wrapperExplicitInsert: PropTypes.bool,
   id: PropTypes.string,
   wrapperLabel: PropTypes.oneOfType([PropTypes.string, Node]),
 };
@@ -141,5 +153,4 @@ withReferenceValues.propTypes = {
 withReferenceValues.defaultProps = {
   id: null,
   wrapperLabel: 'ui-data-import.settings.mappingProfiles.map.wrapper.acceptedValues',
-  wrapperExplicitInsert: false,
 };

--- a/test/bigtest/tests/mapping-profiles/mapping-profile-details-test.js
+++ b/test/bigtest/tests/mapping-profiles/mapping-profile-details-test.js
@@ -252,19 +252,19 @@ const hasReferenceValuesDecorator = (details, accordion, field, fieldLabel, drop
       });
     });
 
-    describe('when accepted values is selected', () => {
+    describe('when accepted value is selected in first time', () => {
       beforeEach(async () => {
         await mappingProfileForm[details][accordion][field].fillValue('');
         await mappingProfileForm[details][accordion][dropdown].clickTrigger();
         await mappingProfileForm[details][accordion][dropdown].menu.items(0).click();
       });
 
-      it('then input field is filled in', () => {
+      it('then input field value extend with selected one', () => {
         expect(mappingProfileForm[details][accordion][field].val).to.equal('"name 1"');
       });
     });
 
-    describe('when several accepted values is selected', () => {
+    describe('when accepted value is selected in second time', () => {
       beforeEach(async () => {
         await mappingProfileForm[details][accordion][field].fillValue('');
         await mappingProfileForm[details][accordion][dropdown].clickTrigger();
@@ -273,8 +273,8 @@ const hasReferenceValuesDecorator = (details, accordion, field, fieldLabel, drop
         await mappingProfileForm[details][accordion][dropdown].menu.items(1).click();
       });
 
-      it('then input field is filled in with selected values', () => {
-        expect(mappingProfileForm[details][accordion][field].val).to.equal('"name 1" "name 2"');
+      it('then input field value inside quotation marks should be replaced with selected value', () => {
+        expect(mappingProfileForm[details][accordion][field].val).to.equal('"name 2"');
       });
     });
 


### PR DESCRIPTION
## Overview
In Instance, Holdings, and Item field mapping profiles, User should only be allowed to select one ref value from the dropdown list. If a second one is selected, it should replace the previously-selected one in the field mapping data field

## Approach
* Remove redundant property wrapperExplicitInsert
* Add updateDecoratorFieldValue handler
* Update test

## Ticket
[UIDATIMP-516](https://issues.folio.org/browse/UIDATIMP-516)

## Before
![decorator_before](https://user-images.githubusercontent.com/63101175/83114937-52be4900-a0d2-11ea-9c4a-8e24709e0a01.gif)


## After
![decorator_after](https://user-images.githubusercontent.com/63101175/83114960-581b9380-a0d2-11ea-8156-89a6cb5cbbc2.gif)
