### PR TITLE
UIDATIMP-488: Field Mapping Profile details: MARC Bib from MARC Bib 4 - Add Subsequent line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add validation rules for Add action for the MARC modifications table fields (UIDATIMP-487)
 * Migrate from `stripes.type` to `stripes.actsAs`
 * Adjust mapping rules for repeatable fields in Field mapping profiles (UIDATIMP-544)
+* Field Mapping Profile details: MARC Bib from MARC Bib 4 - Add Subsequent lines (UIDATIMP-488)
 
 ### Bugs fixed:
 * Fix Item status list in field mapping profiles (UIDATIMP-515)

--- a/src/components/MARCTable/MARCTable.js
+++ b/src/components/MARCTable/MARCTable.js
@@ -27,7 +27,10 @@ export const MARCTable = ({
       order: row.order + 1,
     });
 
-    const newRow = { order: index };
+    const newRow = {
+      order: index,
+      field: { subfields: [{}] },
+    };
     const updatedRows = [
       ...rows.slice(0, index),
       newRow,
@@ -70,6 +73,65 @@ export const MARCTable = ({
     onChange(updatedRows);
   };
 
+  const addSubfieldRow = order => {
+    const updatedRows = [...rows];
+    const rowToUpdateIndex = rows.findIndex(row => row.order === order);
+    const rowToUpdate = updatedRows[rowToUpdateIndex];
+
+    updatedRows[rowToUpdateIndex] = {
+      ...rowToUpdate,
+      field: {
+        ...rowToUpdate.field,
+        subfields: [...rowToUpdate.field.subfields, {}],
+      },
+    };
+
+    onChange(updatedRows);
+  };
+
+  const removeSubfieldRow = (order, index) => {
+    const updatedRows = [...rows];
+    const rowToUpdateIndex = rows.findIndex(row => row.order === order);
+    const rowToUpdate = updatedRows[rowToUpdateIndex];
+
+    const newSubfields = [
+      ...rowToUpdate.field.subfields.slice(0, index),
+      ...rowToUpdate.field.subfields.slice(index + 1),
+    ];
+    const lastSubfieldIndex = newSubfields.length - 1;
+
+    newSubfields[lastSubfieldIndex] = {
+      ...newSubfields[lastSubfieldIndex],
+      subaction: null,
+    };
+
+    updatedRows[rowToUpdateIndex] = {
+      ...rowToUpdate,
+      field: {
+        ...rowToUpdate.field,
+        subfields: newSubfields,
+      },
+    };
+
+    onChange(updatedRows);
+  };
+
+  const removeSubfieldRows = order => {
+    const updatedRows = [...rows];
+    const rowToUpdateIndex = rows.findIndex(row => row.order === order);
+    const rowToUpdate = updatedRows[rowToUpdateIndex];
+
+    updatedRows[rowToUpdateIndex] = {
+      ...rowToUpdate,
+      field: {
+        ...rowToUpdate.field,
+        subfields: [{}],
+      },
+    };
+
+    onChange(updatedRows);
+  };
+
   const columns = ['arrows', 'action', 'field', 'indicator1', 'indicator2',
     'subfield', 'subaction', 'data', 'position', 'addRemove'];
   const columnWidths = {
@@ -100,6 +162,9 @@ export const MARCTable = ({
         onAddNewRow={addNewRow}
         onRemoveRow={removeRow}
         onMoveRow={moveRow}
+        onAddSubfieldRow={addSubfieldRow}
+        onRemoveSubfieldRow={removeSubfieldRow}
+        onRemoveSubfieldRows={removeSubfieldRows}
       />
     </div>
   );

--- a/src/components/MARCTable/MARCTableRow.js
+++ b/src/components/MARCTable/MARCTableRow.js
@@ -52,6 +52,10 @@ export const MARCTableRow = ({
   onRemoveRow,
   onMoveRow,
   subfieldIndex,
+  subfieldsData,
+  onAddSubfieldRow,
+  onRemoveSubfieldRow,
+  onRemoveSubfieldRows,
 }) => {
   const {
     allowedSubactions,
@@ -127,6 +131,28 @@ export const MARCTableRow = ({
     [actionValue, fieldValue],
   );
 
+  const handleActionChange = e => {
+    const { ADD } = MAPPING_DETAILS_ACTIONS;
+
+    setActionValue(e.target.value);
+
+    if (e.target.value !== ADD && subfieldsData?.length > 1) {
+      onRemoveSubfieldRows(order);
+    }
+  };
+
+  const handleSubActionChange = e => {
+    const { ADD_SUBFIELD } = MAPPING_DETAILS_SUBACTIONS;
+
+    setSubactionValue(e.target.value);
+
+    if (e.target.value === ADD_SUBFIELD) {
+      onAddSubfieldRow(order);
+    }
+  };
+
+  const handleRemoveRow = () => (!isSubline ? onRemoveRow(order) : onRemoveSubfieldRow(order, subfieldIndex));
+
   const renderArrows = () => {
     const cellStyle = {
       width: columnWidths.arrows,
@@ -192,7 +218,7 @@ export const MARCTableRow = ({
                 component={Select}
                 dataOptions={dataOptions}
                 placeholder={placeholder}
-                onChange={e => setActionValue(e.target.value)}
+                onChange={handleActionChange}
                 validate={[validateRequiredField]}
                 marginBottom0
               />
@@ -217,6 +243,7 @@ export const MARCTableRow = ({
           component={TextField}
           onChange={e => setFieldValue(e.target.value)}
           validate={[validateTag]}
+          disabled={isSubline}
           marginBottom0
         />
       </div>
@@ -237,6 +264,7 @@ export const MARCTableRow = ({
           component={TextField}
           onChange={e => setIndicator1Value(e.target.value)}
           validate={[validateIndicator1]}
+          disabled={isSubline}
           marginBottom0
         />
       </div>
@@ -257,6 +285,7 @@ export const MARCTableRow = ({
           component={TextField}
           onChange={e => setIndicator2Value(e.target.value)}
           validate={[validateIndicator2]}
+          disabled={isSubline}
           marginBottom0
         />
       </div>
@@ -306,7 +335,7 @@ export const MARCTableRow = ({
                 component={Select}
                 dataOptions={dataOptions}
                 placeholder={placeholder}
-                onChange={e => setSubactionValue(e.target.value)}
+                onChange={handleSubActionChange}
                 marginBottom0
               />
             )}
@@ -519,7 +548,7 @@ export const MARCTableRow = ({
               icon="trash"
               disabled={isSingle}
               ariaLabel={ariaLabel}
-              onClick={() => onRemoveRow(order)}
+              onClick={handleRemoveRow}
             />
           )}
         </FormattedMessage>
@@ -548,9 +577,9 @@ MARCTableRow.propTypes = {
   name: PropTypes.string.isRequired,
   order: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   columnWidths: PropTypes.object.isRequired,
-  onAddNewRow: PropTypes.func.isRequired,
-  onRemoveRow: PropTypes.func.isRequired,
-  onMoveRow: PropTypes.func.isRequired,
+  onAddNewRow: PropTypes.func,
+  onRemoveRow: PropTypes.func,
+  onMoveRow: PropTypes.func,
   action: PropTypes.string,
   subaction: PropTypes.string,
   field: PropTypes.string,
@@ -559,6 +588,14 @@ MARCTableRow.propTypes = {
   isFirst: PropTypes.bool,
   isLast: PropTypes.bool,
   isSubline: PropTypes.bool,
+  subfieldsData: PropTypes.arrayOf(PropTypes.shape({
+    subfield: PropTypes.string,
+    data: PropTypes.object,
+    subaction: PropTypes.string,
+  })),
+  onAddSubfieldRow: PropTypes.func.isRequired,
+  onRemoveSubfieldRow: PropTypes.func.isRequired,
+  onRemoveSubfieldRows: PropTypes.func.isRequired,
 };
 
 MARCTableRow.defaultProps = {
@@ -570,4 +607,5 @@ MARCTableRow.defaultProps = {
   field: '',
   indicator1: '',
   indicator2: '',
+  subfieldsData: [{}],
 };

--- a/src/components/MARCTable/MARCTableRowContainer.js
+++ b/src/components/MARCTable/MARCTableRowContainer.js
@@ -11,10 +11,13 @@ export const MARCTableRowContainer = ({
   onAddNewRow,
   onRemoveRow,
   onMoveRow,
+  onAddSubfieldRow,
+  onRemoveSubfieldRow,
+  onRemoveSubfieldRows,
 }) => {
   const renderRow = (data, i) => {
     const subfieldsData = data.field?.subfields;
-    const containsSubsequentLines = data.field?.subfields?.length > 1;
+    const containsSubsequentLines = subfieldsData?.length > 1;
     const name = `profile.mappingDetails.marcMappingDetails[${i}]`;
 
     return (
@@ -38,10 +41,17 @@ export const MARCTableRowContainer = ({
           onRemoveRow={onRemoveRow}
           onMoveRow={onMoveRow}
           subfieldIndex={0}
+          subfieldsData={subfieldsData}
+          onAddSubfieldRow={onAddSubfieldRow}
+          onRemoveSubfieldRow={onRemoveSubfieldRow}
+          onRemoveSubfieldRows={onRemoveSubfieldRows}
         />
         {containsSubsequentLines &&
           data.field.subfields.map((subfield, idx) => idx !== 0 && (
-            <div key={idx}>
+            <div
+              key={idx}
+              data-test-marc-subfield-row={idx}
+            >
               <MARCTableRow
                 name={name}
                 order={data.order}
@@ -53,6 +63,10 @@ export const MARCTableRowContainer = ({
                 columnWidths={columnWidths}
                 isSubline
                 subfieldIndex={idx}
+                subfieldsData={subfieldsData}
+                onAddSubfieldRow={onAddSubfieldRow}
+                onRemoveSubfieldRow={onRemoveSubfieldRow}
+                onRemoveSubfieldRows={onRemoveSubfieldRows}
               />
             </div>
           ))
@@ -70,4 +84,7 @@ MARCTableRowContainer.propTypes = {
   onRemoveRow: PropTypes.func.isRequired,
   onMoveRow: PropTypes.func.isRequired,
   columnWidths: PropTypes.object,
+  onAddSubfieldRow: PropTypes.func.isRequired,
+  onRemoveSubfieldRow: PropTypes.func.isRequired,
+  onRemoveSubfieldRows: PropTypes.func.isRequired,
 };

--- a/src/settings/MappingProfiles/initialDetails/MARC_BIBLIOGRAPHIC.js
+++ b/src/settings/MappingProfiles/initialDetails/MARC_BIBLIOGRAPHIC.js
@@ -1,7 +1,10 @@
 const MARC_BIBLIOGRAPHIC = {
   name: 'marcBib',
   recordType: 'MARC_BIBLIOGRAPHIC',
-  marcMappingDetails: [{ order: 0 }],
+  marcMappingDetails: [{
+    order: 0,
+    field: { subfields: [{}] },
+  }],
 };
 
 export default MARC_BIBLIOGRAPHIC;

--- a/test/bigtest/interactors/marc-table-interactor.js
+++ b/test/bigtest/interactors/marc-table-interactor.js
@@ -25,8 +25,7 @@ class MARCTableCellInteractor {
   }
 }
 
-@interactor
-class MARCTableRowInteractor {
+class MARCTableRowBaseInteractor {
   cells = collection('[data-test-marc-table-cell]', MARCTableCellInteractor);
   addRow = scoped('[data-test-marc-table-add]', IconButtonInteractor);
   removeRow = scoped('[data-test-marc-table-remove]', IconButtonInteractor);
@@ -43,6 +42,15 @@ class MARCTableRowInteractor {
   dataFindField = scoped('[data-test-marc-table-data-find]', TextAreaInteractor);
   dataReplaceField = scoped('[data-test-marc-table-data-replace]', TextAreaInteractor);
   position = scoped('[data-test-marc-table-position]', SelectInteractor);
+}
+
+@interactor
+class MARCTableSubfieldsRowInteractor extends MARCTableRowBaseInteractor {}
+
+@interactor
+class MARCTableRowInteractor extends MARCTableRowBaseInteractor {
+  subfields = collection('[data-test-marc-subfield-row]', MARCTableSubfieldsRowInteractor);
+  subfieldsCount = count('[data-test-marc-subfield-row]');
 }
 
 @interactor

--- a/test/bigtest/tests/mapping-profiles/mapping-profile-details-test.js
+++ b/test/bigtest/tests/mapping-profiles/mapping-profile-details-test.js
@@ -1679,9 +1679,7 @@ describe('Mapping Profile View', () => {
 
             hasRepeatableField('itemDetails', 'electronicAccessAccordion', 'electronicAccess', '');
             hasRepeatableFieldDecorator('itemDetails', 'electronicAccessAccordion', 'electronicAccessRepeatable');
-            describe('123123', () => {
-              hasReferenceValuesDecorator('itemDetails', 'electronicAccessAccordion', 'electronicRelationship', 'Relationship', 'electronicRelationshipAcceptedValues', true, 'electronicAccess', ['"name 1"', '910', '910', '910', '910']);
-            });
+            hasReferenceValuesDecorator('itemDetails', 'electronicAccessAccordion', 'electronicRelationship', 'Relationship', 'electronicRelationshipAcceptedValues', true, 'electronicAccess', ['"name 1"', '910', '910', '910', '910']);
           });
         });
 
@@ -1707,6 +1705,82 @@ describe('Mapping Profile View', () => {
 
             it('then "Save" button becomes active', () => {
               expect(mappingProfileForm.submitFormButtonDisabled).to.be.false;
+            });
+          });
+
+          describe('row has subfields', () => {
+            beforeEach(async () => {
+              await mappingProfileForm.marcDetailsTable.rows(0).action.selectAndBlur('Add');
+              await mappingProfileForm.marcDetailsTable.rows(0).subaction.selectAndBlur('Add subfield');
+            });
+
+            describe('wnen "Add" action and "Add subfield" subaction are selected', () => {
+              it('then subfield row is added', () => {
+                expect(mappingProfileForm.marcDetailsTable.rows(0).subfieldsCount).to.be.equal(1);
+              });
+
+              it('subfield row does not include up/down arrows', () => {
+                expect(mappingProfileForm.marcDetailsTable.rows(0).subfields(0).moveRowUp.isPresent).to.be.false;
+                expect(mappingProfileForm.marcDetailsTable.rows(0).subfields(0).moveRowDown.isPresent).to.be.false;
+              });
+
+              it('subfield row do not includes "position" field', () => {
+                expect(mappingProfileForm.marcDetailsTable.rows(0).subfields(0).position.hasSelect).to.be.false;
+              });
+
+              it('subfield row do not includes "add" button', () => {
+                expect(mappingProfileForm.marcDetailsTable.rows(0).subfields(0).addRow.isPresent).to.be.false;
+              });
+
+              describe('when data is filled in for main row', () => {
+                beforeEach(async () => {
+                  await mappingProfileForm.marcDetailsTable.rows(0).tag.fillAndBlur('910');
+                  await mappingProfileForm.marcDetailsTable.rows(0).indicator1.fillAndBlur('a');
+                  await mappingProfileForm.marcDetailsTable.rows(0).indicator2.fillAndBlur('a');
+                  await mappingProfileForm.marcDetailsTable.rows(0).subfield.fillAndBlur('a');
+                  await mappingProfileForm.marcDetailsTable.rows(0).dataTextField.fillAndBlur('test');
+                });
+
+                it('subfield\'s "Field" value has the same "Field" value as main row', () => {
+                  expect(mappingProfileForm.marcDetailsTable.rows(0).subfields(0).tag.val).to.be.equal('910');
+                });
+
+                it('subfield\'s "In.1" value has the same "In.1" value as main row', () => {
+                  expect(mappingProfileForm.marcDetailsTable.rows(0).subfields(0).indicator1.val).to.be.equal('a');
+                });
+
+                it('subfield\'s "In.2" value has the same "In.2" value as main row', () => {
+                  expect(mappingProfileForm.marcDetailsTable.rows(0).subfields(0).indicator2.val).to.be.equal('a');
+                });
+
+                it('subfield\'s "Subfield" value is empty', () => {
+                  expect(mappingProfileForm.marcDetailsTable.rows(0).subfields(0).subfield.val).to.be.equal('');
+                });
+
+                it('subfield\'s "Data" value is empty', () => {
+                  expect(mappingProfileForm.marcDetailsTable.rows(0).subfields(0).dataTextField.val).to.be.equal('');
+                });
+              });
+
+              describe('wnen "Add subfield" subaction of subfield row is selected', () => {
+                beforeEach(async () => {
+                  await mappingProfileForm.marcDetailsTable.rows(0).subfields(0).subaction.selectAndBlur('Add subfield');
+                });
+
+                it('then one more subfield row is added', () => {
+                  expect(mappingProfileForm.marcDetailsTable.rows(0).subfieldsCount).to.be.equal(2);
+                });
+
+                describe('when remove button of subfield row is clicked', () => {
+                  beforeEach(async () => {
+                    await mappingProfileForm.marcDetailsTable.rows(0).subfields(0).removeRow.clickIconButton();
+                  });
+
+                  it('then current subfield row is removed', () => {
+                    expect(mappingProfileForm.marcDetailsTable.rows(0).subfieldsCount).to.be.equal(1);
+                  });
+                });
+              });
             });
           });
         });


### PR DESCRIPTION
## Purpose
To create functionality of adding subfields rows main rows in the table of the Field Mapping profile details for MARC modifications

## Approach
* Add `addSubfieldRow` method to the `MARCTable` component
* Add `removeSubfieldRow` method to the `MARCTable` component
* Add `removeSubfieldRows` method to the `MARCTable` component
* Add `handleActionChange` method to the `MARCTableRow` component
* Add `handleSubActionChange` method to the `MARCTableRow` component
* Add `handleRemoveRow` method to the `MARCTableRow` component

* Add test

## Ticket
[UIDATIMP-488](https://issues.folio.org/browse/UIDATIMP-488)

## Screenshot
![QKWE0VVqto](https://user-images.githubusercontent.com/40805351/84510883-5ce56780-acce-11ea-9fb7-d318a6f1d37b.gif)



