### PR TITLE
UIDATIMP-542 Issue with holdings type field population has been fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bugs fixed:
 * Fix Accessibility problems for MARCTable component (UIDATIMP-547)
+* Fix issue with holdings type field population (UIDATIMP-542)
 
 ## [2.0.0](https://github.com/folio-org/ui-data-import/tree/v2.0.0) (2020-06-12)
 

--- a/src/settings/MappingProfiles/initialDetails/HOLDINGS.js
+++ b/src/settings/MappingProfiles/initialDetails/HOLDINGS.js
@@ -31,7 +31,7 @@ const HOLDINGS = {
     }],
   }, {
     name: 'holdingsTypeId',
-    enabled: false,
+    enabled: true,
     path: 'holdings.holdingsTypeId',
     value: '',
     subfields: [],


### PR DESCRIPTION
## Overview
When default value is selected for Holdings type in the Holdings field mapping profile, it does not populate into a newly-created holdings record

## Ticket
[UIDATIMP-542](https://issues.folio.org/browse/UIDATIMP-542)