### PR TITLE
UIDATIMP-525: Update MARC matching UI to differentiate [any] versus [blank] indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Match profile: Add Instance UUID as a match option (UIDATIMP-589)
 * Match profile: Add Holdings UUID as a match option (UIDATIMP-590)
 * Match profile: Add Item UUID as a match option (UIDATIMP-591)
+* UIDATIMP-525: Update MARC matching UI to differentiate [any] versus [blank] indicators
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)

--- a/src/components/MatchCriterion/edit/MARCFieldSection/MARCFieldSection.js
+++ b/src/components/MatchCriterion/edit/MARCFieldSection/MARCFieldSection.js
@@ -1,4 +1,8 @@
-import React from 'react';
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+} from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'redux-form';
@@ -14,8 +18,11 @@ import { Section } from '../../..';
 
 import {
   validateAlphanumericOrAllowedValue,
+  validateRequiredField,
   validateValueLength3,
   validateValueLength1,
+  validateMARCFieldInMatchCriterion,
+  RESTRICTED_MATCHING_MARC_FIELD_VALUE,
 } from '../../../../utils';
 
 import css from '../MatchCriterions.css';
@@ -24,7 +31,53 @@ export const MARCFieldSection = ({
   repeatableIndex,
   recordFieldSectionLabel,
   recordFieldType,
+  field,
+  indicator1,
+  indicator2,
+  subfield,
 }) => {
+  const [fieldValue, setFieldValue] = useState('');
+  const [indicator1Value, setIndicator1Value] = useState('');
+  const [indicator2Value, setIndicator2Value] = useState('');
+  const [subfieldValue, setSubfieldValue] = useState('');
+
+  useEffect(() => {
+    setFieldValue(field);
+  }, [field]);
+  useEffect(() => {
+    setIndicator1Value(indicator1);
+  }, [indicator1]);
+  useEffect(() => {
+    setIndicator2Value(indicator2);
+  }, [indicator2]);
+  useEffect(() => {
+    setSubfieldValue(subfield);
+  }, [subfield]);
+
+  const isRestrictedValue = RESTRICTED_MATCHING_MARC_FIELD_VALUE.some(value => value === fieldValue);
+
+  const validateIndicator = useCallback(
+    value => {
+      if (isRestrictedValue) {
+        return validateMARCFieldInMatchCriterion(indicator1Value, indicator2Value, subfieldValue);
+      }
+
+      return validateAlphanumericOrAllowedValue(value, '*') || validateValueLength1(value);
+    },
+    [isRestrictedValue, indicator1Value, indicator2Value, subfieldValue],
+  );
+
+  const validateSubfield = useCallback(
+    value => {
+      if (isRestrictedValue) {
+        return validateMARCFieldInMatchCriterion(indicator1Value, indicator2Value, subfieldValue);
+      }
+
+      return validateRequiredField(value) || validateAlphanumericOrAllowedValue(value) || validateValueLength1(value);
+    },
+    [isRestrictedValue, indicator1Value, indicator2Value, subfieldValue],
+  );
+
   return (
     <Section
       label={recordFieldSectionLabel}
@@ -39,7 +92,8 @@ export const MARCFieldSection = ({
             component={TextField}
             name={`profile.matchDetails[${repeatableIndex}].${recordFieldType}MatchExpression.fields[0].value`}
             label={<FormattedMessage id={`ui-data-import.match.${recordFieldType}.MARC.field-main`} />}
-            validate={[validateAlphanumericOrAllowedValue, validateValueLength3]}
+            validate={[validateRequiredField, validateAlphanumericOrAllowedValue, validateValueLength3]}
+            onChange={e => setFieldValue(e.target.value)}
           />
         </Col>
         <Col
@@ -51,7 +105,8 @@ export const MARCFieldSection = ({
             component={TextField}
             name={`profile.matchDetails[${repeatableIndex}].${recordFieldType}MatchExpression.fields[1].value`}
             label={<FormattedMessage id={`ui-data-import.match.${recordFieldType}.MARC.field-in1`} />}
-            validate={[validateAlphanumericOrAllowedValue, validateValueLength1]}
+            validate={[validateIndicator]}
+            onChange={e => setIndicator1Value(e.target.value)}
           />
         </Col>
         <Col
@@ -63,7 +118,8 @@ export const MARCFieldSection = ({
             component={TextField}
             name={`profile.matchDetails[${repeatableIndex}].${recordFieldType}MatchExpression.fields[2].value`}
             label={<FormattedMessage id={`ui-data-import.match.${recordFieldType}.MARC.field-in2`} />}
-            validate={[validateAlphanumericOrAllowedValue, validateValueLength1]}
+            validate={[validateIndicator]}
+            onChange={e => setIndicator2Value(e.target.value)}
           />
         </Col>
         <Col
@@ -75,7 +131,8 @@ export const MARCFieldSection = ({
             component={TextField}
             name={`profile.matchDetails[${repeatableIndex}].${recordFieldType}MatchExpression.fields[3].value`}
             label={<FormattedMessage id={`ui-data-import.match.${recordFieldType}.MARC.field-subfield`} />}
-            validate={[validateAlphanumericOrAllowedValue, validateValueLength1]}
+            validate={[validateSubfield]}
+            onChange={e => setSubfieldValue(e.target.value)}
           />
         </Col>
       </Row>
@@ -87,6 +144,16 @@ MARCFieldSection.propTypes = {
   repeatableIndex: PropTypes.number.isRequired,
   recordFieldType: PropTypes.oneOf(['incoming', 'existing']).isRequired,
   recordFieldSectionLabel: PropTypes.node,
+  field: PropTypes.string,
+  indicator1: PropTypes.string,
+  indicator2: PropTypes.string,
+  subfield: PropTypes.string,
 };
 
-MARCFieldSection.defaultProps = { recordFieldSectionLabel: null };
+MARCFieldSection.defaultProps = {
+  recordFieldSectionLabel: null,
+  field: '',
+  indicator1: '',
+  indicator2: '',
+  subfield: '',
+};

--- a/src/components/MatchCriterion/edit/MatchCriterion.js
+++ b/src/components/MatchCriterion/edit/MatchCriterion.js
@@ -62,6 +62,9 @@ export const MatchCriterion = ({
     }
   ));
 
+  const getMARCFieldValue = (typeExpression, fieldName) => typeExpression?.fields
+    .find(field => field.label === fieldName)?.value;
+
   const incomingRecordLbl = (
     <FormattedMessage
       id="ui-data-import.match.incoming.record"
@@ -92,6 +95,10 @@ export const MatchCriterion = ({
       repeatableIndex={repeatableIndex}
       recordFieldSectionLabel={incomingRecordFieldLbl}
       recordFieldType="incoming"
+      field={getMARCFieldValue(incomingMatchExpression, 'field')}
+      indicator1={getMARCFieldValue(incomingMatchExpression, 'indicator1')}
+      indicator2={getMARCFieldValue(incomingMatchExpression, 'indicator2')}
+      subfield={getMARCFieldValue(incomingMatchExpression, 'recordSubfield')}
     />
   );
   const incomingStaticValueSectionElement = (
@@ -122,6 +129,10 @@ export const MatchCriterion = ({
       repeatableIndex={repeatableIndex}
       recordFieldSectionLabel={existingRecordFieldLbl}
       recordFieldType="existing"
+      field={getMARCFieldValue(existingMatchExpression, 'field')}
+      indicator1={getMARCFieldValue(existingMatchExpression, 'indicator1')}
+      indicator2={getMARCFieldValue(existingMatchExpression, 'indicator2')}
+      subfield={getMARCFieldValue(existingMatchExpression, 'recordSubfield')}
     />
   );
   const existingSectionFolioElement = (

--- a/src/components/MatchCriterion/view/MARCFieldSection/MARCFieldSection.js
+++ b/src/components/MatchCriterion/view/MARCFieldSection/MARCFieldSection.js
@@ -19,6 +19,13 @@ export const MARCFieldSection = ({
   recordFieldSectionLabel,
   recordFieldType,
 }) => {
+  const getValue = fieldName => {
+    const value = expressionDetails.fields?.find(field => field.label === fieldName)?.value;
+    const formattedValue = value && value.trim ? value.trim() : value;
+
+    return formattedValue || <NoValue />;
+  };
+
   return (
     <Section
       label={recordFieldSectionLabel}
@@ -31,7 +38,7 @@ export const MARCFieldSection = ({
         >
           <KeyValue
             label={<FormattedMessage id={`ui-data-import.match.${recordFieldType}.MARC.field-main`} />}
-            value={expressionDetails.fields?.find(field => field.label === 'field')?.value || <NoValue />}
+            value={getValue('field')}
           />
         </Col>
         <Col
@@ -40,7 +47,7 @@ export const MARCFieldSection = ({
         >
           <KeyValue
             label={<FormattedMessage id={`ui-data-import.match.${recordFieldType}.MARC.field-in1`} />}
-            value={expressionDetails.fields?.find(field => field.label === 'indicator1')?.value || <NoValue />}
+            value={getValue('indicator1')}
           />
         </Col>
         <Col
@@ -49,7 +56,7 @@ export const MARCFieldSection = ({
         >
           <KeyValue
             label={<FormattedMessage id={`ui-data-import.match.${recordFieldType}.MARC.field-in2`} />}
-            value={expressionDetails.fields?.find(field => field.label === 'indicator2')?.value || <NoValue />}
+            value={getValue('indicator2')}
           />
         </Col>
         <Col
@@ -58,7 +65,7 @@ export const MARCFieldSection = ({
         >
           <KeyValue
             label={<FormattedMessage id={`ui-data-import.match.${recordFieldType}.MARC.field-subfield`} />}
-            value={expressionDetails.fields?.find(field => field.label === 'recordSubfield')?.value || <NoValue />}
+            value={getValue('recordSubfield')}
           />
         </Col>
       </Row>

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -224,6 +224,10 @@ export const STATIC_VALUE_TYPES = {
   DATE_RANGE: 'DATE_RANGE',
 };
 
+export const RESTRICTED_MATCHING_MARC_FIELD_VALUE = [
+  'LDR', '001', '002', '003', '004', '005', '006', '007', '008', '009',
+];
+
 export const FORMS_SETTINGS = {
   [ENTITY_KEYS.MATCH_PROFILES]: {
     MATCHING: {

--- a/src/utils/formValidators.js
+++ b/src/utils/formValidators.js
@@ -277,6 +277,28 @@ export const validateMarcIndicatorField = (field, indicator1, indicator2) => {
 };
 
 /**
+ * Validate MARC Field input value for Match Criterion
+ *
+ * @param {string|*} field
+ * @returns {null|*}
+ *
+ * @example
+ *
+ * validateMarcFieldInMatchCriterion('011')
+ * // => null
+ *
+ * validateMarcFieldInMatchCriterion('002')
+ * // => Translated string (en = 'This field cannot be updated')
+ */
+export const validateMARCFieldInMatchCriterion = (indicator1, indicator2, subfield) => {
+  if (!isEmpty(indicator1) || !isEmpty(indicator2) || !isEmpty(subfield)) {
+    return <FormattedMessage id="ui-data-import.validation.cannotBeUpdated" />;
+  }
+
+  return null;
+};
+
+/**
  * Validate MARC Subfield input value
  *
  * @param {string|*} field

--- a/test/bigtest/tests/match-profiles/new-match-profiles-test.js
+++ b/test/bigtest/tests/match-profiles/new-match-profiles-test.js
@@ -458,6 +458,8 @@ describe('When match profile form', () => {
   describe('is submitted and the response contains', () => {
     describe('error message', () => {
       beforeEach(async function () {
+        await matchProfileForm.matchCriteria.inputMain.fillAndBlur('010');
+        await matchProfileForm.matchCriteria.inputSubfield.fillAndBlur('a');
         await setupFormSubmitErrorScenario(this.server, {
           response: { errors: [{ message: 'matchProfile.duplication.invalid' }] },
           status: 422,
@@ -471,6 +473,8 @@ describe('When match profile form', () => {
 
     describe('network error', () => {
       beforeEach(async function () {
+        await matchProfileForm.matchCriteria.inputMain.fillAndBlur('010');
+        await matchProfileForm.matchCriteria.inputSubfield.fillAndBlur('a');
         await setupFormSubmitErrorScenario(this.server);
       });
 


### PR DESCRIPTION
## Purpose
To update the MARC matching to differentiate wildcard (any) versus [blank] indicators

## Approach
1. Update validation rules for `MARCFieldSection` component
2. Add `validateMARCFieldInMatchCriterion` validation function
3. Update logic for showing empty field in `MARCFieldSection` component

## Ticket
[UIDATIMP-525](https://issues.folio.org/browse/UIDATIMP-525)

## Screenshot
