### PR TITLE
UIDATIMP-523 Update logic for reference dropdowns with datepicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Initial data doesn't show up for checkbox decorator for existing profiles (UIDATIMP-500)
 * Update logic for reference dropdowns (UIDATIMP-516)
 * Fix reference dropdowns long lists height (UIDATIMP-511)
+* Update logic for reference dropdowns with datepicker (UIDATIMP-523)
 
 ## [1.8.3](https://github.com/folio-org/ui-data-import/tree/v1.8.3) (2020-04-27)
 

--- a/src/components/FlexibleForm/ControlDecorators/withDatePicker/withDatePicker.js
+++ b/src/components/FlexibleForm/ControlDecorators/withDatePicker/withDatePicker.js
@@ -68,7 +68,7 @@ export const withDatePicker = memo(props => {
 
     if (wrapperValue === TODAY.value) {
       setIsDatepicker(false);
-      newValue = formatDecoratorValue(currentValue, wrapperValue);
+      newValue = formatDecoratorValue(currentValue, wrapperValue, false);
       handleChange(newValue);
     }
 

--- a/src/components/FlexibleForm/ControlDecorators/withDatePicker/withDatePicker.js
+++ b/src/components/FlexibleForm/ControlDecorators/withDatePicker/withDatePicker.js
@@ -51,13 +51,15 @@ export const withDatePicker = memo(props => {
     },
   ];
 
+  const decoratorDatepickerValueRegExp = /###TODAY###|"[^"]+"/g;
+
   const handleChange = e => {
     setCurrentValue(e.target ? e.target.value : e);
     input.onChange(e);
   };
 
   const handleSetDate = (e, value) => {
-    const newValue = formatDecoratorValue(currentValue, value, true);
+    const newValue = formatDecoratorValue(currentValue, value, decoratorDatepickerValueRegExp, true);
 
     setCurrentValue(newValue);
     input.onChange(newValue);
@@ -67,8 +69,10 @@ export const withDatePicker = memo(props => {
     let newValue = '';
 
     if (wrapperValue === TODAY.value) {
+      const newWrapperValue = `###${wrapperValue}###`;
+
       setIsDatepicker(false);
-      newValue = formatDecoratorValue(currentValue, wrapperValue, false);
+      newValue = formatDecoratorValue(currentValue, newWrapperValue, decoratorDatepickerValueRegExp, false);
       handleChange(newValue);
     }
 

--- a/src/components/FlexibleForm/ControlDecorators/withDatePicker/withDatePicker.js
+++ b/src/components/FlexibleForm/ControlDecorators/withDatePicker/withDatePicker.js
@@ -17,6 +17,7 @@ import {
 import {
   isFormattedMessage,
   isTranslationId,
+  formatDecoratorValue,
   FORMS_SETTINGS,
   ENTITY_KEYS,
 } from '../../../../utils';
@@ -56,7 +57,7 @@ export const withDatePicker = memo(props => {
   };
 
   const handleSetDate = (e, value) => {
-    const newValue = currentValue ? `${currentValue} "${value}"` : `"${value}"`;
+    const newValue = formatDecoratorValue(currentValue, value, true);
 
     setCurrentValue(newValue);
     input.onChange(newValue);
@@ -67,7 +68,7 @@ export const withDatePicker = memo(props => {
 
     if (wrapperValue === TODAY.value) {
       setIsDatepicker(false);
-      newValue = currentValue ? `${currentValue} ###TODAY###` : '###TODAY###';
+      newValue = formatDecoratorValue(currentValue, wrapperValue);
       handleChange(newValue);
     }
 

--- a/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.css
+++ b/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.css
@@ -6,7 +6,7 @@
   & .options-dropdown {
     display: flex;
     height: 100%;
-    margin: 25.5px 0 0 -1px;
+    margin: 25.3px 0 0 -1px;
     & button {
       min-width: 143px;
       height: 23px;

--- a/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.css
+++ b/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.css
@@ -6,7 +6,7 @@
   & .options-dropdown {
     display: flex;
     height: 100%;
-    margin: 25.3px 0 0 -1px;
+    margin: 25.5px 0 0 -1px;
     & button {
       min-width: 143px;
       height: 23px;

--- a/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.js
+++ b/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.js
@@ -37,6 +37,8 @@ export const withReferenceValues = memo(props => {
   const [currentValue, setCurrentValue] = useState(input?.value || '');
   const [wrapperValue, setWrapperValue] = useState(null);
 
+  const decoratorValueRegExp = /"[^"]+"/g;
+
   const handleChange = e => {
     const val = e.target ? e.target.value : e;
 
@@ -50,7 +52,7 @@ export const withReferenceValues = memo(props => {
   }, [dataOptions]);
 
   useLayoutEffect(() => {
-    const newValue = wrapperValue ? formatDecoratorValue(currentValue, wrapperValue, true) : '';
+    const newValue = wrapperValue ? formatDecoratorValue(currentValue, wrapperValue, decoratorValueRegExp, true) : '';
 
     if (newValue) {
       setCurrentValue(newValue);

--- a/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.js
+++ b/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.js
@@ -13,6 +13,7 @@ import { isEmpty } from 'lodash';
 import {
   isFormattedMessage,
   isTranslationId,
+  formatDecoratorValue,
 } from '../../../../utils';
 
 import { OptionsList } from '../partials';
@@ -36,18 +37,11 @@ export const withReferenceValues = memo(props => {
   const [currentValue, setCurrentValue] = useState(input?.value || '');
   const [wrapperValue, setWrapperValue] = useState(null);
 
-  const decoratorValueRegExp = /"(\\.|[^"\\])*"/g;
-
   const handleChange = e => {
     const val = e.target ? e.target.value : e;
 
     setCurrentValue(val);
     input.onChange(e);
-  };
-  const updateDecoratorFieldValue = (curVal, newVal) => {
-    const containQuotedText = curVal.match(decoratorValueRegExp);
-
-    return containQuotedText ? `${curVal.replace(containQuotedText, `"${newVal}"`)}` : `${curVal} "${newVal}"`;
   };
 
   useEffect(() => {
@@ -56,15 +50,7 @@ export const withReferenceValues = memo(props => {
   }, [dataOptions]);
 
   useLayoutEffect(() => {
-    let newValue = '';
-
-    if (wrapperValue) {
-      if (!currentValue) {
-        newValue = `"${wrapperValue}"`;
-      } else {
-        newValue = updateDecoratorFieldValue(currentValue, wrapperValue);
-      }
-    }
+    const newValue = wrapperValue ? formatDecoratorValue(currentValue, wrapperValue, true) : '';
 
     if (newValue) {
       setCurrentValue(newValue);

--- a/src/utils/formUtils.js
+++ b/src/utils/formUtils.js
@@ -113,3 +113,21 @@ export const getEntityTags = props => {
 
   return get(entity, ['tags', 'tagList'], []);
 };
+
+/**
+ * Formats Decorator Value according requirements
+ *
+ * @param {string} currentValue
+ * @param {string} newValue
+ * @param {boolean} isNeedToWrapInQuotes
+ * @return {string} Decorated input value
+ */
+export const formatDecoratorValue = (currentValue, newValue, isNeedToWrapInQuotes) => {
+  const decoratorValueRegExp = /"(\\.|[^"\\])*"/g;
+  const decoratorDatepickerValueRegExp = /###TODAY###|"(\\.|[^"\\])*"/g;
+  const pattern = isNeedToWrapInQuotes || currentValue.includes('###TODAY###') ? decoratorDatepickerValueRegExp : decoratorValueRegExp;
+  const containTextForReplace = currentValue.match(pattern);
+  const updatedValue = isNeedToWrapInQuotes ? `"${newValue}"` : `###${newValue}###`;
+
+  return containTextForReplace ? `${currentValue.replace(containTextForReplace, updatedValue)}` : currentValue ? `${currentValue} ${updatedValue}` : updatedValue;
+};

--- a/src/utils/formUtils.js
+++ b/src/utils/formUtils.js
@@ -119,15 +119,17 @@ export const getEntityTags = props => {
  *
  * @param {string} currentValue
  * @param {string} newValue
+ * @param {RegExp} pattern
  * @param {boolean} isNeedToWrapInQuotes
  * @return {string} Decorated input value
  */
-export const formatDecoratorValue = (currentValue, newValue, isNeedToWrapInQuotes) => {
-  const decoratorValueRegExp = /"(\\.|[^"\\])*"/g;
-  const decoratorDatepickerValueRegExp = /###TODAY###|"(\\.|[^"\\])*"/g;
-  const pattern = isNeedToWrapInQuotes || currentValue.includes('###TODAY###') ? decoratorDatepickerValueRegExp : decoratorValueRegExp;
+export const formatDecoratorValue = (currentValue, newValue, pattern, isNeedToWrapInQuotes) => {
   const containTextForReplace = currentValue.match(pattern);
-  const updatedValue = isNeedToWrapInQuotes ? `"${newValue}"` : `###${newValue}###`;
+  let updatedValue = isNeedToWrapInQuotes ? `"${newValue}"` : newValue;
 
-  return containTextForReplace ? `${currentValue.replace(containTextForReplace, updatedValue)}` : currentValue ? `${currentValue} ${updatedValue}` : updatedValue;
+  if (currentValue.length && !containTextForReplace) {
+    updatedValue = `${currentValue} ${updatedValue}`;
+  }
+
+  return containTextForReplace ? `${currentValue.replace(containTextForReplace.toString(), updatedValue)}` : updatedValue;
 };

--- a/src/utils/formUtils.js
+++ b/src/utils/formUtils.js
@@ -124,12 +124,16 @@ export const getEntityTags = props => {
  * @return {string} Decorated input value
  */
 export const formatDecoratorValue = (currentValue, newValue, pattern, isNeedToWrapInQuotes) => {
-  const containTextForReplace = currentValue.match(pattern);
-  let updatedValue = isNeedToWrapInQuotes ? `"${newValue}"` : newValue;
+  const updatedValue = isNeedToWrapInQuotes ? `"${newValue}"` : newValue;
 
-  if (currentValue.length && !containTextForReplace) {
-    updatedValue = `${currentValue} ${updatedValue}`;
+  if (!currentValue) {
+    return updatedValue;
+  }
+  const containTextForReplace = currentValue.match(pattern);
+
+  if (containTextForReplace) {
+    return `${currentValue.replace(containTextForReplace.toString(), updatedValue)}`;
   }
 
-  return containTextForReplace ? `${currentValue.replace(containTextForReplace.toString(), updatedValue)}` : updatedValue;
+  return `${currentValue} ${updatedValue}`;
 };

--- a/test/bigtest/tests/mapping-profiles/mapping-profile-details-test.js
+++ b/test/bigtest/tests/mapping-profiles/mapping-profile-details-test.js
@@ -332,11 +332,29 @@ const hasDatePickerDecorator = (details, accordion, field, fieldLabel, dropdown,
         await mappingProfileForm[details][accordion][field].fillValue('');
         await mappingProfileForm[details][accordion][dropdown].clickTrigger();
         await mappingProfileForm[details][accordion][dropdown].menu.items(0).click();
-        await mappingProfileForm[details][accordion][field].blurInput();
       });
 
-      it('then input field is filled in with "###TODAY###"', () => {
+      it('then input field is filled in with ###TODAY### value', () => {
         expect(mappingProfileForm[details][accordion][field].val).to.equal('###TODAY###');
+      });
+
+      describe('when 2nd option from select is choosen after 1st option was already choosen', () => {
+        beforeEach(async () => {
+          await mappingProfileForm[details][accordion][dropdown].clickTrigger();
+          await mappingProfileForm[details][accordion][dropdown].menu.items(1).click();
+
+          describe('and date choosen', () => {
+            beforeEach(async () => {
+              await mappingProfileForm[details][accordion][dataPicker].calendarButton.click();
+              await mappingProfileForm[details][accordion][dataPicker].calendar.days(20).click();
+              await mappingProfileForm[details][accordion][dataPicker].blurInput();
+            });
+
+            it('then input field existing quoted date value or ###TODAY### value should be replaced with new quoted date value', () => {
+              expect(mappingProfileForm[details][accordion][field].val).to.equal('"2020-06-20"');
+            });
+          });
+        });
       });
     });
 
@@ -363,7 +381,18 @@ const hasDatePickerDecorator = (details, accordion, field, fieldLabel, dropdown,
         });
 
         it('then field is filled in', () => {
-          expect(mappingProfileForm[details][accordion][dataPicker].inputValue).to.be.equals('"2020-05-16"');
+          expect(mappingProfileForm[details][accordion][dataPicker].inputValue).to.be.equals('"2020-06-20"');
+        });
+
+        describe('when 1st option from select is choosen after 2nd option was already choosen', () => {
+          beforeEach(async () => {
+            await mappingProfileForm[details][accordion][dropdown].clickTrigger();
+            await mappingProfileForm[details][accordion][dropdown].menu.items(0).click();
+          });
+
+          it('then input field existing quoted value should be replaced with ###TODAY###', () => {
+            expect(mappingProfileForm[details][accordion][field].val).to.equal('###TODAY###');
+          });
         });
       });
     });

--- a/test/bigtest/tests/mapping-profiles/mapping-profile-details-test.js
+++ b/test/bigtest/tests/mapping-profiles/mapping-profile-details-test.js
@@ -350,7 +350,7 @@ const hasDatePickerDecorator = (details, accordion, field, fieldLabel, dropdown,
               await mappingProfileForm[details][accordion][dataPicker].blurInput();
             });
 
-            it('then input field existing quoted date value or ###TODAY### value should be replaced with new quoted date value', () => {
+            it('then the previous date value is replaced with the picked date', () => {
               expect(mappingProfileForm[details][accordion][field].val).to.equal('"2020-06-20"');
             });
           });
@@ -390,7 +390,7 @@ const hasDatePickerDecorator = (details, accordion, field, fieldLabel, dropdown,
             await mappingProfileForm[details][accordion][dropdown].menu.items(0).click();
           });
 
-          it('then input field existing quoted value should be replaced with ###TODAY###', () => {
+          it('then the previous date value is replaced with ###TODAY### value', () => {
             expect(mappingProfileForm[details][accordion][field].val).to.equal('###TODAY###');
           });
         });


### PR DESCRIPTION
## Overview
In Instance, Holdings, and Item field mapping profiles, User should only be allowed to select one ref value from the dropdown list. If a second one is selected, it should replace the previously-selected one in the field mapping data field

## Approach
* Create formatDecoratorValue function in formUtils
* Check incoming value, update it in appropriate way
* Add tests

## Ticket
[UIDATIMP-523](https://issues.folio.org/browse/UIDATIMP-523)

## Before
![decorator_before](https://user-images.githubusercontent.com/63101175/83383895-ba380980-a3ee-11ea-863e-fcdcd2e107d3.gif)

## After
![decorator_after](https://user-images.githubusercontent.com/63101175/83383904-c02dea80-a3ee-11ea-99c7-f92e7a3ac945.gif)