### PR TITLE
UIDATIMP-567 Inventory field mapping: Instance, Holding, Item: add RE…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Reuse `<EndOfItem>` component from `stripes-data-transfer-components` repository (UIDATIMP-571)
 * Fix field mapping for Item record check in/check out note (UIDATIMP-554)
 * Field mappings: Repeatable field dropdown Validation (UIDATIMP-508)
+* Inventory field mapping: Instance, Holding, Item: add REMOVE option (UIDATIMP-567)
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)

--- a/src/components/AcceptedValuesField/AcceptedValuesField.js
+++ b/src/components/AcceptedValuesField/AcceptedValuesField.js
@@ -35,6 +35,7 @@ export const AcceptedValuesField = ({
   acceptedValuesPath,
   dataAttributes,
   optionTemplate,
+  isRemoveValueAllowed,
 }) => {
   const [listOptions, setListOptions] = useState(acceptedValuesList);
 
@@ -92,6 +93,13 @@ export const AcceptedValuesField = ({
     [listOptions],
   );
 
+  const validateAcceptedValueField = useCallback(
+    value => {
+      return validateMARCWithElse(value, isRemoveValueAllowed);
+    },
+    [isRemoveValueAllowed],
+  );
+
   return (
     <Field
       id={id}
@@ -103,7 +111,7 @@ export const AcceptedValuesField = ({
       optionLabel={optionLabel}
       wrappedComponent={component}
       wrapperLabel={wrapperLabel}
-      validate={[validateMARCWithElse, memoizedValidation]}
+      validate={[validateAcceptedValueField, memoizedValidation]}
       {...dataAttributes}
     />
   );
@@ -128,6 +136,10 @@ AcceptedValuesField.propTypes = {
   setAcceptedValues: PropTypes.func,
   acceptedValuesPath: PropTypes.string,
   dataAttributes: PropTypes.arrayOf(PropTypes.object),
+  isRemoveValueAllowed: PropTypes.bool,
 };
 
-AcceptedValuesField.defaultProps = { acceptedValuesList: [] };
+AcceptedValuesField.defaultProps = {
+  acceptedValuesList: [],
+  isRemoveValueAllowed: false,
+};

--- a/src/components/AcceptedValuesField/AcceptedValuesField.js
+++ b/src/components/AcceptedValuesField/AcceptedValuesField.js
@@ -94,9 +94,7 @@ export const AcceptedValuesField = ({
   );
 
   const validateAcceptedValueField = useCallback(
-    value => {
-      return validateMARCWithElse(value, isRemoveValueAllowed);
-    },
+    value => validateMARCWithElse(value, isRemoveValueAllowed),
     [isRemoveValueAllowed],
   );
 

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/Acquisition.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/Acquisition.js
@@ -10,6 +10,7 @@ import {
 } from '@folio/stripes/components';
 
 import { getFieldName } from '../../utils';
+import { validateTextFieldRemoveValue } from '../../../../../utils';
 import { TRANSLATION_ID_PREFIX } from '../../constants';
 
 export const Acquisition = () => {
@@ -27,6 +28,7 @@ export const Acquisition = () => {
             component={TextField}
             name={getFieldName(23)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.acquisitionMethod`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
         <Col
@@ -37,6 +39,7 @@ export const Acquisition = () => {
             component={TextField}
             name={getFieldName(24)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.orderFormat`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
         <Col
@@ -47,6 +50,7 @@ export const Acquisition = () => {
             component={TextField}
             name={getFieldName(25)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.receiptStatus`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/AdministrativeData.js
@@ -123,6 +123,7 @@ export const AdministrativeData = ({
               wrapperSourceLink: '/holdings-types?limit=1000&query=cql.allRecords=1 sortby name',
               wrapperSourcePath: 'holdingsTypes',
             }]}
+            isRemoveValueAllowed
             setAcceptedValues={setReferenceTables}
             acceptedValuesPath={getAcceptedValuesPath(3)}
             okapi={okapi}

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsDetails.js
@@ -26,6 +26,7 @@ import {
 } from '../../utils';
 import { TRANSLATION_ID_PREFIX } from '../../constants';
 import {
+  validateTextFieldRemoveValue,
   mappingProfileSubfieldShape,
   okapiShape,
 } from '../../../../../utils';
@@ -53,6 +54,7 @@ export const HoldingsDetails = ({
             component={TextField}
             name={getFieldName(14)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.details.field.numberOfItems`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
       </Row>
@@ -204,6 +206,7 @@ export const HoldingsDetails = ({
               wrapperSourceLink: '/ill-policies?limit=1000&query=cql.allRecords=1 sortby name',
               wrapperSourcePath: 'illPolicies',
             }]}
+            isRemoveValueAllowed
             setAcceptedValues={setReferenceTables}
             acceptedValuesPath={getAcceptedValuesPath(18)}
             okapi={okapi}
@@ -217,6 +220,7 @@ export const HoldingsDetails = ({
             component={TextField}
             name={getFieldName(19)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.field.digitizationPolicy`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
         <Col
@@ -227,6 +231,7 @@ export const HoldingsDetails = ({
             component={TextField}
             name={getFieldName(20)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.field.retentionPolicy`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/Location.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/Location.js
@@ -9,7 +9,10 @@ import {
   Col,
   TextField,
 } from '@folio/stripes/components';
-import { okapiShape } from '../../../../../utils';
+import {
+  validateTextFieldRemoveValue,
+  okapiShape,
+} from '../../../../../utils';
 
 import { AcceptedValuesField } from '../../../../../components';
 
@@ -65,6 +68,7 @@ export const Location = ({
               wrapperSourceLink: '/locations?limit=1000&query=cql.allRecords=1 sortby name',
               wrapperSourcePath: 'locations',
             }]}
+            isRemoveValueAllowed
             setAcceptedValues={setReferenceTables}
             acceptedValuesPath={getAcceptedValuesPath(6)}
             optionTemplate="**name** (**code**)"
@@ -81,6 +85,7 @@ export const Location = ({
             component={TextField}
             name={getFieldName(7)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.location.field.shelvingOrder`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
         <Col
@@ -91,6 +96,7 @@ export const Location = ({
             component={TextField}
             name={getFieldName(8)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.location.field.shelvingTitle`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
       </Row>
@@ -103,6 +109,7 @@ export const Location = ({
             component={TextField}
             name={getFieldName(9)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.copyNumber`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
       </Row>
@@ -122,6 +129,7 @@ export const Location = ({
               wrapperSourceLink: '/call-number-types?limit=1000&query=cql.allRecords=1 sortby name',
               wrapperSourcePath: 'callNumberTypes',
             }]}
+            isRemoveValueAllowed
             setAcceptedValues={setReferenceTables}
             acceptedValuesPath={getAcceptedValuesPath(10)}
             okapi={okapi}
@@ -135,6 +143,7 @@ export const Location = ({
             component={TextField}
             name={getFieldName(11)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.callNumberPrefix`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
         <Col
@@ -145,6 +154,7 @@ export const Location = ({
             component={TextField}
             name={getFieldName(12)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.callNumber`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
         <Col
@@ -155,6 +165,7 @@ export const Location = ({
             component={TextField}
             name={getFieldName(13)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.callNumberSuffix`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/AdministrativeData.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'redux-form';
@@ -42,6 +42,13 @@ export const AdministrativeData = ({
   getRepeatableFieldAction,
   okapi,
 }) => {
+  const validateDatepickerValueField = useCallback(
+    value => {
+      return validateMARCWithDate(value, false);
+    },
+    [],
+  );
+
   return (
     <Accordion
       id="administrative-data"
@@ -111,7 +118,7 @@ export const AdministrativeData = ({
             name={getFieldName(5)}
             wrappedComponent={TextField}
             wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
-            validate={[validateMARCWithDate]}
+            validate={[validateDatepickerValueField]}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/AdministrativeData.js
@@ -42,10 +42,8 @@ export const AdministrativeData = ({
   getRepeatableFieldAction,
   okapi,
 }) => {
-  const validateDatepickerValueField = useCallback(
-    value => {
-      return validateMARCWithDate(value, false);
-    },
+  const validateDatepickerFieldValue = useCallback(
+    value => validateMARCWithDate(value, false),
     [],
   );
 
@@ -118,7 +116,7 @@ export const AdministrativeData = ({
             name={getFieldName(5)}
             wrappedComponent={TextField}
             wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
-            validate={[validateDatepickerValueField]}
+            validate={[validateDatepickerFieldValue]}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/AdministrativeData.js
@@ -28,6 +28,7 @@ import {
 } from '../../utils';
 import { TRANSLATION_ID_PREFIX } from '../../constants';
 import {
+  validateTextFieldRemoveValue,
   mappingProfileSubfieldShape,
   okapiShape,
 } from '../../../../../utils';
@@ -75,6 +76,7 @@ export const AdministrativeData = ({
             component={TextField}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.administrativeData.field.barcode`} />}
             name={getFieldName(2)}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
         <Col
@@ -85,6 +87,7 @@ export const AdministrativeData = ({
             component={TextField}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.administrativeData.field.accessionNumber`} />}
             name={getFieldName(3)}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
         <Col
@@ -95,6 +98,7 @@ export const AdministrativeData = ({
             component={TextField}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.administrativeData.field.itemIdentifier`} />}
             name={getFieldName(4)}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/Condition.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/Condition.js
@@ -21,6 +21,7 @@ import {
 } from '../../utils';
 import { TRANSLATION_ID_PREFIX } from '../../constants';
 import {
+  validateTextFieldRemoveValue,
   validateMARCWithDate,
   okapiShape,
 } from '../../../../../utils';
@@ -43,6 +44,7 @@ export const Condition = ({
             component={TextField}
             name={getFieldName(19)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.itemCondition.field.numberOfMissingPieces`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
         <Col
@@ -53,6 +55,7 @@ export const Condition = ({
             component={TextField}
             name={getFieldName(20)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.itemCondition.field.missingPieces`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
         <Col
@@ -85,6 +88,7 @@ export const Condition = ({
               wrapperSourceLink: '/item-damaged-statuses?limit=1000&query=cql.allRecords=1 sortby name',
               wrapperSourcePath: 'itemDamageStatuses',
             }]}
+            isRemoveValueAllowed
             setAcceptedValues={setReferenceTables}
             acceptedValuesPath={getAcceptedValuesPath(22)}
             okapi={okapi}

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/EnumerationData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/EnumerationData.js
@@ -21,7 +21,10 @@ import {
   onRemove,
 } from '../../utils';
 import { TRANSLATION_ID_PREFIX } from '../../constants';
-import { mappingProfileSubfieldShape } from '../../../../../utils';
+import {
+  validateTextFieldRemoveValue,
+  mappingProfileSubfieldShape,
+} from '../../../../../utils';
 
 export const EnumerationData = ({
   yearCaption,
@@ -43,6 +46,7 @@ export const EnumerationData = ({
             component={TextField}
             name={getFieldName(15)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.enumeration`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
         <Col
@@ -53,6 +57,7 @@ export const EnumerationData = ({
             component={TextField}
             name={getFieldName(16)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.chronology`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
       </Row>
@@ -65,6 +70,7 @@ export const EnumerationData = ({
             component={TextField}
             name={getFieldName(17)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.enumerationData.field.volume`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/ItemData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/ItemData.js
@@ -17,7 +17,10 @@ import {
   getFieldName,
 } from '../../utils';
 import { TRANSLATION_ID_PREFIX } from '../../constants';
-import { okapiShape } from '../../../../../utils';
+import {
+  validateTextFieldRemoveValue,
+  okapiShape,
+} from '../../../../../utils';
 
 export const ItemData = ({
   setReferenceTables,
@@ -59,6 +62,7 @@ export const ItemData = ({
             component={TextField}
             name={getFieldName(8)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.copyNumber`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
       </Row>
@@ -78,6 +82,7 @@ export const ItemData = ({
               wrapperSourceLink: '/call-number-types?limit=1000&query=cql.allRecords=1 sortby name',
               wrapperSourcePath: 'callNumberTypes',
             }]}
+            isRemoveValueAllowed
             setAcceptedValues={setReferenceTables}
             acceptedValuesPath={getAcceptedValuesPath(9)}
             okapi={okapi}
@@ -91,6 +96,7 @@ export const ItemData = ({
             component={TextField}
             name={getFieldName(10)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.callNumberPrefix`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
         <Col
@@ -101,6 +107,7 @@ export const ItemData = ({
             component={TextField}
             name={getFieldName(11)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.callNumber`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
         <Col
@@ -111,6 +118,7 @@ export const ItemData = ({
             component={TextField}
             name={getFieldName(12)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.callNumberSuffix`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
       </Row>
@@ -123,6 +131,7 @@ export const ItemData = ({
             component={TextField}
             name={getFieldName(13)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.itemData.field.numberOfPieces`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
         <Col
@@ -133,6 +142,7 @@ export const ItemData = ({
             component={TextField}
             name={getFieldName(14)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.itemData.field.descriptionOfPieces`} />}
+            validate={[validateTextFieldRemoveValue]}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/LoanAndAvailability.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/LoanAndAvailability.js
@@ -92,6 +92,7 @@ export const LoanAndAvailability = ({
               wrapperSourceLink: '/loan-types?limit=1000&query=cql.allRecords=1 sortby name',
               wrapperSourcePath: 'loantypes',
             }]}
+            isRemoveValueAllowed
             setAcceptedValues={setReferenceTables}
             acceptedValuesPath={getAcceptedValuesPath(26)}
             okapi={okapi}

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/Location.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/Location.js
@@ -43,6 +43,7 @@ export const Location = ({
               wrapperSourceLink: '/locations?limit=1000&query=cql.allRecords=1 sortby name',
               wrapperSourcePath: 'locations',
             }]}
+            isRemoveValueAllowed
             optionTemplate="**name** (**code**)"
             setAcceptedValues={setReferenceTables}
             acceptedValuesPath={getAcceptedValuesPath(29)}
@@ -64,6 +65,7 @@ export const Location = ({
               wrapperSourceLink: '/locations?limit=1000&query=cql.allRecords=1 sortby name',
               wrapperSourcePath: 'locations',
             }]}
+            isRemoveValueAllowed
             optionTemplate="**name** (**code**)"
             setAcceptedValues={setReferenceTables}
             acceptedValuesPath={getAcceptedValuesPath(30)}

--- a/src/utils/formValidators.js
+++ b/src/utils/formValidators.js
@@ -140,11 +140,7 @@ export const validateMARCWithElse = (value, isRemoveValueAllowed) => {
  * @returns {null|*}
  */
 export const validateTextFieldRemoveValue = value => {
-  if (isEmpty(value)) {
-    return null;
-  }
-
-  if (value.includes(REMOVE_OPTION_VALUE) && value !== REMOVE_OPTION_VALUE) {
+  if (!isEmpty(value) && value.includes(REMOVE_OPTION_VALUE) && value !== REMOVE_OPTION_VALUE) {
     return <FormattedMessage id="ui-data-import.validation.syntaxError" />;
   }
 


### PR DESCRIPTION
## Purpose
To add a field mapping option that allows a field to be emptied (data removed) by the field mapping profile.

## Approach
1. Add isRemoveValueAllowed property for AcceptedValuesField component
2. Add validateTextFieldRemoveValue validation rule for appropriate text fields
3. Update validateMARCWithDate and validateMARCWithElse validation rules

## Tickets
[UIDATIMP-567](https://issues.folio.org/browse/UIDATIMP-567)

## Before
![image](https://user-images.githubusercontent.com/63101175/88183802-99e03a80-cc3a-11ea-85f8-9bbb0f674496.png)
![image](https://user-images.githubusercontent.com/63101175/88184595-94372480-cc3b-11ea-9d1e-cc2114558f8a.png)

## After
![image](https://user-images.githubusercontent.com/63101175/88187803-a87d2080-cc3f-11ea-8e7f-63a6a138b709.png)
![image](https://user-images.githubusercontent.com/63101175/88188282-4bce3580-cc40-11ea-8029-d67d89085f61.png)
