### PR TITLE
UIDATIMP-538: Fix deletion of repeatable fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix Accessibility problems for MARCTable component (UIDATIMP-547)
 * Fix issue with holdings type field population (UIDATIMP-542)
 * Fix issue with digitization policy field (UIDATIMP-543)
+* Fix repeatable fields in Field mapping profiles (UIDATIMP-538)
 
 ## [2.0.0](https://github.com/folio-org/ui-data-import/tree/v2.0.0) (2020-06-12)
 

--- a/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.js
+++ b/src/components/FlexibleForm/ControlDecorators/withReferenceValues/withReferenceValues.js
@@ -51,6 +51,10 @@ export const withReferenceValues = memo(props => {
     setListOptions(dataOptions);
   }, [dataOptions]);
 
+  useEffect(() => {
+    setCurrentValue(input.value);
+  }, [input.value]);
+
   useLayoutEffect(() => {
     const newValue = wrapperValue ? formatDecoratorValue(currentValue, wrapperValue, decoratorValueRegExp, true) : '';
 


### PR DESCRIPTION
## Description

Fix deletion of repeatable fields in Field mapping profiles

## Issue
[UIDATIMP-538](https://issues.folio.org/browse/UIDATIMP-538)

## Screenshots

**Before**
![before-fix](https://user-images.githubusercontent.com/55138456/85267754-500b0580-b47e-11ea-892e-25d1b91436c6.gif)

**After**
![after_fix](https://user-images.githubusercontent.com/55138456/85267779-5600e680-b47e-11ea-9b03-9e436ea095c7.gif)

