### PR TITLE
UIDATIMP-560/561/562/626: Update the available Data types and remove Delimited option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 * Reuse `<FullScreenForm>` component from `stripes-data-transfer-components` repository (UIDATIMP-578)
 * Add option for Modify or Update MARC Bib field mapping profile (UIDATIMP-612)
 * Change Shelving order to unmappable on Holdings field mapping (UIDATIMP-611)
+* Update the available options for Field mapping profile Incoming record types (UIDATIMP-560)
+* Update the available Accepted data types for Job profiles (UIDATIMP-561)
+* Update the available Incoming record options for Match profiles (UIDATIMP-562)
+* Update the available Data type options for File extension settings (UIDATIMP-626)
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)

--- a/src/components/ListTemplate/incomingRecordTypes.js
+++ b/src/components/ListTemplate/incomingRecordTypes.js
@@ -9,14 +9,4 @@ export const INCOMING_RECORD_TYPES = {
     captionId: 'ui-data-import.incomingRecordTypes.edifact-invoice',
     iconKey: 'invoices',
   },
-  DELIMITED: {
-    type: 'DELIMITED',
-    captionId: 'ui-data-import.incomingRecordTypes.delimited',
-    iconKey: '',
-  },
-  STATIC_VALUE: {
-    type: 'STATIC_VALUE',
-    captionId: 'ui-data-import.incomingRecordTypes.static',
-    iconKey: '',
-  },
 };

--- a/src/components/ListTemplate/index.js
+++ b/src/components/ListTemplate/index.js
@@ -4,5 +4,6 @@ export * from './listTemplate';
 export * from './searchAndSortTemplate';
 export * from './folioRecordTypes';
 export * from './incomingRecordTypes';
+export * from './matchIncomingRecordTypes';
 export * from './actionTypes';
 export * from './actionProfilesFormFolioRecordTypes';

--- a/src/components/ListTemplate/matchIncomingRecordTypes.js
+++ b/src/components/ListTemplate/matchIncomingRecordTypes.js
@@ -1,0 +1,10 @@
+import { INCOMING_RECORD_TYPES } from './incomingRecordTypes';
+
+export const MATCH_INCOMING_RECORD_TYPES = {
+  ...INCOMING_RECORD_TYPES,
+  STATIC_VALUE: {
+    type: 'STATIC_VALUE',
+    captionId: 'ui-data-import.incomingRecordTypes.static',
+    iconKey: '',
+  },
+};

