### PR TITLE
UIDATIMP-481: Fix rendering qualifier sections with old data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 * Increment `@folio/stripes` to `v5` and update dependency on `react-router`.
 
 ### Bugs fixed:
+* Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)
+
+## [2.1.1](https://github.com/folio-org/ui-data-import/tree/v2.1.1) (2020-07-09)
+
+### Features added:
+* Get rid of imported translations for math profiles (UIDATIMP-570)
+
+### Bugs fixed:
 * Fix deletion repeatable fields in Field mapping profile (UIDATIMP-482)
 * Fix assigning and unassigning tags to data import profiles (UIDATIMP-499)
 * Fix failing tests and turn on tests on CI (UIDATIMP-556)

--- a/src/components/Section/Section.js
+++ b/src/components/Section/Section.js
@@ -1,5 +1,6 @@
 import React, {
   memo,
+  useEffect,
   useState,
 } from 'react';
 import PropTypes from 'prop-types';
@@ -23,6 +24,10 @@ export const Section = memo(({
   ...rest
 }) => {
   const [isChecked, setChecked] = useState(isOpen);
+
+  useEffect(() => {
+    setChecked(isOpen);
+  }, [isOpen]);
 
   const getDataAttributes = attrs => pickBy(attrs, (_, key) => key.startsWith('data-test-'));
 


### PR DESCRIPTION
## Description
Fix rendering qualifier sections in match profiles details with old data.

## Approach
Add `useEffect` hook to `Section` component to update state if updated `isOpen` prop received.

## Issue
[UIDATIMP-481](https://issues.folio.org/browse/UIDATIMP-481)