### PR TITLE
UIDATIMP-535: Field Mapping Profile details: Have view details screen cover the entire screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Field mappings: Repeatable field dropdown Validation (UIDATIMP-508)
 * Inventory field mapping: Instance, Holding, Item: add REMOVE option (UIDATIMP-567)
 * Field Mapping Profile details: MARC Bib from MARC Bib 10 - View details screen (UIDATIMP-494)
+* Field Mapping Profile details: Have view details screen cover the entire screen (UIDATIMP-535)
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)

--- a/src/components/ListView/ListView.js
+++ b/src/components/ListView/ListView.js
@@ -58,6 +58,7 @@ export class ListView extends Component {
     columnWidths: PropTypes.object.isRequired,
     initialValues: PropTypes.object.isRequired,
     renderHeaders: PropTypes.func.isRequired,
+    isFullScreen: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -205,6 +206,7 @@ export class ListView extends Component {
       RecordForm,
       renderHeaders,
       actionMenuItems,
+      isFullScreen,
     } = this.props;
     const { showRestoreModal } = this.state;
 
@@ -255,6 +257,7 @@ export class ListView extends Component {
               editRecordInitialValuesAreLoaded={selectedRecord.hasLoaded}
               showSingleResult={showSingleResult}
               onSubmitSearch={deselectAll}
+              isFullScreen={isFullScreen}
               rowUpdater={rowUpdater}
               {...props}
             />

--- a/src/components/SearchAndSort/SearchAndSort.js
+++ b/src/components/SearchAndSort/SearchAndSort.js
@@ -138,6 +138,7 @@ export class SearchAndSort extends Component {
     finishedResourceName: PropTypes.string,
     fullWidthContainer: PropTypes.instanceOf(Element),
     rowUpdater: PropTypes.func,
+    isFullScreen: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -462,8 +463,30 @@ export class SearchAndSort extends Component {
       fullWidthContainer,
       handleEditSuccess,
       ViewRecordComponent,
+      isFullScreen,
       location: { pathname },
     } = this.props;
+
+    const commonProps = {
+      key: pathname,
+      stripes,
+      editContainer: fullWidthContainer,
+      parentResources,
+      connectedSource: source,
+      parentMutato: parentMutator,
+      onClose: this.collapseRecordDetails,
+      onCloseEdit: this.onCloseEditRecord,
+      onEdit: this.editRecord,
+      onDelete: this.deleteRecord,
+      onEditSuccess: handleEditSuccess,
+    };
+
+    const narrowViewScreenProps = {
+      ...commonProps,
+      paneWidth: '44%',
+    };
+
+    const viewRecordComponentProps = isFullScreen ? commonProps : narrowViewScreenProps;
 
     return (
       <Route
@@ -471,18 +494,7 @@ export class SearchAndSort extends Component {
         render={
           props => (
             <ViewRecordComponent
-              key={pathname}
-              stripes={stripes}
-              paneWidth="44%"
-              editContainer={fullWidthContainer}
-              parentResources={parentResources}
-              connectedSource={source}
-              parentMutator={parentMutator}
-              onClose={this.collapseRecordDetails}
-              onCloseEdit={this.onCloseEditRecord}
-              onEdit={this.editRecord}
-              onDelete={this.deleteRecord}
-              onEditSuccess={handleEditSuccess}
+              {...viewRecordComponentProps}
               {...props}
               {...detailProps}
             />
@@ -725,28 +737,33 @@ export class SearchAndSort extends Component {
   };
 
   render() {
+    const { isFullScreen } = this.props;
+
     const source = this.getSource();
 
     return (
-      <Paneset>
-        <SRStatus ref={this.SRStatusRef} />
-        <Pane
-          id="pane-results"
-          defaultWidth="fill"
-          noOverflow
-          padContent={false}
-          renderHeader={this.renderPaneHeader}
-        >
-          <div className={css.paneBody}>
-            {this.renderSearch(source)}
-            <div className={css.searchResults}>
-              {this.renderSearchResults(source)}
+      <>
+        <Paneset>
+          <SRStatus ref={this.SRStatusRef} />
+          <Pane
+            id="pane-results"
+            defaultWidth="fill"
+            noOverflow
+            padContent={false}
+            renderHeader={this.renderPaneHeader}
+          >
+            <div className={css.paneBody}>
+              {this.renderSearch(source)}
+              <div className={css.searchResults}>
+                {this.renderSearchResults(source)}
+              </div>
             </div>
-          </div>
-        </Pane>
-        {this.renderDetailsPane(source)}
-        {this.renderCreateRecordLayer(source)}
-      </Paneset>
+          </Pane>
+          {!isFullScreen && this.renderDetailsPane(source)}
+          {this.renderCreateRecordLayer(source)}
+        </Paneset>
+        {isFullScreen && this.renderDetailsPane(source)}
+      </>
     );
   }
 }

--- a/src/components/Spinner/Spinner.js
+++ b/src/components/Spinner/Spinner.js
@@ -9,17 +9,12 @@ import {
 import { Preloader } from '../Preloader';
 
 export const Spinner = memo(({
-  entity: {
-    props: {
-      onClose,
-      paneId,
-    },
-  },
+  entity: { props: { onClose } },
+  ...props
 }) => {
   const header = renderProps => (
     <PaneHeader
       {...renderProps}
-      id={paneId}
       dismissible
       onClose={onClose}
     />
@@ -30,6 +25,7 @@ export const Spinner = memo(({
       defaultWidth="fill"
       fluidContentWidth
       renderHeader={header}
+      {...props}
     >
       <Preloader />
     </Pane>

--- a/src/settings/ActionProfiles/ViewActionProfile.js
+++ b/src/settings/ActionProfiles/ViewActionProfile.js
@@ -78,13 +78,11 @@ export class ViewActionProfile extends Component {
     tagsEnabled: PropTypes.bool,
     onClose: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
-    paneId: PropTypes.string,
     ENTITY_KEY: PropTypes.string, // eslint-disable-line
     actionMenuItems: PropTypes.arrayOf(PropTypes.string), // eslint-disable-line
   };
 
   static defaultProps = {
-    paneId: 'pane-action-profile-details',
     ENTITY_KEY: ENTITY_KEYS.ACTION_PROFILES,
     actionMenuItems: [
       'edit',
@@ -169,10 +167,7 @@ export class ViewActionProfile extends Component {
   };
 
   render() {
-    const {
-      tagsEnabled,
-      paneId,
-    } = this.props;
+    const { tagsEnabled } = this.props;
     const { showDeleteConfirmation } = this.state;
     const {
       hasLoaded,
@@ -180,7 +175,12 @@ export class ViewActionProfile extends Component {
     } = this.actionProfileData;
 
     if (!actionProfile || !hasLoaded) {
-      return <Spinner entity={this} />;
+      return (
+        <Spinner
+          data-test-mapping-profile-details
+          entity={this}
+        />
+      );
     }
 
     // ActionProfiles sample data does not contain user Ids because of back-end limitations
@@ -201,7 +201,7 @@ export class ViewActionProfile extends Component {
 
     return (
       <Pane
-        id={paneId}
+        data-test-pane-action-profile-details
         defaultWidth="fill"
         fluidContentWidth
         renderHeader={this.renderPaneHeader}

--- a/src/settings/FileExtensions/ViewFileExtension.js
+++ b/src/settings/FileExtensions/ViewFileExtension.js
@@ -65,13 +65,11 @@ export class ViewFileExtension extends Component {
     }).isRequired,
     onClose: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
-    paneId: PropTypes.string, // eslint-disable-line
     ENTITY_KEY: PropTypes.string, // eslint-disable-line
     actionMenuItems: PropTypes.arrayOf(PropTypes.string), // eslint-disable-line
   };
 
   static defaultProps = {
-    paneId: 'pane-file-extension-details',
     ENTITY_KEY: ENTITY_KEYS.FILE_EXTENSIONS,
     actionMenuItems: [
       'edit',
@@ -149,7 +147,7 @@ export class ViewFileExtension extends Component {
 
     return (
       <Pane
-        id="pane-file-extension-details"
+        data-test-pane-file-extension-details
         defaultWidth="fill"
         fluidContentWidth
         renderHeader={this.renderPaneHeader}
@@ -238,7 +236,12 @@ export class ViewFileExtension extends Component {
     } = this.fileExtensionData;
 
     if (!record || !hasLoaded) {
-      return <Spinner entity={this} />;
+      return (
+        <Spinner
+          data-test-pane-file-extension-details
+          entity={this}
+        />
+      );
     }
 
     return this.renderFileExtension(record);

--- a/src/settings/JobProfiles/ViewJobProfile.js
+++ b/src/settings/JobProfiles/ViewJobProfile.js
@@ -160,13 +160,11 @@ export class ViewJobProfile extends Component {
     tagsEnabled: PropTypes.bool,
     onClose: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
-    paneId: PropTypes.string, // eslint-disable-line
     ENTITY_KEY: PropTypes.string, // eslint-disable-line
     actionMenuItems: PropTypes.arrayOf(PropTypes.string), // eslint-disable-line
   };
 
   static defaultProps = {
-    paneId: 'pane-job-profile-details',
     ENTITY_KEY: ENTITY_KEYS.JOB_PROFILES,
     actionMenuItems: [
       'edit',
@@ -362,7 +360,12 @@ export class ViewJobProfile extends Component {
     } = this.jobsUsingThisProfileData;
 
     if (!record || !hasLoaded) {
-      return <Spinner entity={this} />;
+      return (
+        <Spinner
+          data-test-pane-job-profile-details
+          entity={this}
+        />
+      );
     }
 
     /** JobProfiles sample data does not contain user Ids because of back-end limitations
@@ -385,7 +388,7 @@ export class ViewJobProfile extends Component {
 
     return (
       <Pane
-        id="pane-job-profile-details"
+        data-test-pane-job-profile-details
         defaultWidth="fill"
         fluidContentWidth
         renderHeader={this.renderPaneHeader}

--- a/src/settings/MappingProfiles/MappingProfiles.js
+++ b/src/settings/MappingProfiles/MappingProfiles.js
@@ -197,6 +197,7 @@ export class MappingProfiles extends Component {
     visibleColumns: PropTypes.arrayOf(PropTypes.string),
     columnWidths: PropTypes.object,
     initialValues: PropTypes.object,
+    isFullScreen: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -220,6 +221,7 @@ export class MappingProfiles extends Component {
       description: '',
       mappingDetails: {},
     },
+    isFullScreen: true,
     RecordView: ViewMappingProfile,
     RecordForm: MappingProfilesForm,
   };

--- a/src/settings/MappingProfiles/ViewMappingProfile.js
+++ b/src/settings/MappingProfiles/ViewMappingProfile.js
@@ -9,7 +9,6 @@ import {
 } from '@folio/stripes/core';
 import {
   Headline,
-  Pane,
   ConfirmationModal,
   PaneHeader,
   AccordionSet,
@@ -26,7 +25,10 @@ import {
   withTags,
   TagsAccordion,
 } from '@folio/stripes/smart-components';
-import { EndOfItem } from '@folio/stripes-data-transfer-components';
+import {
+  EndOfItem,
+  FullScreenView,
+} from '@folio/stripes-data-transfer-components';
 
 import {
   Spinner,
@@ -89,13 +91,11 @@ export class ViewMappingProfile extends Component {
     tagsEnabled: PropTypes.bool,
     onClose: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
-    paneId: PropTypes.string,
     ENTITY_KEY: PropTypes.string, // eslint-disable-line
     actionMenuItems: PropTypes.arrayOf(PropTypes.string), // eslint-disable-line
   };
 
   static defaultProps = {
-    paneId: 'pane-mapping-profile-details',
     ENTITY_KEY: ENTITY_KEYS.MAPPING_PROFILES,
     actionMenuItems: [
       'edit',
@@ -181,10 +181,7 @@ export class ViewMappingProfile extends Component {
   };
 
   render() {
-    const {
-      tagsEnabled,
-      paneId,
-    } = this.props;
+    const { tagsEnabled } = this.props;
     const { showDeleteConfirmation } = this.state;
 
     const {
@@ -193,7 +190,13 @@ export class ViewMappingProfile extends Component {
     } = this.mappingProfileData;
 
     if (!mappingProfile || !hasLoaded) {
-      return <Spinner entity={this} />;
+      return (
+        <Spinner
+          data-test-mapping-profile-details
+          entity={this}
+          style={{ position: 'absolute' }}
+        />
+      );
     }
 
     const {
@@ -219,11 +222,11 @@ export class ViewMappingProfile extends Component {
     };
 
     return (
-      <Pane
-        id={paneId}
-        defaultWidth="fill"
-        fluidContentWidth
+      <FullScreenView
+        data-test-mapping-profile-details
+        contentLabel="Mapping profile details"
         renderHeader={this.renderPaneHeader}
+        centerContent={false}
       >
         <TitleManager record={name} />
         <Headline
@@ -291,11 +294,11 @@ export class ViewMappingProfile extends Component {
                     />
                   </Col>
                   {!isMARCRecord && (
-                    <Col>
-                      <div data-test-expand-all-button>
-                        <ExpandAllButton />
-                      </div>
-                    </Col>
+                  <Col>
+                    <div data-test-expand-all-button>
+                      <ExpandAllButton />
+                    </div>
+                  </Col>
                   )}
                 </Row>
                 {renderDetails[existingRecordType]}
@@ -334,14 +337,14 @@ export class ViewMappingProfile extends Component {
               id="ui-data-import.modal.mappingProfile.delete.header"
               values={{ name }}
             />
-          )}
+            )}
           message={<FormattedMessage id="ui-data-import.modal.mappingProfile.delete.message" />}
           confirmLabel={<FormattedMessage id="ui-data-import.delete" />}
           cancelLabel={<FormattedMessage id="ui-data-import.cancel" />}
           onConfirm={() => this.handleDelete(mappingProfile)}
           onCancel={this.hideDeleteConfirmation}
         />
-      </Pane>
+      </FullScreenView>
     );
   }
 }

--- a/src/settings/MatchProfiles/ViewMatchProfile.js
+++ b/src/settings/MatchProfiles/ViewMatchProfile.js
@@ -81,13 +81,11 @@ export class ViewMatchProfile extends Component {
     tagsEnabled: PropTypes.bool,
     onClose: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
-    paneId: PropTypes.string,
     ENTITY_KEY: PropTypes.string, // eslint-disable-line
     actionMenuItems: PropTypes.arrayOf(PropTypes.string), // eslint-disable-line
   };
 
   static defaultProps = {
-    paneId: 'pane-match-profile-details',
     ENTITY_KEY: ENTITY_KEYS.MATCH_PROFILES,
     actionMenuItems: [
       'edit',
@@ -173,10 +171,7 @@ export class ViewMatchProfile extends Component {
   };
 
   render() {
-    const {
-      tagsEnabled,
-      paneId,
-    } = this.props;
+    const { tagsEnabled } = this.props;
     const { showDeleteConfirmation } = this.state;
 
     const {
@@ -186,7 +181,12 @@ export class ViewMatchProfile extends Component {
     const associations = [...[], ...get(matchProfile, ['parentProfiles'], []), ...get(matchProfile, ['childProfiles'], [])];
 
     if (!matchProfile || !hasLoaded) {
-      return <Spinner entity={this} />;
+      return (
+        <Spinner
+          data-test-pane-match-profile-details
+          entity={this}
+        />
+      );
     }
 
     const tagsEntityLink = `data-import-profiles/matchProfiles/${matchProfile.id}`;
@@ -199,7 +199,7 @@ export class ViewMatchProfile extends Component {
 
     return (
       <Pane
-        id={paneId}
+        data-test-pane-match-profile-details
         renderHeader={this.renderPaneHeader}
         defaultWidth="620px"
         fluidContentWidth

--- a/test/bigtest/interactors/action-profiles/action-profile-details.js
+++ b/test/bigtest/interactors/action-profiles/action-profile-details.js
@@ -25,4 +25,4 @@ import { ActionMenuInteractor } from '../action-menu-interactor';
   callout = new CalloutInteractor();
 }
 
-export const actionProfileDetails = new ActionProfileDetailsInteractor('#pane-action-profile-details');
+export const actionProfileDetails = new ActionProfileDetailsInteractor('[data-test-pane-action-profile-details]');

--- a/test/bigtest/interactors/file-extensions/file-extension-details.js
+++ b/test/bigtest/interactors/file-extensions/file-extension-details.js
@@ -16,4 +16,4 @@ import { ActionMenuInteractor } from '../action-menu-interactor';
   confirmationModal = new ConfirmationModalInteractor('#delete-file-extension-modal');
 }
 
-export const fileExtensionDetails = new FileExtensionDetailsInteractor('#pane-file-extension-details');
+export const fileExtensionDetails = new FileExtensionDetailsInteractor('[data-test-pane-file-extension-details]');

--- a/test/bigtest/interactors/job-profiles/job-profile-details.js
+++ b/test/bigtest/interactors/job-profiles/job-profile-details.js
@@ -27,4 +27,4 @@ import { ActionMenuInteractor } from '../action-menu-interactor';
   hotLink = new Interactor('[class*="profile-tree---"] [data-test-profile-link]');
 }
 
-export const jobProfileDetails = new JobProfileDetailsInteractor('#pane-job-profile-details');
+export const jobProfileDetails = new JobProfileDetailsInteractor('[data-test-pane-job-profile-details]');

--- a/test/bigtest/interactors/mapping-profiles/mapping-profile-details.js
+++ b/test/bigtest/interactors/mapping-profiles/mapping-profile-details.js
@@ -15,7 +15,7 @@ import { ItemDetailsAccordion } from './details/static/item-details-interactor';
 
 @interactor
 class MappingProfileDetailsInteractor {
-  actionMenu = new ActionMenuInteractor('#pane-mapping-profile-details [data-pane-header-actions-dropdown]');
+  actionMenu = new ActionMenuInteractor('[data-test-mapping-profile-details] [data-pane-header-actions-dropdown]');
   headline = scoped('[data-test-headline]');
   description = scoped('[data-test-description]');
   incomingRecordType = scoped('[data-test-incoming-record-type]');
@@ -29,4 +29,4 @@ class MappingProfileDetailsInteractor {
   callout = new CalloutInteractor();
 }
 
-export const mappingProfileDetails = new MappingProfileDetailsInteractor('#pane-mapping-profile-details');
+export const mappingProfileDetails = new MappingProfileDetailsInteractor('[data-test-mapping-profile-details]');

--- a/test/bigtest/interactors/match-profiles/match-profile-details.js
+++ b/test/bigtest/interactors/match-profiles/match-profile-details.js
@@ -26,4 +26,4 @@ import { ActionMenuInteractor } from '../action-menu-interactor';
   callout = new CalloutInteractor();
 }
 
-export const matchProfileDetails = new MatchProfileDetailsInteractor('#pane-match-profile-details');
+export const matchProfileDetails = new MatchProfileDetailsInteractor('[data-test-pane-match-profile-details]');


### PR DESCRIPTION
## Purpose
To provide a full screen view of the field mapping profile View details

## Approach
- Use  `FullScreenView` component from stripes-data-transfer-components
- add detecting `isMappingProfile` to render Mapping profile details in another way
- update styles

## Issue
[UIDATIMP-535](https://issues.folio.org/browse/UIDATIMP-535) 