### PR TITLE
UIDATIMP-508: Field mappings: Repeatable field dropdown Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Increment `@folio/stripes` to `v5` and update dependency on `react-router`.
 * Reuse `<EndOfItem>` component from `stripes-data-transfer-components` repository (UIDATIMP-571)
 * Fix field mapping for Item record check in/check out note (UIDATIMP-554)
+* Field mappings: Repeatable field dropdown Validation (UIDATIMP-508)
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)

--- a/src/components/FlexibleForm/ControlDecorators/withRepeatableActions/withRepeatableActions.js
+++ b/src/components/FlexibleForm/ControlDecorators/withRepeatableActions/withRepeatableActions.js
@@ -32,10 +32,10 @@ export const withRepeatableActions = memo(props => {
     wrapperFieldName,
   } = props;
 
-  const actions = get(FORMS_SETTINGS, [ENTITY_KEYS.MAPPING_PROFILES, 'DECORATORS', 'REPEATABLE_ACTIONS'], []);
-  const dataOptions = Object.keys(actions).map(key => ({
-    value: key,
-    label: intl.formatMessage({ id: actions[key] }),
+  const actions = FORMS_SETTINGS[ENTITY_KEYS.MAPPING_PROFILES].DECORATORS.REPEATABLE_ACTIONS;
+  const dataOptions = actions.map(action => ({
+    value: action.value,
+    label: intl.formatMessage({ id: action.label }),
   }));
 
   const legendHeadline = (

--- a/src/settings/MappingProfiles/MappingProfilesForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm.js
@@ -120,7 +120,6 @@ export const MappingProfilesFormComponent = ({
     };
 
     setInitials(newInitials);
-    // @TODO: change method should be changed to initialize
     dispatch(change(formName, 'profile.mappingDetails', newInitDetails));
 
     if (!isEqual) {
@@ -170,9 +169,14 @@ export const MappingProfilesFormComponent = ({
     dispatch(change(formName, fieldsPath, updatedValue));
   };
 
+  const getRepeatableFieldAction = mappingFieldIndex => {
+    return mappingDetails?.mappingFields?.[mappingFieldIndex]?.repeatableFieldAction || '';
+  };
+
   const detailsProps = {
     initialFields,
     referenceTables,
+    getRepeatableFieldAction,
     setReferenceTables: setFormFieldValue,
     okapi,
   };

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/AdministrativeData.js
@@ -38,6 +38,7 @@ export const AdministrativeData = ({
   statisticalCodeIds,
   initialFields,
   setReferenceTables,
+  getRepeatableFieldAction,
   okapi,
 }) => {
   return (
@@ -78,24 +79,31 @@ export const AdministrativeData = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(2)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.administrativeData.field.formerId.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(2)}
+            repeatableFieldIndex={2}
+            hasRepeatableFields={!!formerIds.length}
+            onRepeatableActionChange={setReferenceTables}
           >
-            <RepeatableField
-              fields={formerIds}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.administrativeData.field.formerId.addLabel`} />}
-              onAdd={() => onAdd(formerIds, 'formerIds', 2, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, formerIds, 2, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col xs={12}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.administrativeData.field.formerId`} />}
-                      name={getSubfieldName(2, 0, index)}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {isDisabled => (
+              <RepeatableField
+                fields={formerIds}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.administrativeData.field.formerId.addLabel`} />}
+                onAdd={() => onAdd(formerIds, 'formerIds', 2, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, formerIds, 2, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col xs={12}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.administrativeData.field.formerId`} />}
+                        name={getSubfieldName(2, 0, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -130,42 +138,49 @@ export const AdministrativeData = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(4)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(4)}
+            repeatableFieldIndex={4}
+            hasRepeatableFields={!!statisticalCodeIds.length}
+            onRepeatableActionChange={setReferenceTables}
           >
-            <RepeatableField
-              fields={statisticalCodeIds}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.addLabel`} />}
-              onAdd={() => onAdd(statisticalCodeIds, 'statisticalCodeIds', 4, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, statisticalCodeIds, 4, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col
-                    data-test-statistical-code
-                    xs={12}
-                  >
-                    <AcceptedValuesField
-                      component={TextField}
-                      name={getSubfieldName(4, 0, index)}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCode`} />}
-                      optionValue="name"
-                      optionLabel="name"
-                      wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
-                      wrapperSourcesFn="statisticalCodeTypeName"
-                      wrapperSources={[{
-                        wrapperSourceLink: '/statistical-codes?limit=2000&query=cql.allRecords=1 sortby name',
-                        wrapperSourcePath: 'statisticalCodes',
-                      }, {
-                        wrapperSourceLink: '/statistical-code-types?limit=1000&query=cql.allRecords=1 sortby name',
-                        wrapperSourcePath: 'statisticalCodeTypes',
-                      }]}
-                      optionTemplate="**statisticalCodeTypeName**: **code** - **name**"
-                      setAcceptedValues={setReferenceTables}
-                      acceptedValuesPath={getRepeatableAcceptedValuesPath(4, 0, index)}
-                      okapi={okapi}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {isDisabled => (
+              <RepeatableField
+                fields={statisticalCodeIds}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.addLabel`} />}
+                onAdd={() => onAdd(statisticalCodeIds, 'statisticalCodeIds', 4, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, statisticalCodeIds, 4, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col
+                      data-test-statistical-code
+                      xs={12}
+                    >
+                      <AcceptedValuesField
+                        component={TextField}
+                        name={getSubfieldName(4, 0, index)}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCode`} />}
+                        optionValue="name"
+                        optionLabel="name"
+                        wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
+                        wrapperSourcesFn="statisticalCodeTypeName"
+                        wrapperSources={[{
+                          wrapperSourceLink: '/statistical-codes?limit=2000&query=cql.allRecords=1 sortby name',
+                          wrapperSourcePath: 'statisticalCodes',
+                        }, {
+                          wrapperSourceLink: '/statistical-code-types?limit=1000&query=cql.allRecords=1 sortby name',
+                          wrapperSourcePath: 'statisticalCodeTypes',
+                        }]}
+                        optionTemplate="**statisticalCodeTypeName**: **code** - **name**"
+                        setAcceptedValues={setReferenceTables}
+                        acceptedValuesPath={getRepeatableAcceptedValuesPath(4, 0, index)}
+                        okapi={okapi}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -178,5 +193,6 @@ AdministrativeData.propTypes = {
   statisticalCodeIds: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   initialFields: PropTypes.object.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
   okapi: okapiShape.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/ElectronicAccess.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/ElectronicAccess.js
@@ -33,6 +33,7 @@ export const ElectronicAccess = ({
   electronicAccess,
   initialFields,
   setReferenceTables,
+  getRepeatableFieldAction,
   okapi,
 }) => {
   return (
@@ -46,65 +47,74 @@ export const ElectronicAccess = ({
           id="section-electronic-access"
           xs={12}
         >
-          <RepeatableActionsField wrapperFieldName={getRepeatableFieldName(22)}>
-            <RepeatableField
-              fields={electronicAccess}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.EAccess.addLabel`} />}
-              onAdd={() => onAdd(electronicAccess, 'electronicAccess', 22, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, electronicAccess, 22, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col
-                    data-test-electronic-relationship
-                    xs={4}
-                  >
-                    <AcceptedValuesField
-                      component={TextField}
-                      name={getSubfieldName(22, 0, index)}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.relationship`} />}
-                      optionValue="name"
-                      optionLabel="name"
-                      wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
-                      wrapperSources={[{
-                        wrapperSourceLink: '/electronic-access-relationships?limit=1000&query=cql.allRecords=1 sortby name',
-                        wrapperSourcePath: 'electronicAccessRelationships',
-                      }]}
-                      setAcceptedValues={setReferenceTables}
-                      acceptedValuesPath={getRepeatableAcceptedValuesPath(22, 0, index)}
-                      okapi={okapi}
-                    />
-                  </Col>
-                  <Col xs={2}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.uri`} />}
-                      name={getSubfieldName(22, 1, index)}
-                    />
-                  </Col>
-                  <Col xs={2}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.linkText`} />}
-                      name={getSubfieldName(22, 2, index)}
-                    />
-                  </Col>
-                  <Col xs={2}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.materialsSpecified`} />}
-                      name={getSubfieldName(22, 3, index)}
-                    />
-                  </Col>
-                  <Col xs={2}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.urlPublicNote`} />}
-                      name={getSubfieldName(22, 4, index)}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+          <RepeatableActionsField
+            wrapperFieldName={getRepeatableFieldName(22)}
+            repeatableFieldAction={getRepeatableFieldAction(22)}
+            repeatableFieldIndex={22}
+            hasRepeatableFields={!!electronicAccess.length}
+            onRepeatableActionChange={setReferenceTables}
+          >
+            {isDisabled => (
+              <RepeatableField
+                fields={electronicAccess}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.EAccess.addLabel`} />}
+                onAdd={() => onAdd(electronicAccess, 'electronicAccess', 22, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, electronicAccess, 22, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col
+                      data-test-electronic-relationship
+                      xs={4}
+                    >
+                      <AcceptedValuesField
+                        component={TextField}
+                        name={getSubfieldName(22, 0, index)}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.relationship`} />}
+                        optionValue="name"
+                        optionLabel="name"
+                        wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
+                        wrapperSources={[{
+                          wrapperSourceLink: '/electronic-access-relationships?limit=1000&query=cql.allRecords=1 sortby name',
+                          wrapperSourcePath: 'electronicAccessRelationships',
+                        }]}
+                        setAcceptedValues={setReferenceTables}
+                        acceptedValuesPath={getRepeatableAcceptedValuesPath(22, 0, index)}
+                        okapi={okapi}
+                      />
+                    </Col>
+                    <Col xs={2}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.uri`} />}
+                        name={getSubfieldName(22, 1, index)}
+                      />
+                    </Col>
+                    <Col xs={2}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.linkText`} />}
+                        name={getSubfieldName(22, 2, index)}
+                      />
+                    </Col>
+                    <Col xs={2}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.materialsSpecified`} />}
+                        name={getSubfieldName(22, 3, index)}
+                      />
+                    </Col>
+                    <Col xs={2}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.urlPublicNote`} />}
+                        name={getSubfieldName(22, 4, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -116,5 +126,6 @@ ElectronicAccess.propTypes = {
   electronicAccess: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   initialFields: PropTypes.object.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
   okapi: okapiShape.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsDetails.js
@@ -36,6 +36,7 @@ export const HoldingsDetails = ({
   holdingStatementsForIndexes,
   initialFields,
   setReferenceTables,
+  getRepeatableFieldAction,
   okapi,
 }) => {
   return (
@@ -64,31 +65,38 @@ export const HoldingsDetails = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(15)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(15)}
+            repeatableFieldIndex={15}
+            hasRepeatableFields={!!holdingStatements.length}
+            onRepeatableActionChange={setReferenceTables}
           >
-            <RepeatableField
-              fields={holdingStatements}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement.addLabel`} />}
-              onAdd={() => onAdd(holdingStatements, 'holdingStatements', 15, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, holdingStatements, 15, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col xs={4}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement`} />}
-                      name={getSubfieldName(15, 0, index)}
-                    />
-                  </Col>
-                  <Col xs={4}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatementNote`} />}
-                      name={getSubfieldName(15, 1, index)}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {isDisabled => (
+              <RepeatableField
+                fields={holdingStatements}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement.addLabel`} />}
+                onAdd={() => onAdd(holdingStatements, 'holdingStatements', 15, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, holdingStatements, 15, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col xs={4}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement`} />}
+                        name={getSubfieldName(15, 0, index)}
+                      />
+                    </Col>
+                    <Col xs={4}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatementNote`} />}
+                        name={getSubfieldName(15, 1, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -101,31 +109,38 @@ export const HoldingsDetails = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(16)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForSupplements.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(16)}
+            repeatableFieldIndex={16}
+            hasRepeatableFields={!!holdingStatementsForSupplements.length}
+            onRepeatableActionChange={setReferenceTables}
           >
-            <RepeatableField
-              fields={holdingStatementsForSupplements}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForSupplements.addLabel`} />}
-              onAdd={() => onAdd(holdingStatementsForSupplements, 'holdingStatementsForSupplements', 16, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, holdingStatementsForSupplements, 16, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col xs={4}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement`} />}
-                      name={getSubfieldName(16, 0, index)}
-                    />
-                  </Col>
-                  <Col xs={4}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatementNote`} />}
-                      name={getSubfieldName(16, 1, index)}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {isDisabled => (
+              <RepeatableField
+                fields={holdingStatementsForSupplements}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForSupplements.addLabel`} />}
+                onAdd={() => onAdd(holdingStatementsForSupplements, 'holdingStatementsForSupplements', 16, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, holdingStatementsForSupplements, 16, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col xs={4}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement`} />}
+                        name={getSubfieldName(16, 0, index)}
+                      />
+                    </Col>
+                    <Col xs={4}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatementNote`} />}
+                        name={getSubfieldName(16, 1, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -138,31 +153,38 @@ export const HoldingsDetails = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(17)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForIndexes.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(17)}
+            repeatableFieldIndex={17}
+            hasRepeatableFields={!!holdingStatementsForIndexes.length}
+            onRepeatableActionChange={setReferenceTables}
           >
-            <RepeatableField
-              fields={holdingStatementsForIndexes}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForIndexes.addLabel`} />}
-              onAdd={() => onAdd(holdingStatementsForIndexes, 'holdingStatementsForIndexes', 17, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, holdingStatementsForIndexes, 17, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col xs={4}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement`} />}
-                      name={getSubfieldName(17, 0, index)}
-                    />
-                  </Col>
-                  <Col xs={4}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatementNote`} />}
-                      name={getSubfieldName(17, 1, index)}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {isDisabled => (
+              <RepeatableField
+                fields={holdingStatementsForIndexes}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForIndexes.addLabel`} />}
+                onAdd={() => onAdd(holdingStatementsForIndexes, 'holdingStatementsForIndexes', 17, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, holdingStatementsForIndexes, 17, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col xs={4}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement`} />}
+                        name={getSubfieldName(17, 0, index)}
+                      />
+                    </Col>
+                    <Col xs={4}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatementNote`} />}
+                        name={getSubfieldName(17, 1, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -218,5 +240,6 @@ HoldingsDetails.propTypes = {
   holdingStatementsForIndexes: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   initialFields: PropTypes.object.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
   okapi: okapiShape.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsNotes.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsNotes.js
@@ -35,6 +35,7 @@ export const HoldingsNotes = ({
   notes,
   initialFields,
   setReferenceTables,
+  getRepeatableFieldAction,
   okapi,
 }) => {
   return (
@@ -48,53 +49,62 @@ export const HoldingsNotes = ({
           id="section-holding-statements"
           xs={12}
         >
-          <RepeatableActionsField wrapperFieldName={getRepeatableFieldName(21)}>
-            <RepeatableField
-              fields={notes}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.holdingsNotes.addLabel`} />}
-              onAdd={() => onAdd(notes, 'notes', 21, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, notes, 21, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col
-                    data-test-note
-                    xs={4}
-                  >
-                    <AcceptedValuesField
-                      component={TextField}
-                      name={getSubfieldName(21, 0, index)}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.noteType`} />}
-                      optionValue="name"
-                      optionLabel="name"
-                      wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
-                      wrapperSources={[{
-                        wrapperSourceLink: '/holdings-note-types?limit=1000&query=cql.allRecords=1 sortby name',
-                        wrapperSourcePath: 'holdingsNoteTypes',
-                      }]}
-                      setAcceptedValues={setReferenceTables}
-                      acceptedValuesPath={getRepeatableAcceptedValuesPath(21, 0, index)}
-                      okapi={okapi}
-                    />
-                  </Col>
-                  <Col xs={4}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.note`} />}
-                      name={getSubfieldName(21, 1, index)}
-                    />
-                  </Col>
-                  <Col
-                    data-test-staff-only
-                    xs={4}
-                  >
-                    <BooleanActionField
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.staffOnly`} />}
-                      name={getBoolSubfieldName(21, 2, index)}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+          <RepeatableActionsField
+            wrapperFieldName={getRepeatableFieldName(21)}
+            repeatableFieldAction={getRepeatableFieldAction(21)}
+            repeatableFieldIndex={21}
+            hasRepeatableFields={!!notes.length}
+            onRepeatableActionChange={setReferenceTables}
+          >
+            {isDisabled => (
+              <RepeatableField
+                fields={notes}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.holdingsNotes.addLabel`} />}
+                onAdd={() => onAdd(notes, 'notes', 21, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, notes, 21, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col
+                      data-test-note
+                      xs={4}
+                    >
+                      <AcceptedValuesField
+                        component={TextField}
+                        name={getSubfieldName(21, 0, index)}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.noteType`} />}
+                        optionValue="name"
+                        optionLabel="name"
+                        wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
+                        wrapperSources={[{
+                          wrapperSourceLink: '/holdings-note-types?limit=1000&query=cql.allRecords=1 sortby name',
+                          wrapperSourcePath: 'holdingsNoteTypes',
+                        }]}
+                        setAcceptedValues={setReferenceTables}
+                        acceptedValuesPath={getRepeatableAcceptedValuesPath(21, 0, index)}
+                        okapi={okapi}
+                      />
+                    </Col>
+                    <Col xs={4}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.note`} />}
+                        name={getSubfieldName(21, 1, index)}
+                      />
+                    </Col>
+                    <Col
+                      data-test-staff-only
+                      xs={4}
+                    >
+                      <BooleanActionField
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.staffOnly`} />}
+                        name={getBoolSubfieldName(21, 2, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -106,5 +116,6 @@ HoldingsNotes.propTypes = {
   notes: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   initialFields: PropTypes.object.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
   okapi: okapiShape.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/ReceivingHistory.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/ReceivingHistory.js
@@ -30,6 +30,7 @@ export const ReceivingHistory = ({
   receivingHistory,
   initialFields,
   setReferenceTables,
+  getRepeatableFieldAction,
 }) => {
   return (
     <Accordion
@@ -42,43 +43,52 @@ export const ReceivingHistory = ({
           id="section-receiving-history"
           xs={12}
         >
-          <RepeatableActionsField wrapperFieldName={getRepeatableFieldName(26)}>
-            <RepeatableField
-              fields={receivingHistory}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.receivingHistory.addLabel`} />}
-              onAdd={() => onAdd(receivingHistory, 'receivingHistory.entries', 26, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, receivingHistory, 26, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col
-                    data-test-public-display
-                    xs={4}
-                  >
-                    <BooleanActionField
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.publicDisplay`} />}
-                      name={getBoolSubfieldName(26, 0, index)}
-                    />
-                  </Col>
-                  <Col xs={4}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.enumeration`} />}
-                      name={getSubfieldName(26, 1, index)}
-                    />
-                  </Col>
-                  <Col
-                    data-test-staff-only
-                    xs={4}
-                  >
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.chronology`} />}
-                      name={getSubfieldName(26, 2, index)}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+          <RepeatableActionsField
+            wrapperFieldName={getRepeatableFieldName(26)}
+            repeatableFieldAction={getRepeatableFieldAction(26)}
+            repeatableFieldIndex={26}
+            hasRepeatableFields={!!receivingHistory.length}
+            onRepeatableActionChange={setReferenceTables}
+          >
+            {isDisabled => (
+              <RepeatableField
+                fields={receivingHistory}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.receivingHistory.addLabel`} />}
+                onAdd={() => onAdd(receivingHistory, 'receivingHistory.entries', 26, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, receivingHistory, 26, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col
+                      data-test-public-display
+                      xs={4}
+                    >
+                      <BooleanActionField
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.publicDisplay`} />}
+                        name={getBoolSubfieldName(26, 0, index)}
+                      />
+                    </Col>
+                    <Col xs={4}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.enumeration`} />}
+                        name={getSubfieldName(26, 1, index)}
+                      />
+                    </Col>
+                    <Col
+                      data-test-staff-only
+                      xs={4}
+                    >
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.chronology`} />}
+                        name={getSubfieldName(26, 2, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -90,4 +100,5 @@ ReceivingHistory.propTypes = {
   receivingHistory: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   initialFields: PropTypes.object.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/AdministrativeData.js
@@ -39,6 +39,7 @@ export const AdministrativeData = ({
   statisticalCodes,
   initialFields,
   setReferenceTables,
+  getRepeatableFieldAction,
   okapi,
 }) => {
   return (
@@ -157,43 +158,49 @@ export const AdministrativeData = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(8)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(8)}
+            repeatableFieldIndex={8}
+            hasRepeatableFields={!!statisticalCodes.length}
+            onRepeatableActionChange={setReferenceTables}
           >
-            <RepeatableField
-              fields={statisticalCodes}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.addLabel`} />}
-              onAdd={() => onAdd(statisticalCodes, 'statisticalCodeIds', 8, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, statisticalCodes, 8, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col
-                    data-test-statistical-code
-                    xs={12}
-                  >
-                    <AcceptedValuesField
-                      okapi={okapi}
-                      component={TextField}
-                      name={getSubfieldName(8, 0, index)}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCode`} />}
-                      optionLabel="name"
-                      optionValue="name"
-                      wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
-                      wrapperSourcesFn="statisticalCodeTypeName"
-                      wrapperSources={[{
-                        wrapperSourceLink: '/statistical-codes?limit=2000&query=cql.allRecords=1 sortby name',
-                        wrapperSourcePath: 'statisticalCodes',
-                      }, {
-                        wrapperSourceLink: '/statistical-code-types?limit=1000&query=cql.allRecords=1 sortby name',
-                        wrapperSourcePath: 'statisticalCodeTypes',
-                      }]}
-                      optionTemplate="**statisticalCodeTypeName**: **code** - **name**"
-                      setAcceptedValues={setReferenceTables}
-                      acceptedValuesPath={getRepeatableAcceptedValuesPath(8, 0, index)}
-
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {isDisabled => (
+              <RepeatableField
+                fields={statisticalCodes}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.addLabel`} />}
+                onAdd={() => onAdd(statisticalCodes, 'statisticalCodeIds', 8, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, statisticalCodes, 8, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col
+                      data-test-statistical-code
+                      xs={12}
+                    >
+                      <AcceptedValuesField
+                        okapi={okapi}
+                        component={TextField}
+                        name={getSubfieldName(8, 0, index)}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCode`} />}
+                        optionLabel="name"
+                        optionValue="name"
+                        wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
+                        wrapperSourcesFn="statisticalCodeTypeName"
+                        wrapperSources={[{
+                          wrapperSourceLink: '/statistical-codes?limit=2000&query=cql.allRecords=1 sortby name',
+                          wrapperSourcePath: 'statisticalCodes',
+                        }, {
+                          wrapperSourceLink: '/statistical-code-types?limit=1000&query=cql.allRecords=1 sortby name',
+                          wrapperSourcePath: 'statisticalCodeTypes',
+                        }]}
+                        optionTemplate="**statisticalCodeTypeName**: **code** - **name**"
+                        setAcceptedValues={setReferenceTables}
+                        acceptedValuesPath={getRepeatableAcceptedValuesPath(8, 0, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -205,5 +212,6 @@ AdministrativeData.propTypes = {
   statisticalCodes: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   initialFields: PropTypes.object.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
   okapi: okapiShape.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/DescriptiveData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/DescriptiveData.js
@@ -42,6 +42,7 @@ export const DescriptiveData = ({
   publicationRange,
   initialFields,
   setReferenceTables,
+  getRepeatableFieldAction,
   okapi,
 }) => {
   return (
@@ -175,37 +176,44 @@ export const DescriptiveData = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(21)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.natureOfContentTermsIds.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(21)}
+            repeatableFieldIndex={21}
+            hasRepeatableFields={!!natureOfContentTermIds.length}
+            onRepeatableActionChange={setReferenceTables}
           >
-            <RepeatableField
-              fields={natureOfContentTermIds}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.natureOfContentTermsIds.addLabel`} />}
-              onAdd={() => onAdd(natureOfContentTermIds, 'natureOfContentTermIds', 21, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, natureOfContentTermIds, 21, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col
-                    data-test-nature-of-content-term
-                    xs={12}
-                  >
-                    <AcceptedValuesField
-                      okapi={okapi}
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.natureOfContentTermId`} />}
-                      name={getSubfieldName(21, 0, index)}
-                      optionValue="name"
-                      optionLabel="name"
-                      wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
-                      wrapperSources={[{
-                        wrapperSourceLink: '/nature-of-content-terms?limit=1000&query=cql.allRecords=1 sortby name',
-                        wrapperSourcePath: 'natureOfContentTerms',
-                      }]}
-                      setAcceptedValues={setReferenceTables}
-                      acceptedValuesPath={getRepeatableAcceptedValuesPath(21, 0, index)}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {isDisabled => (
+              <RepeatableField
+                fields={natureOfContentTermIds}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.natureOfContentTermsIds.addLabel`} />}
+                onAdd={() => onAdd(natureOfContentTermIds, 'natureOfContentTermIds', 21, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, natureOfContentTermIds, 21, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col
+                      data-test-nature-of-content-term
+                      xs={12}
+                    >
+                      <AcceptedValuesField
+                        okapi={okapi}
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.natureOfContentTermId`} />}
+                        name={getSubfieldName(21, 0, index)}
+                        optionValue="name"
+                        optionLabel="name"
+                        wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
+                        wrapperSources={[{
+                          wrapperSourceLink: '/nature-of-content-terms?limit=1000&query=cql.allRecords=1 sortby name',
+                          wrapperSourcePath: 'natureOfContentTerms',
+                        }]}
+                        setAcceptedValues={setReferenceTables}
+                        acceptedValuesPath={getRepeatableAcceptedValuesPath(21, 0, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -332,5 +340,6 @@ DescriptiveData.propTypes = {
   publicationRange: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   initialFields: PropTypes.object.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
   okapi: okapiShape.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/InstanceRelationship.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/InstanceRelationship.js
@@ -34,6 +34,7 @@ export const InstanceRelationship = ({
   childInstances,
   initialFields,
   setReferenceTables,
+  getRepeatableFieldAction,
   okapi,
 }) => {
   return (
@@ -49,44 +50,51 @@ export const InstanceRelationship = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(30)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.field.parentInstances.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(30)}
+            repeatableFieldIndex={30}
+            hasRepeatableFields={!!parentInstances.length}
+            onRepeatableActionChange={setReferenceTables}
           >
-            <RepeatableField
-              fields={parentInstances}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.field.parentInstances.addLabel`} />}
-              onAdd={() => onAdd(parentInstances, 'parentInstances', 30, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, parentInstances, 30, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col xs={6}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.parentInstances.field.superInstanceId`} />}
-                      name={getSubfieldName(30, 0, index)}
-                    />
-                  </Col>
-                  <Col
-                    data-test-parent-type-of-relation
-                    xs={6}
-                  >
-                    <AcceptedValuesField
-                      okapi={okapi}
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.parentInstances.field.instanceRelationshipTypeId`} />}
-                      name={getSubfieldName(30, 1, index)}
-                      optionValue="name"
-                      optionLabel="name"
-                      wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
-                      wrapperSources={[{
-                        wrapperSourceLink: '/instance-relationship-types?limit=1000&query=cql.allRecords=1 sortby name',
-                        wrapperSourcePath: 'instanceRelationshipTypes',
-                      }]}
-                      setAcceptedValues={setReferenceTables}
-                      acceptedValuesPath={getRepeatableAcceptedValuesPath(30, 1, index)}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {isDisabled => (
+              <RepeatableField
+                fields={parentInstances}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.field.parentInstances.addLabel`} />}
+                onAdd={() => onAdd(parentInstances, 'parentInstances', 30, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, parentInstances, 30, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col xs={6}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.parentInstances.field.superInstanceId`} />}
+                        name={getSubfieldName(30, 0, index)}
+                      />
+                    </Col>
+                    <Col
+                      data-test-parent-type-of-relation
+                      xs={6}
+                    >
+                      <AcceptedValuesField
+                        okapi={okapi}
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.parentInstances.field.instanceRelationshipTypeId`} />}
+                        name={getSubfieldName(30, 1, index)}
+                        optionValue="name"
+                        optionLabel="name"
+                        wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
+                        wrapperSources={[{
+                          wrapperSourceLink: '/instance-relationship-types?limit=1000&query=cql.allRecords=1 sortby name',
+                          wrapperSourcePath: 'instanceRelationshipTypes',
+                        }]}
+                        setAcceptedValues={setReferenceTables}
+                        acceptedValuesPath={getRepeatableAcceptedValuesPath(30, 1, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -98,44 +106,51 @@ export const InstanceRelationship = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(31)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.field.childInstances.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(31)}
+            repeatableFieldIndex={31}
+            hasRepeatableFields={!!childInstances.length}
+            onRepeatableActionChange={setReferenceTables}
           >
-            <RepeatableField
-              fields={childInstances}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.field.childInstances.addLabel`} />}
-              onAdd={() => onAdd(childInstances, 'childInstances', 31, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, childInstances, 31, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col xs={6}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.childInstances.field.subInstanceId`} />}
-                      name={getSubfieldName(31, 0, index)}
-                    />
-                  </Col>
-                  <Col
-                    data-test-child-type-of-relation
-                    xs={6}
-                  >
-                    <AcceptedValuesField
-                      okapi={okapi}
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.childInstances.field.instanceRelationshipTypeId`} />}
-                      name={getSubfieldName(31, 1, index)}
-                      optionValue="name"
-                      optionLabel="name"
-                      wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
-                      wrapperSources={[{
-                        wrapperSourceLink: '/instance-relationship-types?limit=1000&query=cql.allRecords=1 sortby name',
-                        wrapperSourcePath: 'instanceRelationshipTypes',
-                      }]}
-                      setAcceptedValues={setReferenceTables}
-                      acceptedValuesPath={getRepeatableAcceptedValuesPath(31, 1, index)}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {isDisabled => (
+              <RepeatableField
+                fields={childInstances}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.field.childInstances.addLabel`} />}
+                onAdd={() => onAdd(childInstances, 'childInstances', 31, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, childInstances, 31, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col xs={6}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.childInstances.field.subInstanceId`} />}
+                        name={getSubfieldName(31, 0, index)}
+                      />
+                    </Col>
+                    <Col
+                      data-test-child-type-of-relation
+                      xs={6}
+                    >
+                      <AcceptedValuesField
+                        okapi={okapi}
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.childInstances.field.instanceRelationshipTypeId`} />}
+                        name={getSubfieldName(31, 1, index)}
+                        optionValue="name"
+                        optionLabel="name"
+                        wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
+                        wrapperSources={[{
+                          wrapperSourceLink: '/instance-relationship-types?limit=1000&query=cql.allRecords=1 sortby name',
+                          wrapperSourcePath: 'instanceRelationshipTypes',
+                        }]}
+                        setAcceptedValues={setReferenceTables}
+                        acceptedValuesPath={getRepeatableAcceptedValuesPath(31, 1, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -148,5 +163,6 @@ InstanceRelationship.propTypes = {
   childInstances: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   initialFields: PropTypes.object.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
   okapi: okapiShape.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/TitleData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/TitleData.js
@@ -27,6 +27,8 @@ export const TitleData = ({
   seriesStatements,
   precedingTitles,
   succeedingTitles,
+  setReferenceTables,
+  getRepeatableFieldAction,
 }) => {
   return (
     <Accordion
@@ -135,51 +137,57 @@ export const TitleData = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(13)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.field.precedingTitles.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(13)}
+            repeatableFieldIndex={13}
+            hasRepeatableFields={!!precedingTitles.length}
+            onRepeatableActionChange={setReferenceTables}
             disabled
           >
-            <RepeatableField
-              fields={precedingTitles}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.field.precedingTitles.addLabel`} />}
-              canAdd={false}
-              canRemove={false}
-              onAdd={noop}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col xs={3}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.precedingTitles.field.precedingTitlesTitle`} />}
-                      name={getSubfieldName(13, 0, index)}
-                      disabled
-                    />
-                  </Col>
-                  <Col xs={3}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.precedingTitles.field.precedingTitlesHrid`} />}
-                      name={getSubfieldName(13, 1, index)}
-                      disabled
-                    />
-                  </Col>
-                  <Col xs={3}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.precedingTitles.field.precedingTitlesIsbn`} />}
-                      name={getSubfieldName(13, 2, index)}
-                      disabled
-                    />
-                  </Col>
-                  <Col xs={3}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.precedingTitles.field.precedingTitlesIssn`} />}
-                      name={getSubfieldName(13, 3, index)}
-                      disabled
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {() => (
+              <RepeatableField
+                fields={precedingTitles}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.field.precedingTitles.addLabel`} />}
+                canAdd={false}
+                canRemove={false}
+                onAdd={noop}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col xs={3}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.precedingTitles.field.precedingTitlesTitle`} />}
+                        name={getSubfieldName(13, 0, index)}
+                        disabled
+                      />
+                    </Col>
+                    <Col xs={3}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.precedingTitles.field.precedingTitlesHrid`} />}
+                        name={getSubfieldName(13, 1, index)}
+                        disabled
+                      />
+                    </Col>
+                    <Col xs={3}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.precedingTitles.field.precedingTitlesIsbn`} />}
+                        name={getSubfieldName(13, 2, index)}
+                        disabled
+                      />
+                    </Col>
+                    <Col xs={3}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.precedingTitles.field.precedingTitlesIssn`} />}
+                        name={getSubfieldName(13, 3, index)}
+                        disabled
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -191,51 +199,57 @@ export const TitleData = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(14)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.field.succeedingTitles.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(14)}
+            repeatableFieldIndex={14}
+            hasRepeatableFields={!!succeedingTitles.length}
+            onRepeatableActionChange={setReferenceTables}
             disabled
           >
