### PR TITLE
UIDATIMP-433: Fix Accessibility problems for settings/data-import/job-profiles?layer=create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix repeatable fields in Field mapping profiles (UIDATIMP-538)
 * Fix Accessibility problems for /data-import page (UIDATIMP-429)
 * Fix Accessibility problems for data-import/job-logs (Buttons must have discernible text) (UIDATIMP-432)
+* Fix Accessibility problems for settings/data-import/job-profiles?layer=create (UIDATIMP-433)
 
 ## [2.0.0](https://github.com/folio-org/ui-data-import/tree/v2.0.0) (2020-06-12)
 

--- a/src/components/ListTemplate/ColumnTemplates/CheckboxColumn.js
+++ b/src/components/ListTemplate/ColumnTemplates/CheckboxColumn.js
@@ -1,4 +1,5 @@
 import React, { memo } from 'react';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import { noop } from 'lodash';
@@ -18,11 +19,16 @@ export const CheckboxColumn = memo(({
     data-test-select-item
     onClick={e => e.stopPropagation()}
   >
-    <Checkbox
-      name={`selected-${value}`}
-      checked={checked}
-      onChange={() => onChange(value)}
-    />
+    <FormattedMessage id="ui-data-import.settings.table.checkbox">
+      {ariaLabel => (
+        <Checkbox
+          name={`selected-${value}`}
+          checked={checked}
+          onChange={() => onChange(value)}
+          aria-label={ariaLabel}
+        />
+      )}
+    </FormattedMessage>
   </div>
 ));
 

--- a/src/components/ListTemplate/HeaderTemplates/CheckboxHeader.js
+++ b/src/components/ListTemplate/HeaderTemplates/CheckboxHeader.js
@@ -1,4 +1,5 @@
 import React, { memo } from 'react';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import { noop } from 'lodash';
@@ -17,11 +18,16 @@ export const CheckboxHeader = memo(({
     data-test-select-all-checkbox
     onClick={e => e.stopPropagation()}
   >
-    <Checkbox
-      name="selected-all"
-      checked={checked}
-      onChange={onChange}
-    />
+    <FormattedMessage id="ui-data-import.settings.table.checkboxAll">
+      {ariaLabel => (
+        <Checkbox
+          name="selected-all"
+          checked={checked}
+          onChange={onChange}
+          aria-label={ariaLabel}
+        />
+      )}
+    </FormattedMessage>
   </div>
 ));
 

--- a/src/components/ProfileTree/ProfileLinker/LinkerTrigger.js
+++ b/src/components/ProfileTree/ProfileLinker/LinkerTrigger.js
@@ -14,13 +14,14 @@ export const LinkerTrigger = ({
   ariaProps,
   keyHandler,
   onClick,
+  id,
 }) => (
   <>
     <Button
       buttonStyle="default"
       ref={triggerRef}
-      aria-labelledby="linker-tooltip-text"
-      aria-describedby="linker-tooltip-sub"
+      aria-labelledby={`${id}-text`}
+      aria-describedby={`${id}-sub`}
       onClick={onClick}
       onKeyDown={keyHandler}
       {...ariaProps}
@@ -30,12 +31,14 @@ export const LinkerTrigger = ({
         size="medium"
       />
     </Button>
-    <Tooltip
-      id="linker-tooltip"
-      text={title || <FormattedMessage id="ui-data-import.settings.getStarted" />}
-      triggerRef={triggerRef}
-      placement="right-end"
-    />
+    <div data-test-linker-tooltip-text>
+      <Tooltip
+        id={id}
+        text={title || <FormattedMessage id="ui-data-import.settings.getStarted" />}
+        triggerRef={triggerRef}
+        placement="right-end"
+      />
+    </div>
   </>
 );
 
@@ -45,4 +48,5 @@ LinkerTrigger.propTypes = {
   ariaProps: PropTypes.object.isRequired,
   keyHandler: PropTypes.func.isRequired,
   onClick: PropTypes.func.isRequired,
+  id: PropTypes.string.isRequired,
 };

--- a/src/components/SearchAndSort/SearchAndSort.js
+++ b/src/components/SearchAndSort/SearchAndSort.js
@@ -400,10 +400,7 @@ export class SearchAndSort extends Component {
     } = row;
 
     return (
-      <div
-        role="listitem"
-        key={`row-${rowIndex}`}
-      >
+      <div key={`row-${rowIndex}`}>
         <a
           href={this.getRowURL(rowData.id)}
           aria-label={labelStrings && labelStrings.join('...')}

--- a/src/settings/JobProfiles/JobProfilesForm.js
+++ b/src/settings/JobProfiles/JobProfilesForm.js
@@ -154,7 +154,7 @@ export const JobProfilesFormComponent = ({
           </div>
         </Accordion>
         <Accordion
-          id="job-profile-overview"
+          data-test-job-profile-overview
           label={<FormattedMessage id="ui-data-import.settings.jobProfiles.overview" />}
           separator={false}
         >

--- a/src/settings/JobProfiles/ViewJobProfile.js
+++ b/src/settings/JobProfiles/ViewJobProfile.js
@@ -422,7 +422,7 @@ export class ViewJobProfile extends Component {
             </div>
           )}
           <Accordion
-            id="job-profile-overview"
+            data-test-job-profile-overview-details
             label={<FormattedMessage id="ui-data-import.settings.jobProfiles.overview" />}
           >
             {wrappersLoaded ? (

--- a/test/bigtest/interactors/job-profiles/job-profile-details.js
+++ b/test/bigtest/interactors/job-profiles/job-profile-details.js
@@ -18,7 +18,7 @@ import { ActionMenuInteractor } from '../action-menu-interactor';
   acceptedDataType = scoped('[data-test-accepted-data-type]');
   description = scoped('[data-test-description]');
   isTagsPresent = isPresent('[data-test-tags-accordion]');
-  isOverviewPresent = isPresent('#job-profile-overview');
+  isOverviewPresent = isPresent('[data-test-job-profile-overview-details]');
   profileTree = new ProfileTreeInteractor();
   jobsUsingThisProfile = new MultiColumnListInteractor('#jobs-using-this-profile');
   confirmationModal = new ConfirmationModalInteractor('#delete-job-profile-modal');

--- a/test/bigtest/interactors/job-profiles/job-profile-form.js
+++ b/test/bigtest/interactors/job-profiles/job-profile-form.js
@@ -14,7 +14,7 @@ class NewJobProfileInteractor extends FullScreenFormInteractor {
   dataTypeField = new SelectInteractor('[data-test-accepted-data-types-field]');
   descriptionField = new TextAreaInteractor('[data-test-description-field]');
   profileTree = new ProfileTreeInteractor();
-  overviewAccordion = new AccordionInteractor('#job-profile-overview');
+  overviewAccordion = new AccordionInteractor('[data-test-job-profile-overview]');
   summaryAccordion = new AccordionInteractor('#job-profile-summary');
 
   whenLoaded() {

--- a/test/bigtest/interactors/profile-tree-interactor.js
+++ b/test/bigtest/interactors/profile-tree-interactor.js
@@ -13,7 +13,7 @@ import Button from '@folio/stripes-components/lib/Button/tests/interactor';
 
 @interactor
 class ProfileLinkerInteractor {
-  tooltipText = text('#linker-tooltip-text');
+  tooltipText = text('[data-test-linker-tooltip-text]');
   isOpen = attribute('[aria-haspopup]', 'aria-expanded');
   options = collection('[data-test-plugin-find-record-button]');
   optionsCount = count('[data-test-plugin-find-record-button]');

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -152,6 +152,8 @@
   "returnToAssign.resume": "Resume",
   "returnToAssign.deleteFiles": "Delete files",
   "loadMarcRecords": "Load MARC bibliographic records",
+  "settings.table.checkbox": "select item",
+  "settings.table.checkboxAll": "select all items",
   "settings.action.add": "Add",
   "settings.index.paneTitle": "Data Import",
   "settings.getStarted": "Click here to get started",


### PR DESCRIPTION
## Purpose
To fix Accessibility problems for settings/data-import/job-profiles?layer=create page

## Approach
- add `aria-label` attribute to checkbox in `CheckboxColumn` component
- add `aria-label` attribute to checkbox in `CheckboxHeader` component
- add translations for `aria-label` attributes
- add unique `id` for `Tooltip` in `LinkerTrigger` component
- remove extra `role` attribute for row content in `SearchAndSort`  component
- update tests

## Ticket
[UIDATIMP-433](https://issues.folio.org/browse/UIDATIMP-433)