--- a/src/components/MatchCriterion/edit/MatchCriterion.js
+++ b/src/components/MatchCriterion/edit/MatchCriterion.js
@@ -17,7 +17,7 @@ import {
 
 import {
   Section,
-  INCOMING_RECORD_TYPES,
+  MATCH_INCOMING_RECORD_TYPES,
   FOLIO_RECORD_TYPES,
 } from '../..';
 import {
@@ -170,14 +170,12 @@ export const MatchCriterion = ({
     MARC_HOLDINGS: incomingQualifierSectionElement,
     MARC_AUTHORITY: incomingQualifierSectionElement,
     EDIFACT_INVOICE: incomingQualifierSectionElement,
-    DELIMITED: incomingQualifierSectionElement,
   };
   const incomingRecordQualifierPartSections = {
     MARC_BIBLIOGRAPHIC: incomingQualifierPartSectionElement,
     MARC_HOLDINGS: incomingQualifierPartSectionElement,
     MARC_AUTHORITY: incomingQualifierPartSectionElement,
     EDIFACT_INVOICE: incomingQualifierPartSectionElement,
-    DELIMITED: incomingQualifierPartSectionElement,
   };
   const existingRecordFieldSections = {
     INSTANCE: existingSectionFolioElement,
@@ -263,7 +261,7 @@ MatchCriterion.propTypes = {
     value: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
   })).isRequired,
-  incomingRecordType: PropTypes.oneOf(Object.keys(INCOMING_RECORD_TYPES)),
+  incomingRecordType: PropTypes.oneOf(Object.keys(MATCH_INCOMING_RECORD_TYPES)),
   existingRecordType: PropTypes.oneOf(Object.keys(FOLIO_RECORD_TYPES)),
   staticValueType: PropTypes.oneOf(Object.keys(STATIC_VALUE_TYPES)),
   incomingRecordLabel: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),

--- a/src/components/MatchCriterion/view/ViewMatchCriterion.js
+++ b/src/components/MatchCriterion/view/ViewMatchCriterion.js
@@ -12,7 +12,7 @@ import {
 
 import {
   Section,
-  INCOMING_RECORD_TYPES,
+  MATCH_INCOMING_RECORD_TYPES,
   FOLIO_RECORD_TYPES,
 } from '../..';
 import {
@@ -128,14 +128,12 @@ export const ViewMatchCriterion = ({
     MARC_HOLDINGS: incomingQualifierSectionElement,
     MARC_AUTHORITY: incomingQualifierSectionElement,
     EDIFACT_INVOICE: incomingQualifierSectionElement,
-    DELIMITED: incomingQualifierSectionElement,
   };
   const incomingRecordQualifierPartSections = {
     MARC_BIBLIOGRAPHIC: incomingQualifierPartSectionElement,
     MARC_HOLDINGS: incomingQualifierPartSectionElement,
     MARC_AUTHORITY: incomingQualifierPartSectionElement,
     EDIFACT_INVOICE: incomingQualifierPartSectionElement,
-    DELIMITED: incomingQualifierPartSectionElement,
   };
   const existingRecordFieldSections = {
     INSTANCE: existingSectionFolioElement,
@@ -215,7 +213,7 @@ export const ViewMatchCriterion = ({
 
 ViewMatchCriterion.propTypes = {
   matchDetails: matchDetailsShape.isRequired,
-  incomingRecordType: PropTypes.oneOf(Object.keys(INCOMING_RECORD_TYPES)),
+  incomingRecordType: PropTypes.oneOf(Object.keys(MATCH_INCOMING_RECORD_TYPES)),
   existingRecordType: PropTypes.oneOf(Object.keys(FOLIO_RECORD_TYPES)),
   incomingRecordLabel: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   existingRecordLabel: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),

--- a/src/components/RecordTypesSelect/RecordTypesSelect.js
+++ b/src/components/RecordTypesSelect/RecordTypesSelect.js
@@ -13,7 +13,7 @@ import { InitialRecordSelect } from './components/InitialRecordSelect';
 import { CompareRecordSelect } from './components/CompareRecordSelect';
 import {
   FOLIO_RECORD_TYPES,
-  INCOMING_RECORD_TYPES,
+  MATCH_INCOMING_RECORD_TYPES,
 } from '../ListTemplate';
 import { HTML_LANG_DIRECTIONS } from '../../utils/constants';
 
@@ -51,7 +51,7 @@ export const RecordTypesSelect = memo(({
   }, [existingRecordType]);
 
   useEffect(() => {
-    setIncomingRecord(INCOMING_RECORD_TYPES?.[incomingRecordType]);
+    setIncomingRecord(MATCH_INCOMING_RECORD_TYPES?.[incomingRecordType]);
   }, [incomingRecordType]);
 
   const handleSelect = selectedRecord => {
@@ -100,7 +100,7 @@ RecordTypesSelect.propTypes = {
 RecordTypesSelect.defaultProps = {
   id: 'compare-record-types',
   existingRecordType: '',
-  incomingRecordType: INCOMING_RECORD_TYPES.MARC_BIBLIOGRAPHIC,
+  incomingRecordType: MATCH_INCOMING_RECORD_TYPES.MARC_BIBLIOGRAPHIC,
   onExistingSelect: noop,
   onIncomingSelect: noop,
   isEditable: true,

--- a/src/components/RecordTypesSelect/components/IncomingRecordMenu.js
+++ b/src/components/RecordTypesSelect/components/IncomingRecordMenu.js
@@ -7,7 +7,7 @@ import {
   DropdownMenu,
 } from '@folio/stripes-components';
 
-import { INCOMING_RECORD_TYPES } from '../../ListTemplate/incomingRecordTypes';
+import { MATCH_INCOMING_RECORD_TYPES } from '../../ListTemplate';
 
 export const IncomingRecordMenu = ({
   open,
@@ -25,14 +25,14 @@ export const IncomingRecordMenu = ({
     open={open}
     minWidth="auto"
   >
-    {Object.keys(INCOMING_RECORD_TYPES).map((recordType, i) => (
+    {Object.keys(MATCH_INCOMING_RECORD_TYPES).map((recordType, i) => (
       <Button
         key={i}
         buttonStyle="dropdownItem"
-        onClick={() => onClick(INCOMING_RECORD_TYPES[recordType])}
+        onClick={() => onClick(MATCH_INCOMING_RECORD_TYPES[recordType])}
         {...dataAttributes}
       >
-        <FormattedMessage id={INCOMING_RECORD_TYPES[recordType].captionId} />
+        <FormattedMessage id={MATCH_INCOMING_RECORD_TYPES[recordType].captionId} />
       </Button>
     ))}
   </DropdownMenu>

--- a/src/settings/MatchProfiles/MatchProfiles.js
+++ b/src/settings/MatchProfiles/MatchProfiles.js
@@ -144,7 +144,6 @@ const sectionInitialValues = {
     dataValueType: 'VALUE_FROM_RECORD',
   },
   EDIFACT_INVOICE: {},
-  DELIMITED: {},
   STATIC_VALUE: {
     fields: [],
     staticValueDetails: {

--- a/src/settings/MatchProfiles/MatchProfilesForm.js
+++ b/src/settings/MatchProfiles/MatchProfilesForm.js
@@ -34,7 +34,7 @@ import { FullScreenForm } from '@folio/stripes-data-transfer-components';
 
 import {
   FOLIO_RECORD_TYPES,
-  INCOMING_RECORD_TYPES,
+  MATCH_INCOMING_RECORD_TYPES,
   RecordTypesSelect,
 } from '../../components';
 import { MatchCriterion } from '../../components/MatchCriterion/edit';
@@ -80,7 +80,7 @@ export const MatchProfilesFormComponent = memo(({
   const isEditMode = layer === LAYER_TYPES.EDIT;
   const staticValueTypes = FORMS_SETTINGS[ENTITY_KEYS.MATCH_PROFILES].MATCHING.STATIC_VALUE_TYPES;
 
-  const [incomingRecord, setIncomingRecord] = useState(INCOMING_RECORD_TYPES[incomingRecordType]);
+  const [incomingRecord, setIncomingRecord] = useState(MATCH_INCOMING_RECORD_TYPES[incomingRecordType]);
   const [existingRecord, setExistingRecord] = useState(isEditMode ? existingRecordType : '');
   const [existingRecordFields, setExistingRecordFields] = useState([]);
   const [staticValueType, setStaticValueType] = useState(currentStaticValueType);
@@ -151,7 +151,7 @@ export const MatchProfilesFormComponent = memo(({
       dispatch(change(formName, `profile.matchDetails[${i}].incomingRecordType`, record.type));
     });
 
-    if (record.type === INCOMING_RECORD_TYPES.STATIC_VALUE.type) {
+    if (record.type === MATCH_INCOMING_RECORD_TYPES.STATIC_VALUE.type) {
       setStaticValueType(staticValueTypes[0]);
     } else {
       setStaticValueType(null);

--- a/src/settings/MatchProfiles/ViewMatchProfile.js
+++ b/src/settings/MatchProfiles/ViewMatchProfile.js
@@ -42,7 +42,7 @@ import {
 import { ViewMatchCriterion } from '../../components/MatchCriterion/view';
 import {
   FOLIO_RECORD_TYPES,
-  INCOMING_RECORD_TYPES,
+  MATCH_INCOMING_RECORD_TYPES,
 } from '../../components/ListTemplate';
 
 import sharedCss from '../../shared.css';
@@ -193,8 +193,8 @@ export class ViewMatchProfile extends Component {
     const existingRecordLabel = FOLIO_RECORD_TYPES[matchProfile.existingRecordType]
       ? <FormattedMessage id={FOLIO_RECORD_TYPES[matchProfile.existingRecordType].captionId} />
       : '';
-    const incomingRecordLabel = INCOMING_RECORD_TYPES[matchProfile.incomingRecordType]
-      ? <FormattedMessage id={INCOMING_RECORD_TYPES[matchProfile.incomingRecordType].captionId} />
+    const incomingRecordLabel = MATCH_INCOMING_RECORD_TYPES[matchProfile.incomingRecordType]
+      ? <FormattedMessage id={MATCH_INCOMING_RECORD_TYPES[matchProfile.incomingRecordType].captionId} />
       : '';
 
     return (

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -51,7 +51,6 @@ export const SYSTEM_USER_NAME = 'System';
 
 export const DATA_TYPES = [
   'MARC',
-  'Delimited',
   'EDIFACT',
 ];
 

--- a/test/bigtest/mocks/form-config-samples.js
+++ b/test/bigtest/mocks/form-config-samples.js
@@ -476,7 +476,6 @@ export const formConfigSamples = [
                       MARC_HOLDINGS: 'qualifier',
                       MARC_AUTHORITY: 'qualifier',
                       EDIFACT_INVOICE: 'qualifier',
-                      DELIMITED: 'qualifier',
                     },
                   }, {
                     controlType: 'CommonSection',
@@ -488,7 +487,6 @@ export const formConfigSamples = [
                       MARC_HOLDINGS: 'qualifierPart',
                       MARC_AUTHORITY: 'qualifierPart',
                       EDIFACT_INVOICE: 'qualifierPart',
-                      DELIMITED: 'qualifierPart',
                     },
                   }],
                 }, { // Match Criterion Section
@@ -580,7 +578,6 @@ export const formConfigSamples = [
                       MARC_HOLDINGS: 'qualifier',
                       MARC_AUTHORITY: 'qualifier',
                       EDIFACT_INVOICE: 'qualifier',
-                      DELIMITED: 'qualifier',
                     },
                   }, {
                     controlType: 'CommonSection',
@@ -597,7 +594,6 @@ export const formConfigSamples = [
                       MARC_HOLDINGS: 'qualifierPart',
                       MARC_AUTHORITY: 'qualifierPart',
                       EDIFACT_INVOICE: 'qualifierPart',
-                      DELIMITED: 'qualifierPart',
                     },
                   }],
                 }],

--- a/test/bigtest/network/factories/file-extension.js
+++ b/test/bigtest/network/factories/file-extension.js
@@ -6,7 +6,7 @@ import {
 export default Factory.extend({
   id: () => faker.random.uuid(),
   importBlocked: () => faker.random.boolean(),
-  dataTypes: () => [faker.random.arrayElement(['Delimited', 'MARC'])],
+  dataTypes: () => [faker.random.arrayElement(['EDIFACT', 'MARC'])],
   extension: i => `.marc${i}`,
   metadata: { updatedDate: faker.date.past(0.1, faker.date.past(0.1)).toString() },
   userInfo: {

--- a/test/bigtest/network/factories/match-profile.js
+++ b/test/bigtest/network/factories/match-profile.js
@@ -6,7 +6,7 @@ import {
 import { associatedJobProfiles } from '../../mocks';
 import { fieldsConfig } from '../../../../src/utils/fields-config';
 import {
-  INCOMING_RECORD_TYPES,
+  MATCH_INCOMING_RECORD_TYPES,
   FOLIO_RECORD_TYPES,
 } from '../../../../src/components/ListTemplate';
 import {
@@ -21,11 +21,11 @@ export default Factory.extend({
   description: i => `Description ${i}`,
   tags: { tagList: [faker.random.arrayElement(['tag1', 'tag2', 'tag3'])] },
   entityType: 'INVENTORY_ITEM',
-  incomingRecordType: () => faker.random.arrayElement(Object.keys(INCOMING_RECORD_TYPES)),
+  incomingRecordType: () => faker.random.arrayElement(Object.keys(MATCH_INCOMING_RECORD_TYPES)),
   existingRecordType: () => faker.random.arrayElement(Object.keys(FOLIO_RECORD_TYPES)),
   matchDetails: [
     {
-      incomingRecordType: () => faker.random.arrayElement(Object.keys(INCOMING_RECORD_TYPES)),
+      incomingRecordType: () => faker.random.arrayElement(Object.keys(MATCH_INCOMING_RECORD_TYPES)),
       existingRecordType: () => faker.random.arrayElement(Object.keys(FOLIO_RECORD_TYPES)),
       matchCriterion: () => faker.random.arrayElement(CRITERION_TYPES_OPTIONS.map(type => type.value)),
       existingMatchExpression: {

--- a/test/bigtest/network/scenarios/fetch-file-extensions-success.js
+++ b/test/bigtest/network/scenarios/fetch-file-extensions-success.js
@@ -11,12 +11,12 @@ export default server => {
   });
   server.create('file-extension', {
     extension: '.csv',
-    dataTypes: ['Delimited'],
+    dataTypes: ['EDIFACT'],
     userInfo: { userName: SYSTEM_USER_NAME },
   });
   server.create('file-extension', {
     extension: '.math',
-    dataTypes: ['Delimited', 'EDIFACT'],
+    dataTypes: ['EDIFACT'],
     userInfo: { lastName: 'Doe' },
   });
 

--- a/test/bigtest/network/scenarios/fetch-job-profiles-success.js
+++ b/test/bigtest/network/scenarios/fetch-job-profiles-success.js
@@ -21,7 +21,7 @@ export default server => {
     id: '87e4ad58-d677-43dd-8b04-9795741b2103',
     name: 'DDA discovery records',
     tags: { tagList: [] },
-    dataType: ['Delimited'],
+    dataType: ['EDIFACT'],
     userInfo: { lastName: 'Doe' },
   });
 

--- a/test/bigtest/network/scenarios/load-records.js
+++ b/test/bigtest/network/scenarios/load-records.js
@@ -23,7 +23,7 @@ export default server => {
   server.create('job-profile', {
     name: 'DDA discovery records',
     tags: { tagList: [] },
-    dataType: ['Delimited'],
+    dataType: ['EDIFACT'],
     userInfo: { lastName: 'Doe' },
   });
 

--- a/test/bigtest/tests/file-extensions/new-file-extensions-test.js
+++ b/test/bigtest/tests/file-extensions/new-file-extensions-test.js
@@ -92,7 +92,7 @@ describe('File extension form', () => {
 
   describe('when data types field has value', () => {
     beforeEach(async () => {
-      await fileExtensionForm.dataTypesField.expandAndFilter('Del');
+      await fileExtensionForm.dataTypesField.expandAndFilter('MARC');
       await fileExtensionForm.dataTypesField.clickOption('1');
       await fileExtensionForm.dataTypesField.blur('input');
     });
@@ -136,7 +136,7 @@ describe('File extension form', () => {
   describe('when form is submitted with unblocked import', () => {
     beforeEach(async () => {
       await fileExtensionForm.descriptionField.fillAndBlur('Description');
-      await fileExtensionForm.dataTypesField.expandAndFilter('Del');
+      await fileExtensionForm.dataTypesField.expandAndFilter('MARC');
       await fileExtensionForm.dataTypesField.clickOption('1');
       await fileExtensionForm.extensionField.fillAndBlur('.csv');
       await fileExtensionForm.submitFormButton.click();
@@ -146,7 +146,7 @@ describe('File extension form', () => {
       expect(fileExtensionDetails.description.text).to.equal('Description');
       expect(fileExtensionDetails.headline.text).to.equal('.csv');
       expect(fileExtensionDetails.extension.text).to.equal('.csv');
-      expect(fileExtensionDetails.dataTypes.text).to.equal('Delimited');
+      expect(fileExtensionDetails.dataTypes.text).to.equal('MARC');
       expect(fileExtensionDetails.importBlocked.isPresent).to.be.false;
     });
   });

--- a/test/bigtest/tests/match-profiles/new-match-profiles-test.js
+++ b/test/bigtest/tests/match-profiles/new-match-profiles-test.js
@@ -265,7 +265,7 @@ describe('Match profile form', () => {
           describe('when incoming record is Static value', () => {
             beforeEach(async function () {
               await matchProfileForm.recordTypesSelect.incomingRecordDropdown.clickTrigger();
-              await matchProfileForm.recordTypesSelect.incomingRecordDropdown.menu.items(5).click();
+              await matchProfileForm.recordTypesSelect.incomingRecordDropdown.menu.items(4).click();
             });
 
             it('has correct label', () => {

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -452,7 +452,6 @@
   "actionProfilesForm.recordTypes.marc-auth": "MARC Authority [will affect SRS and MARCcat]",
   "actionProfilesForm.recordTypes.marc-hold": "MARC Holdings [will affect SRS and MARCcat]",
   "incomingRecordTypes.edifact-invoice": "EDIFACT invoice",
-  "incomingRecordTypes.delimited": "Delimited",
   "settings.actionProfiles.title": "Action profiles",
   "settings.actionProfiles.count": "{count, number} action {count, plural, one {profile} other {profiles}}",
   "settings.actionProfiles.new": "New action profile",


### PR DESCRIPTION
## Description
To remove the Delimited option from the Match profile, Mapping profile, Job profile and File extension Incoming data types and Remove Static match options from Field mapping Incoming record types.

## Approach
- Add `matchIncomingRecordTypes` template
- Update all dependencies to `IncomingRecordTypes` template
- Remove `DELIMITED` type from all places
- Update tests

## Tickets:
[UIDATIMP-560](https://issues.folio.org/browse/UIDATIMP-560)
[UIDATIMP-561](https://issues.folio.org/browse/UIDATIMP-561)
[UIDATIMP-562](https://issues.folio.org/browse/UIDATIMP-562)
[UIDATIMP-626](https://issues.folio.org/browse/UIDATIMP-626)
