### PR TITLE
locking version for react-intl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features added:
 * Field Mapping Profile details: MARC Bib from MARC Bib 2 - Delete (UIDATIMP-486)
+* Locking version for react-intl (UIDATIMP-551)
 
 ### Bugs fixed:
 * Fix Accessibility problems for MARCTable component (UIDATIMP-547)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "query-string": "^5.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-intl": "^4.5.1",
+    "react-intl": "~4.6.10",
     "react-router": "^5.0.1",
     "react-router-dom": "^5.0.1",
     "sinon": "^7.2.2"
@@ -56,7 +56,7 @@
   "peerDependencies": {
     "@folio/stripes": "^4.0.0",
     "react": "*",
-    "react-intl": "^4.5.1",
+    "react-intl": "~4.6.10",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1"
   },


### PR DESCRIPTION
## Overview
We faced with build failures on Jenkins during npm install step. This is related a new release of react-intl v4.7.1 (released at around 3am EST). To avoid build failures the decision was made to lock previous version of this package.

## Ticket
[UIDATIMP-551](https://issues.folio.org/browse/UIDATIMP-551)