-            <RepeatableField
-              fields={succeedingTitles}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.field.succeedingTitles.addLabel`} />}
-              canAdd={false}
-              canRemove={false}
-              onAdd={noop}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col xs={3}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.succeedingTitles.field.succeedingTitlesTitle`} />}
-                      name={getSubfieldName(14, 0, index)}
-                      disabled
-                    />
-                  </Col>
-                  <Col xs={3}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.succeedingTitles.field.succeedingTitlesHrid`} />}
-                      name={getSubfieldName(14, 1, index)}
-                      disabled
-                    />
-                  </Col>
-                  <Col xs={3}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.succeedingTitles.field.succeedingTitlesIsbn`} />}
-                      name={getSubfieldName(14, 2, index)}
-                      disabled
-                    />
-                  </Col>
-                  <Col xs={3}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.succeedingTitles.field.succeedingTitlesIssn`} />}
-                      name={getSubfieldName(14, 3, index)}
-                      disabled
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {() => (
+              <RepeatableField
+                fields={succeedingTitles}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.field.succeedingTitles.addLabel`} />}
+                canAdd={false}
+                canRemove={false}
+                onAdd={noop}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col xs={3}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.succeedingTitles.field.succeedingTitlesTitle`} />}
+                        name={getSubfieldName(14, 0, index)}
+                        disabled
+                      />
+                    </Col>
+                    <Col xs={3}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.succeedingTitles.field.succeedingTitlesHrid`} />}
+                        name={getSubfieldName(14, 1, index)}
+                        disabled
+                      />
+                    </Col>
+                    <Col xs={3}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.succeedingTitles.field.succeedingTitlesIsbn`} />}
+                        name={getSubfieldName(14, 2, index)}
+                        disabled
+                      />
+                    </Col>
+                    <Col xs={3}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.succeedingTitles.field.succeedingTitlesIssn`} />}
+                        name={getSubfieldName(14, 3, index)}
+                        disabled
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -248,4 +262,6 @@ TitleData.propTypes = {
   seriesStatements: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   precedingTitles: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   succeedingTitles: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
+  setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/AdministrativeData.js
@@ -37,6 +37,7 @@ export const AdministrativeData = ({
   statisticalCodeIds,
   initialFields,
   setReferenceTables,
+  getRepeatableFieldAction,
   okapi,
 }) => {
   return (
@@ -48,11 +49,10 @@ export const AdministrativeData = ({
         <Col
           data-test-suppress-from-discovery
           xs={4}
-        >
-          <BooleanActionField
-            label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.discoverySuppress`} />}
-            name={getBoolFieldName(0)}
-          />
+        ><BooleanActionField
+          label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.discoverySuppress`} />}
+          name={getBoolFieldName(0)}
+        />
         </Col>
       </Row>
       <Row left="xs">
@@ -107,24 +107,31 @@ export const AdministrativeData = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(5)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.administrativeData.field.formerId.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(5)}
+            repeatableFieldIndex={5}
+            hasRepeatableFields={!!formerIds.length}
+            onRepeatableActionChange={setReferenceTables}
           >
-            <RepeatableField
-              fields={formerIds}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.administrativeData.field.formerId.addLabel`} />}
-              onAdd={() => onAdd(formerIds, 'formerIds', 5, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, formerIds, 5, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col xs={12}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.administrativeData.field.formerId`} />}
-                      name={getSubfieldName(5, 0, index)}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {isDisabled => (
+              <RepeatableField
+                fields={formerIds}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.administrativeData.field.formerId.addLabel`} />}
+                onAdd={() => onAdd(formerIds, 'formerIds', 5, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, formerIds, 5, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col xs={12}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.administrativeData.field.formerId`} />}
+                        name={getSubfieldName(5, 0, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -137,42 +144,49 @@ export const AdministrativeData = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(6)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(6)}
+            repeatableFieldIndex={6}
+            hasRepeatableFields={!!statisticalCodeIds.length}
+            onRepeatableActionChange={setReferenceTables}
           >
-            <RepeatableField
-              fields={statisticalCodeIds}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.addLabel`} />}
-              onAdd={() => onAdd(statisticalCodeIds, 'statisticalCodeIds', 6, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, statisticalCodeIds, 6, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col
-                    data-test-statistical-code
-                    xs={12}
-                  >
-                    <AcceptedValuesField
-                      component={TextField}
-                      name={getSubfieldName(6, 0, index)}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCode`} />}
-                      optionValue="name"
-                      optionLabel="name"
-                      wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
-                      wrapperSourcesFn="statisticalCodeTypeName"
-                      wrapperSources={[{
-                        wrapperSourceLink: '/statistical-codes?limit=2000&query=cql.allRecords=1 sortby name',
-                        wrapperSourcePath: 'statisticalCodes',
-                      }, {
-                        wrapperSourceLink: '/statistical-code-types?limit=1000&query=cql.allRecords=1 sortby name',
-                        wrapperSourcePath: 'statisticalCodeTypes',
-                      }]}
-                      optionTemplate="**statisticalCodeTypeName**: **code** - **name**"
-                      setAcceptedValues={setReferenceTables}
-                      acceptedValuesPath={getRepeatableAcceptedValuesPath(6, 0, index)}
-                      okapi={okapi}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {isDisabled => (
+              <RepeatableField
+                fields={statisticalCodeIds}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.addLabel`} />}
+                onAdd={() => onAdd(statisticalCodeIds, 'statisticalCodeIds', 6, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, statisticalCodeIds, 6, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col
+                      data-test-statistical-code
+                      xs={12}
+                    >
+                      <AcceptedValuesField
+                        component={TextField}
+                        name={getSubfieldName(6, 0, index)}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCode`} />}
+                        optionValue="name"
+                        optionLabel="name"
+                        wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
+                        wrapperSourcesFn="statisticalCodeTypeName"
+                        wrapperSources={[{
+                          wrapperSourceLink: '/statistical-codes?limit=2000&query=cql.allRecords=1 sortby name',
+                          wrapperSourcePath: 'statisticalCodes',
+                        }, {
+                          wrapperSourceLink: '/statistical-code-types?limit=1000&query=cql.allRecords=1 sortby name',
+                          wrapperSourcePath: 'statisticalCodeTypes',
+                        }]}
+                        optionTemplate="**statisticalCodeTypeName**: **code** - **name**"
+                        setAcceptedValues={setReferenceTables}
+                        acceptedValuesPath={getRepeatableAcceptedValuesPath(6, 0, index)}
+                        okapi={okapi}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -185,5 +199,6 @@ AdministrativeData.propTypes = {
   statisticalCodeIds: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   initialFields: PropTypes.object.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
   okapi: okapiShape.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/ElectronicAccess.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/ElectronicAccess.js
@@ -33,6 +33,7 @@ export const ElectronicAccess = ({
   electronicAccess,
   initialFields,
   setReferenceTables,
+  getRepeatableFieldAction,
   okapi,
 }) => {
   return (
@@ -46,65 +47,74 @@ export const ElectronicAccess = ({
           id="section-electronic-access"
           xs={12}
         >
-          <RepeatableActionsField wrapperFieldName={getRepeatableFieldName(31)}>
-            <RepeatableField
-              fields={electronicAccess}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.EAccess.addLabel`} />}
-              onAdd={() => onAdd(electronicAccess, 'electronicAccess', 31, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, electronicAccess, 31, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col
-                    data-test-electronic-relationship
-                    xs={4}
-                  >
-                    <AcceptedValuesField
-                      component={TextField}
-                      name={getSubfieldName(31, 0, index)}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.relationship`} />}
-                      optionValue="name"
-                      optionLabel="name"
-                      wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
-                      wrapperSources={[{
-                        wrapperSourceLink: '/electronic-access-relationships?limit=1000&query=cql.allRecords=1 sortby name',
-                        wrapperSourcePath: 'electronicAccessRelationships',
-                      }]}
-                      setAcceptedValues={setReferenceTables}
-                      acceptedValuesPath={getRepeatableAcceptedValuesPath(31, 0, index)}
-                      okapi={okapi}
-                    />
-                  </Col>
-                  <Col xs={2}>
-                    <Field
-                      component={TextField}
-                      name={getSubfieldName(31, 1, index)}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.uri`} />}
-                    />
-                  </Col>
-                  <Col xs={2}>
-                    <Field
-                      component={TextField}
-                      name={getSubfieldName(31, 2, index)}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.linkText`} />}
-                    />
-                  </Col>
-                  <Col xs={2}>
-                    <Field
-                      component={TextField}
-                      name={getSubfieldName(31, 3, index)}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.materialsSpecified`} />}
-                    />
-                  </Col>
-                  <Col xs={2}>
-                    <Field
-                      component={TextField}
-                      name={getSubfieldName(31, 4, index)}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.urlPublicNote`} />}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+          <RepeatableActionsField
+            wrapperFieldName={getRepeatableFieldName(31)}
+            repeatableFieldAction={getRepeatableFieldAction(31)}
+            repeatableFieldIndex={31}
+            hasRepeatableFields={!!electronicAccess.length}
+            onRepeatableActionChange={setReferenceTables}
+          >
+            {isDisabled => (
+              <RepeatableField
+                fields={electronicAccess}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.EAccess.addLabel`} />}
+                onAdd={() => onAdd(electronicAccess, 'electronicAccess', 31, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, electronicAccess, 31, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col
+                      data-test-electronic-relationship
+                      xs={4}
+                    >
+                      <AcceptedValuesField
+                        component={TextField}
+                        name={getSubfieldName(31, 0, index)}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.relationship`} />}
+                        optionValue="name"
+                        optionLabel="name"
+                        wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
+                        wrapperSources={[{
+                          wrapperSourceLink: '/electronic-access-relationships?limit=1000&query=cql.allRecords=1 sortby name',
+                          wrapperSourcePath: 'electronicAccessRelationships',
+                        }]}
+                        setAcceptedValues={setReferenceTables}
+                        acceptedValuesPath={getRepeatableAcceptedValuesPath(31, 0, index)}
+                        okapi={okapi}
+                      />
+                    </Col>
+                    <Col xs={2}>
+                      <Field
+                        component={TextField}
+                        name={getSubfieldName(31, 1, index)}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.uri`} />}
+                      />
+                    </Col>
+                    <Col xs={2}>
+                      <Field
+                        component={TextField}
+                        name={getSubfieldName(31, 2, index)}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.linkText`} />}
+                      />
+                    </Col>
+                    <Col xs={2}>
+                      <Field
+                        component={TextField}
+                        name={getSubfieldName(31, 3, index)}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.materialsSpecified`} />}
+                      />
+                    </Col>
+                    <Col xs={2}>
+                      <Field
+                        component={TextField}
+                        name={getSubfieldName(31, 4, index)}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.urlPublicNote`} />}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -116,5 +126,6 @@ ElectronicAccess.propTypes = {
   electronicAccess: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   initialFields: PropTypes.object.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
   okapi: okapiShape.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/EnumerationData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/EnumerationData.js
@@ -27,6 +27,7 @@ export const EnumerationData = ({
   yearCaption,
   initialFields,
   setReferenceTables,
+  getRepeatableFieldAction,
 }) => {
   return (
     <Accordion
@@ -76,24 +77,31 @@ export const EnumerationData = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(18)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.enumerationData.field.yearCaption`} />}
+            repeatableFieldAction={getRepeatableFieldAction(18)}
+            repeatableFieldIndex={18}
+            hasRepeatableFields={!!yearCaption.length}
+            onRepeatableActionChange={setReferenceTables}
           >
-            <RepeatableField
-              fields={yearCaption}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.enumerationData.field.yearCaption.addLabel`} />}
-              onAdd={() => onAdd(yearCaption, 'yearCaption', 18, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, yearCaption, 18, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col xs={12}>
-                    <Field
-                      component={TextField}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.enumerationData.field.yearCaption`} />}
-                      name={getSubfieldName(18, 0, index)}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {isDisabled => (
+              <RepeatableField
+                fields={yearCaption}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.enumerationData.field.yearCaption.addLabel`} />}
+                onAdd={() => onAdd(yearCaption, 'yearCaption', 18, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, yearCaption, 18, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col xs={12}>
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.enumerationData.field.yearCaption`} />}
+                        name={getSubfieldName(18, 0, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -105,4 +113,5 @@ EnumerationData.propTypes = {
   yearCaption: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   initialFields: PropTypes.object.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/ItemNotes.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/ItemNotes.js
@@ -35,6 +35,7 @@ export const ItemNotes = ({
   notes,
   initialFields,
   setReferenceTables,
+  getRepeatableFieldAction,
   okapi,
 }) => {
   return (
@@ -48,53 +49,62 @@ export const ItemNotes = ({
           id="section-item-notes"
           xs={12}
         >
-          <RepeatableActionsField wrapperFieldName={getRepeatableFieldName(24)}>
-            <RepeatableField
-              fields={notes}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.field.notes.addLabel`} />}
-              onAdd={() => onAdd(notes, 'notes', 24, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, notes, 24, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col
-                    data-test-item-note
-                    xs={4}
-                  >
-                    <AcceptedValuesField
-                      component={TextField}
-                      name={getSubfieldName(24, 0, index)}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.noteType`} />}
-                      optionValue="name"
-                      optionLabel="name"
-                      wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
-                      wrapperSources={[{
-                        wrapperSourceLink: '/item-note-types?limit=1000&query=cql.allRecords=1 sortby name',
-                        wrapperSourcePath: 'itemNoteTypes',
-                      }]}
-                      setAcceptedValues={setReferenceTables}
-                      acceptedValuesPath={getRepeatableAcceptedValuesPath(24, 0, index)}
-                      okapi={okapi}
-                    />
-                  </Col>
-                  <Col xs={4}>
-                    <Field
-                      component={TextField}
-                      name={getSubfieldName(24, 1, index)}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.note`} />}
-                    />
-                  </Col>
-                  <Col
-                    data-test-staff-only
-                    xs={4}
-                  >
-                    <BooleanActionField
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.staffOnly`} />}
-                      name={getBoolSubfieldName(24, 2, index)}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+          <RepeatableActionsField
+            wrapperFieldName={getRepeatableFieldName(24)}
+            repeatableFieldAction={getRepeatableFieldAction(24)}
+            repeatableFieldIndex={24}
+            hasRepeatableFields={!!notes.length}
+            onRepeatableActionChange={setReferenceTables}
+          >
+            {isDisabled => (
+              <RepeatableField
+                fields={notes}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.field.notes.addLabel`} />}
+                onAdd={() => onAdd(notes, 'notes', 24, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, notes, 24, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col
+                      data-test-item-note
+                      xs={4}
+                    >
+                      <AcceptedValuesField
+                        component={TextField}
+                        name={getSubfieldName(24, 0, index)}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.noteType`} />}
+                        optionValue="name"
+                        optionLabel="name"
+                        wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
+                        wrapperSources={[{
+                          wrapperSourceLink: '/item-note-types?limit=1000&query=cql.allRecords=1 sortby name',
+                          wrapperSourcePath: 'itemNoteTypes',
+                        }]}
+                        setAcceptedValues={setReferenceTables}
+                        acceptedValuesPath={getRepeatableAcceptedValuesPath(24, 0, index)}
+                        okapi={okapi}
+                      />
+                    </Col>
+                    <Col xs={4}>
+                      <Field
+                        component={TextField}
+                        name={getSubfieldName(24, 1, index)}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.note`} />}
+                      />
+                    </Col>
+                    <Col
+                      data-test-staff-only
+                      xs={4}
+                    >
+                      <BooleanActionField
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.staffOnly`} />}
+                        name={getBoolSubfieldName(24, 2, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -106,5 +116,6 @@ ItemNotes.propTypes = {
   notes: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   initialFields: PropTypes.object.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
   okapi: okapiShape.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/LoanAndAvailability.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/LoanAndAvailability.js
@@ -38,6 +38,7 @@ export const LoanAndAvailability = ({
   circulationNotes,
   initialFields,
   setReferenceTables,
+  getRepeatableFieldAction,
   okapi,
 }) => {
   const createOptionList = arr => arr.map(option => ({
@@ -123,48 +124,55 @@ export const LoanAndAvailability = ({
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(28)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.field.circulationNotes.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(28)}
+            repeatableFieldIndex={28}
+            hasRepeatableFields={!!circulationNotes.length}
+            onRepeatableActionChange={setReferenceTables}
           >
-            <RepeatableField
-              fields={circulationNotes}
-              addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.field.circulationNotes.addLabel`} />}
-              onAdd={() => onAdd(circulationNotes, 'circulationNotes', 28, initialFields, setReferenceTables, 'order')}
-              onRemove={index => onRemove(index, circulationNotes, 28, setReferenceTables, 'order')}
-              renderField={(field, index) => (
-                <Row left="xs">
-                  <Col
-                    data-test-circulation-note
-                    xs={4}
-                  >
-                    <AcceptedValuesField
-                      component={TextField}
-                      name={getSubfieldName(28, 0, index)}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.noteType`} />}
-                      optionValue="value"
-                      optionLabel="label"
-                      wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
-                      acceptedValuesList={circulationNotesList}
-                      okapi={okapi}
-                    />
-                  </Col>
-                  <Col xs={4}>
-                    <Field
-                      component={TextField}
-                      name={getSubfieldName(28, 1, index)}
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.note`} />}
-                    />
-                  </Col>
-                  <Col
-                    data-test-staff-only
-                    xs={4}
-                  >
-                    <BooleanActionField
-                      label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.staffOnly`} />}
-                      name={getBoolSubfieldName(28, 2, index)}
-                    />
-                  </Col>
-                </Row>
-              )}
-            />
+            {isDisabled => (
+              <RepeatableField
+                fields={circulationNotes}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.field.circulationNotes.addLabel`} />}
+                onAdd={() => onAdd(circulationNotes, 'circulationNotes', 28, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, circulationNotes, 28, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col
+                      data-test-circulation-note
+                      xs={4}
+                    >
+                      <AcceptedValuesField
+                        component={TextField}
+                        name={getSubfieldName(28, 0, index)}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.noteType`} />}
+                        optionValue="value"
+                        optionLabel="label"
+                        wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
+                        acceptedValuesList={circulationNotesList}
+                        okapi={okapi}
+                      />
+                    </Col>
+                    <Col xs={4}>
+                      <Field
+                        component={TextField}
+                        name={getSubfieldName(28, 1, index)}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.note`} />}
+                      />
+                    </Col>
+                    <Col
+                      data-test-staff-only
+                      xs={4}
+                    >
+                      <BooleanActionField
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.staffOnly`} />}
+                        name={getBoolSubfieldName(28, 2, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
           </RepeatableActionsField>
         </Col>
       </Row>
@@ -176,5 +184,6 @@ LoanAndAvailability.propTypes = {
   circulationNotes: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   initialFields: PropTypes.object.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
   okapi: okapiShape.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/MappingHoldingsDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/MappingHoldingsDetails.js
@@ -23,6 +23,7 @@ export const MappingHoldingsDetails = ({
   initialFields,
   referenceTables,
   setReferenceTables,
+  getRepeatableFieldAction,
   okapi,
 }) => {
   const formerIds = referenceTables?.formerIds || [];
@@ -39,6 +40,7 @@ export const MappingHoldingsDetails = ({
       <AdministrativeData
         formerIds={formerIds}
         statisticalCodeIds={statisticalCodeIds}
+        getRepeatableFieldAction={getRepeatableFieldAction}
         initialFields={initialFields}
         setReferenceTables={setReferenceTables}
         okapi={okapi}
@@ -49,6 +51,7 @@ export const MappingHoldingsDetails = ({
       />
       <HoldingsDetails
         holdingStatements={holdingStatements}
+        getRepeatableFieldAction={getRepeatableFieldAction}
         holdingStatementsForSupplements={holdingStatementsForSupplements}
         holdingStatementsForIndexes={holdingStatementsForIndexes}
         initialFields={initialFields}
@@ -57,12 +60,14 @@ export const MappingHoldingsDetails = ({
       />
       <HoldingsNotes
         notes={notes}
+        getRepeatableFieldAction={getRepeatableFieldAction}
         initialFields={initialFields}
         setReferenceTables={setReferenceTables}
         okapi={okapi}
       />
       <ElectronicAccess
         electronicAccess={electronicAccess}
+        getRepeatableFieldAction={getRepeatableFieldAction}
         initialFields={initialFields}
         setReferenceTables={setReferenceTables}
         okapi={okapi}
@@ -70,6 +75,7 @@ export const MappingHoldingsDetails = ({
       <Acquisition />
       <ReceivingHistory
         receivingHistory={receivingHistory}
+        getRepeatableFieldAction={getRepeatableFieldAction}
         initialFields={initialFields}
         setReferenceTables={setReferenceTables}
       />
@@ -81,5 +87,6 @@ MappingHoldingsDetails.propTypes = {
   initialFields: mappingHoldingsInitialFieldsShape.isRequired,
   referenceTables: mappingHoldingsRefTablesShape.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
   okapi: okapiShape.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/MappingInstanceDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/MappingInstanceDetails.js
@@ -27,6 +27,7 @@ export const MappingInstanceDetails = ({
   initialFields,
   referenceTables,
   setReferenceTables,
+  getRepeatableFieldAction,
   okapi,
 }) => {
   const statisticalCodes = referenceTables?.statisticalCodeIds || [];
@@ -55,12 +56,15 @@ export const MappingInstanceDetails = ({
     <AccordionSet>
       <AdministrativeData
         statisticalCodes={statisticalCodes}
+        getRepeatableFieldAction={getRepeatableFieldAction}
         initialFields={initialFields}
         setReferenceTables={setReferenceTables}
         okapi={okapi}
       />
       <TitleData
         alternativeTitles={alternativeTitles}
+        getRepeatableFieldAction={getRepeatableFieldAction}
+        setReferenceTables={setReferenceTables}
         seriesStatements={seriesStatements}
         precedingTitles={precedingTitles}
         succeedingTitles={succeedingTitles}
@@ -73,6 +77,7 @@ export const MappingInstanceDetails = ({
       />
       <DescriptiveData
         publications={publications}
+        getRepeatableFieldAction={getRepeatableFieldAction}
         editions={editions}
         physicalDescriptions={physicalDescriptions}
         natureOfContentTermIds={natureOfContentTermIds}
@@ -99,6 +104,7 @@ export const MappingInstanceDetails = ({
       />
       <InstanceRelationship
         parentInstances={parentInstances}
+        getRepeatableFieldAction={getRepeatableFieldAction}
         childInstances={childInstances}
         initialFields={initialFields}
         setReferenceTables={setReferenceTables}
@@ -113,5 +119,6 @@ MappingInstanceDetails.propTypes = {
   initialFields: mappingInstanceInitialFieldsShape.isRequired,
   referenceTables: mappingInstanceRefTablesShape.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
   okapi: okapiShape.isRequired,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/MappingItemDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/MappingItemDetails.js
@@ -24,6 +24,7 @@ export const MappingItemDetails = ({
   initialFields,
   referenceTables,
   setReferenceTables,
+  getRepeatableFieldAction,
   okapi,
 }) => {
   const formerIds = referenceTables?.formerIds || [];
@@ -38,6 +39,7 @@ export const MappingItemDetails = ({
       <AdministrativeData
         formerIds={formerIds}
         statisticalCodeIds={statisticalCodeIds}
+        getRepeatableFieldAction={getRepeatableFieldAction}
         initialFields={initialFields}
         setReferenceTables={setReferenceTables}
         okapi={okapi}
@@ -48,6 +50,7 @@ export const MappingItemDetails = ({
       />
       <EnumerationData
         yearCaption={yearCaption}
+        getRepeatableFieldAction={getRepeatableFieldAction}
         initialFields={initialFields}
         setReferenceTables={setReferenceTables}
       />
@@ -57,12 +60,14 @@ export const MappingItemDetails = ({
       />
       <ItemNotes
         notes={notes}
+        getRepeatableFieldAction={getRepeatableFieldAction}
         initialFields={initialFields}
         setReferenceTables={setReferenceTables}
         okapi={okapi}
       />
       <LoanAndAvailability
         circulationNotes={circulationNotes}
+        getRepeatableFieldAction={getRepeatableFieldAction}
         initialFields={initialFields}
         setReferenceTables={setReferenceTables}
         okapi={okapi}
@@ -73,6 +78,7 @@ export const MappingItemDetails = ({
       />
       <ElectronicAccess
         electronicAccess={electronicAccess}
+        getRepeatableFieldAction={getRepeatableFieldAction}
         initialFields={initialFields}
         setReferenceTables={setReferenceTables}
         okapi={okapi}
@@ -85,5 +91,6 @@ MappingItemDetails.propTypes = {
   initialFields: mappingItemInitialFieldsShape.isRequired,
   referenceTables: mappingItemRefTablesShape.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
+  getRepeatableFieldAction: PropTypes.func.isRequired,
   okapi: okapiShape.isRequired,
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -259,12 +259,24 @@ export const FORMS_SETTINGS = {
   },
   [ENTITY_KEYS.MAPPING_PROFILES]: {
     DECORATORS: {
-      REPEATABLE_ACTIONS: {
-        EXTEND_EXISTING: 'ui-data-import.settings.mappingProfiles.map.wrapper.repeatableActions.extendExisting',
-        DELETE_EXISTING: 'ui-data-import.settings.mappingProfiles.map.wrapper.repeatableActions.deleteExisting',
-        EXCHANGE_EXISTING: 'ui-data-import.settings.mappingProfiles.map.wrapper.repeatableActions.exchangeExisting',
-        DELETE_INCOMING: 'ui-data-import.settings.mappingProfiles.map.wrapper.repeatableActions.deleteIncoming',
-      },
+      REPEATABLE_ACTIONS: [
+        {
+          label: 'ui-data-import.settings.mappingProfiles.map.wrapper.repeatableActions.extendExisting',
+          value: REPEATABLE_ACTIONS.EXTEND_EXISTING,
+        },
+        {
+          label: 'ui-data-import.settings.mappingProfiles.map.wrapper.repeatableActions.deleteExisting',
+          value: REPEATABLE_ACTIONS.DELETE_EXISTING,
+        },
+        {
+          label: 'ui-data-import.settings.mappingProfiles.map.wrapper.repeatableActions.exchangeExisting',
+          value: REPEATABLE_ACTIONS.EXCHANGE_EXISTING,
+        },
+        {
+          label: 'ui-data-import.settings.mappingProfiles.map.wrapper.repeatableActions.deleteIncoming',
+          value: REPEATABLE_ACTIONS.DELETE_INCOMING,
+        },
+      ],
       DATE_PICKER: {
         TODAY: {
           value: 'TODAY',

--- a/src/utils/formValidators.js
+++ b/src/utils/formValidators.js
@@ -164,6 +164,16 @@ export const validateMARCWithDate = value => {
   return <FormattedMessage id="ui-data-import.validation.syntaxError" />;
 };
 
+export const validateRepeatableActionsField = (value, hasFields) => {
+  const val = value && value.trim ? value.trim() : value;
+
+  if (!isEmpty(val) && !hasFields) {
+    return <FormattedMessage id="ui-data-import.validation.chooseAtLeastOneValue" />;
+  }
+
+  return null;
+};
+
 export const validateAcceptedValues = (acceptedValues, valueKey) => value => {
   const pattern = /"[^"]+"/g;
 

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -211,6 +211,7 @@
   "validation.syntaxError": "Please correct the syntax to continue",
   "validation.cannotBeUpdated": "This field cannot be updated",
   "validation.chooseDifferentField": "Please choose a different field",
+  "validation.chooseAtLeastOneValue": "One or more values must be added before the profile can be saved.",
   "error.fileExtension.extension.invalid": "File extension {name} is not a valid format",
   "error.fileExtension.duplication.invalid": "File extension {name} already exists",
   "error.fileExtensions.action": "The file extension \"{name}\" was not {action}",


### PR DESCRIPTION
## Purpose
To provide additional validation for repeatable fields on Instance, Holdings, and Item field mapping screens

## Approach

- handle changes of `RepeatableActionsField`
- Add `validateRepeatableActions` for validate chosen option and presence of repeatable field 
- Add `getRepeatableFieldAction ` method for getting chosen repeatable action

## Ticket
[UIDATIMP-508](https://issues.folio.org/browse/UIDATIMP-508)

## Screenshot
![HYPpRF7aKt](https://user-images.githubusercontent.com/40805351/87783938-15f31080-c83e-11ea-96b7-36c3fae77e46.gif)
