### PR TITLE
UIDATIMP-555: Update the Field mapping View for repeatable fields options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Reuse `<FullScreenForm>` component from `stripes-data-transfer-components` repository (UIDATIMP-578)
 * Add option for Modify or Update MARC Bib field mapping profile (UIDATIMP-612)
 * Change Shelving order to unmappable on Holdings field mapping (UIDATIMP-611)
+* Update the Field mapping View for repeatable fields options (UIDATIMP-555)
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)

--- a/src/components/RepeatableActionsField/RepeatableActionsField.js
+++ b/src/components/RepeatableActionsField/RepeatableActionsField.js
@@ -16,8 +16,7 @@ import {
 import { WithTranslation } from '..';
 
 import {
-  ENTITY_KEYS,
-  FORMS_SETTINGS,
+  MAPPING_REPEATABLE_FIELD_ACTIONS,
   REPEATABLE_ACTIONS,
   validateRepeatableActionsField,
 } from '../../utils';
@@ -45,7 +44,7 @@ export const RepeatableActionsField = memo(({
 
   const intl = useIntl();
 
-  const actions = FORMS_SETTINGS[ENTITY_KEYS.MAPPING_PROFILES].DECORATORS.REPEATABLE_ACTIONS;
+  const actions = MAPPING_REPEATABLE_FIELD_ACTIONS;
   const dataOptions = actions.map(action => ({
     value: action.value,
     label: intl.formatMessage({ id: action.label }),

--- a/src/settings/MappingProfiles/detailsSections/view/HoldingsDetailsSections/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/view/HoldingsDetailsSections/AdministrativeData.js
@@ -8,15 +8,14 @@ import {
   Col,
   NoValue,
   KeyValue,
-  MultiColumnList,
 } from '@folio/stripes/components';
 
 import { ProhibitionIcon } from '../../../../../components';
+import { ViewRepeatableField } from '../ViewRepeatableField';
 
 import {
   getFieldValue,
   getBooleanLabelId,
-  getContentData,
   transformSubfieldsData,
   getValueById,
 } from '../../utils';
@@ -31,8 +30,10 @@ export const AdministrativeData = ({ mappingDetails }) => {
   const discoverySuppress = getFieldValue(mappingDetails, 'discoverySuppress', 'booleanFieldAction');
   const holdingsHrid = getFieldValue(mappingDetails, 'hrid', 'value');
   const formerIds = getFieldValue(mappingDetails, 'formerIds', 'subfields');
+  const formerIdsRepeatableAction = getFieldValue(mappingDetails, 'formerIds', 'repeatableFieldAction');
   const holdingsType = getFieldValue(mappingDetails, 'holdingsTypeId', 'value');
   const statisticalCodes = getFieldValue(mappingDetails, 'statisticalCodeIds', 'subfields');
+  const statisticalCodesRepeatableAction = getFieldValue(mappingDetails, 'statisticalCodeIds', 'repeatableFieldAction');
 
   const discoverySuppressLabelId = getBooleanLabelId(discoverySuppress);
   const discoverySuppressValue = getValueById(discoverySuppressLabelId);
@@ -100,14 +101,14 @@ export const AdministrativeData = ({ mappingDetails }) => {
           xs={12}
           className={css.colWithTable}
         >
-          <KeyValue label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.administrativeData.field.formerId.legend`} />}>
-            <MultiColumnList
-              contentData={getContentData(formerIdsData)}
-              visibleColumns={formerIdsVisibleColumns}
-              columnMapping={formerIdsMapping}
-              formatter={formerIdsFormatter}
-            />
-          </KeyValue>
+          <ViewRepeatableField
+            repeatableAction={formerIdsRepeatableAction}
+            fieldData={formerIdsData}
+            visibleColumns={formerIdsVisibleColumns}
+            columnMapping={formerIdsMapping}
+            formatter={formerIdsFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.holdings.administrativeData.field.formerId.legend`}
+          />
         </Col>
       </Row>
       <Row left="xs">
@@ -127,14 +128,14 @@ export const AdministrativeData = ({ mappingDetails }) => {
           id="section-statistical-code-ids"
           xs={12}
         >
-          <KeyValue label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.legend`} />}>
-            <MultiColumnList
-              contentData={getContentData(statisticalCodesData)}
-              visibleColumns={statisticalCodesVisibleColumns}
-              columnMapping={statisticalCodesMapping}
-              formatter={statisticalCodesFormatter}
-            />
-          </KeyValue>
+          <ViewRepeatableField
+            repeatableAction={statisticalCodesRepeatableAction}
+            fieldData={statisticalCodesData}
+            visibleColumns={statisticalCodesVisibleColumns}
+            columnMapping={statisticalCodesMapping}
+            formatter={statisticalCodesFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.legend`}
+          />
         </Col>
       </Row>
     </Accordion>

--- a/src/settings/MappingProfiles/detailsSections/view/HoldingsDetailsSections/ElectronicAccess.js
+++ b/src/settings/MappingProfiles/detailsSections/view/HoldingsDetailsSections/ElectronicAccess.js
@@ -6,24 +6,24 @@ import {
   Accordion,
   Row,
   Col,
-  MultiColumnList,
   NoValue,
 } from '@folio/stripes/components';
 
+import { ViewRepeatableField } from '../ViewRepeatableField';
+
 import {
-  getContentData,
   getFieldValue,
   transformSubfieldsData,
 } from '../../utils';
 import { TRANSLATION_ID_PREFIX } from '../../constants';
 import { mappingProfileFieldShape } from '../../../../../utils';
 
-import css from '../../../MappingProfiles.css';
-
 export const ElectronicAccess = ({ mappingDetails }) => {
   const noValueElement = <NoValue />;
 
   const electronicAccess = getFieldValue(mappingDetails, 'electronicAccess', 'subfields');
+  const electronicAccessRepeatableAction = getFieldValue(mappingDetails,
+    'electronicAccess', 'repeatableFieldAction');
 
   const electronicAccessVisibleColumns = ['relationshipId', 'uri', 'linkText', 'materialsSpecification', 'publicNote'];
   const electronicAccessMapping = {
@@ -80,13 +80,14 @@ export const ElectronicAccess = ({ mappingDetails }) => {
           data-test-electronic-access
           id="section-electronic-access"
           xs={12}
-          className={css.colWithTable}
         >
-          <MultiColumnList
-            contentData={getContentData(electronicAccessData)}
+          <ViewRepeatableField
+            repeatableAction={electronicAccessRepeatableAction}
+            fieldData={electronicAccessData}
             visibleColumns={electronicAccessVisibleColumns}
             columnMapping={electronicAccessMapping}
             formatter={electronicAccessFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.EAccess.section`}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/view/HoldingsDetailsSections/HoldingsDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/view/HoldingsDetailsSections/HoldingsDetails.js
@@ -8,11 +8,11 @@ import {
   Col,
   NoValue,
   KeyValue,
-  MultiColumnList,
 } from '@folio/stripes/components';
 
+import { ViewRepeatableField } from '../ViewRepeatableField';
+
 import {
-  getContentData,
   getFieldValue,
   transformSubfieldsData,
 } from '../../utils';
@@ -25,8 +25,14 @@ export const HoldingsDetails = ({ mappingDetails }) => {
 
   const numberOfItems = getFieldValue(mappingDetails, 'numberOfItems', 'value');
   const statements = getFieldValue(mappingDetails, 'holdingsStatements', 'subfields');
+  const statementsRepeatableAction = getFieldValue(mappingDetails,
+    'holdingsStatements', 'repeatableFieldAction');
   const statementsForSupplement = getFieldValue(mappingDetails, 'holdingsStatementsForSupplements', 'subfields');
+  const statementsForSupplementRepeatableAction = getFieldValue(mappingDetails,
+    'holdingsStatementsForSupplements', 'repeatableFieldAction');
   const statementsForIndexes = getFieldValue(mappingDetails, 'holdingsStatementsForIndexes', 'subfields');
+  const statementsForIndexesRepeatableAction = getFieldValue(mappingDetails,
+    'holdingsStatementsForIndexes', 'repeatableFieldAction');
   const illPolicy = getFieldValue(mappingDetails, 'illPolicyId', 'value');
   const digitizationPolicy = getFieldValue(mappingDetails, 'digitizationPolicy', 'value');
   const retentionPolicy = getFieldValue(mappingDetails, 'retentionPolicy', 'value');
@@ -126,14 +132,14 @@ export const HoldingsDetails = ({ mappingDetails }) => {
           xs={12}
           className={css.colWithTable}
         >
-          <KeyValue label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement.legend`} />}>
-            <MultiColumnList
-              contentData={getContentData(statementsData)}
-              visibleColumns={statementsVisibleColumns}
-              columnMapping={statementsMapping}
-              formatter={statementsFormatter}
-            />
-          </KeyValue>
+          <ViewRepeatableField
+            repeatableAction={statementsRepeatableAction}
+            fieldData={statementsData}
+            visibleColumns={statementsVisibleColumns}
+            columnMapping={statementsMapping}
+            formatter={statementsFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement.legend`}
+          />
         </Col>
       </Row>
       <Row left="xs">
@@ -143,14 +149,14 @@ export const HoldingsDetails = ({ mappingDetails }) => {
           xs={12}
           className={css.colWithTable}
         >
-          <KeyValue label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForSupplements.legend`} />}>
-            <MultiColumnList
-              contentData={getContentData(statementsForSupplementData)}
-              visibleColumns={statementsForSupplementVisibleColumns}
-              columnMapping={statementsForSupplementMapping}
-              formatter={statementsForSupplementFormatter}
-            />
-          </KeyValue>
+          <ViewRepeatableField
+            repeatableAction={statementsForSupplementRepeatableAction}
+            fieldData={statementsForSupplementData}
+            visibleColumns={statementsForSupplementVisibleColumns}
+            columnMapping={statementsForSupplementMapping}
+            formatter={statementsForSupplementFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForSupplements.legend`}
+          />
         </Col>
       </Row>
       <Row left="xs">
@@ -160,14 +166,14 @@ export const HoldingsDetails = ({ mappingDetails }) => {
           xs={12}
           className={css.colWithTable}
         >
-          <KeyValue label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForIndexes.legend`} />}>
-            <MultiColumnList
-              contentData={getContentData(statementsForIndexesData)}
-              visibleColumns={statementsForIndexesVisibleColumns}
-              columnMapping={statementsForIndexesMapping}
-              formatter={statementsForIndexesFormatter}
-            />
-          </KeyValue>
+          <ViewRepeatableField
+            repeatableAction={statementsForIndexesRepeatableAction}
+            fieldData={statementsForIndexesData}
+            visibleColumns={statementsForIndexesVisibleColumns}
+            columnMapping={statementsForIndexesMapping}
+            formatter={statementsForIndexesFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForIndexes.legend`}
+          />
         </Col>
       </Row>
       <Row left="xs">

--- a/src/settings/MappingProfiles/detailsSections/view/HoldingsDetailsSections/HoldingsNotes.js
+++ b/src/settings/MappingProfiles/detailsSections/view/HoldingsDetailsSections/HoldingsNotes.js
@@ -6,12 +6,12 @@ import {
   Accordion,
   Row,
   Col,
-  MultiColumnList,
   NoValue,
 } from '@folio/stripes/components';
 
+import { ViewRepeatableField } from '../ViewRepeatableField';
+
 import {
-  getContentData,
   getFieldValue,
   transformSubfieldsData,
   getBooleanLabelId,
@@ -20,12 +20,11 @@ import {
 import { TRANSLATION_ID_PREFIX } from '../../constants';
 import { mappingProfileFieldShape } from '../../../../../utils';
 
-import css from '../../../MappingProfiles.css';
-
 export const HoldingsNotes = ({ mappingDetails }) => {
   const noValueElement = <NoValue />;
 
   const notes = getFieldValue(mappingDetails, 'notes', 'subfields');
+  const notesRepeatableAction = getFieldValue(mappingDetails, 'notes', 'repeatableFieldAction');
 
   const notesVisibleColumns = ['noteType', 'note', 'staffOnly'];
   const notesMapping = {
@@ -72,13 +71,14 @@ export const HoldingsNotes = ({ mappingDetails }) => {
           data-test-notes
           id="section-holding-statements"
           xs={12}
-          className={css.colWithTable}
         >
-          <MultiColumnList
-            contentData={getContentData(notesData)}
+          <ViewRepeatableField
+            repeatableAction={notesRepeatableAction}
+            fieldData={notesData}
             visibleColumns={notesVisibleColumns}
             columnMapping={notesMapping}
             formatter={notesFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.holdings.holdingsNotes.section`}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/view/HoldingsDetailsSections/ReceivingHistory.js
+++ b/src/settings/MappingProfiles/detailsSections/view/HoldingsDetailsSections/ReceivingHistory.js
@@ -6,13 +6,13 @@ import {
   Accordion,
   Row,
   Col,
-  MultiColumnList,
   NoValue,
 } from '@folio/stripes/components';
 
+import { ViewRepeatableField } from '../ViewRepeatableField';
+
 import {
   getBooleanLabelId,
-  getContentData,
   getFieldValue,
   getValueById,
   transformSubfieldsData,
@@ -20,12 +20,12 @@ import {
 import { TRANSLATION_ID_PREFIX } from '../../constants';
 import { mappingProfileFieldShape } from '../../../../../utils';
 
-import css from '../../../MappingProfiles.css';
-
 export const ReceivingHistory = ({ mappingDetails }) => {
   const noValueElement = <NoValue />;
 
   const receivingHistory = getFieldValue(mappingDetails, 'receivingHistory.entries', 'subfields');
+  const receivingHistoryRepeatableAction = getFieldValue(mappingDetails,
+    'receivingHistory.entries', 'repeatableFieldAction');
 
   const receivingHistoryVisibleColumns = ['publicDisplay', 'enumeration', 'chronology'];
   const receivingHistoryMapping = {
@@ -72,13 +72,14 @@ export const ReceivingHistory = ({ mappingDetails }) => {
           data-test-receiving-history-note
           id="section-receiving-history"
           xs={12}
-          className={css.colWithTable}
         >
-          <MultiColumnList
-            contentData={getContentData(receivingHistoryData)}
+          <ViewRepeatableField
+            repeatableAction={receivingHistoryRepeatableAction}
+            fieldData={receivingHistoryData}
             visibleColumns={receivingHistoryVisibleColumns}
             columnMapping={receivingHistoryMapping}
             formatter={receivingHistoryFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.receivingHistory.section`}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/AdministrativeData.js
@@ -8,22 +8,19 @@ import {
   Row,
   KeyValue,
   NoValue,
-  MultiColumnList,
 } from '@folio/stripes/components';
 
 import { ProhibitionIcon } from '../../../../../components';
+import { ViewRepeatableField } from '../ViewRepeatableField';
 
 import { TRANSLATION_ID_PREFIX } from '../../constants';
 import {
   getFieldValue,
   transformSubfieldsData,
-  getContentData,
   getBooleanLabelId,
   getValueById,
 } from '../../utils';
 import { mappingProfileFieldShape } from '../../../../../utils';
-
-import css from '../../../MappingProfiles.css';
 
 export const AdministrativeData = ({ mappingDetails }) => {
   const noValueElement = <NoValue />;
@@ -38,6 +35,7 @@ export const AdministrativeData = ({ mappingDetails }) => {
   const statusTerm = getFieldValue(mappingDetails, 'statusId', 'value');
   const modeOfIssuance = getFieldValue(mappingDetails, 'modeOfIssuanceId', 'value');
   const statisticalCodes = getFieldValue(mappingDetails, 'statisticalCodeIds', 'subfields');
+  const statisticalCodesRepeatableAction = getFieldValue(mappingDetails, 'statisticalCodeIds', 'repeatableFieldAction');
 
   const discoverySuppressLabelId = getBooleanLabelId(discoverySuppress);
   const staffSuppressLabelId = getBooleanLabelId(staffSuppress);
@@ -153,16 +151,15 @@ export const AdministrativeData = ({ mappingDetails }) => {
         <Col
           data-test-statistical-codes
           xs={12}
-          className={css.colWithTable}
         >
-          <KeyValue label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.legend`} />}>
-            <MultiColumnList
-              contentData={getContentData(statisticalCodesData)}
-              visibleColumns={statisticalCodesVisibleColumns}
-              columnMapping={statisticalCodesMapping}
-              formatter={statisticalCodesFormatter}
-            />
-          </KeyValue>
+          <ViewRepeatableField
+            repeatableAction={statisticalCodesRepeatableAction}
+            fieldData={statisticalCodesData}
+            visibleColumns={statisticalCodesVisibleColumns}
+            columnMapping={statisticalCodesMapping}
+            formatter={statisticalCodesFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.legend`}
+          />
         </Col>
       </Row>
     </Accordion>

--- a/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/DescriptiveData.js
+++ b/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/DescriptiveData.js
@@ -12,6 +12,7 @@ import {
 } from '@folio/stripes/components';
 
 import { ProhibitionIcon } from '../../../../../components';
+import { ViewRepeatableField } from '../ViewRepeatableField';
 
 import {
   transformSubfieldsData,
@@ -32,6 +33,8 @@ export const DescriptiveData = ({ mappingDetails }) => {
   const physicalDescriptions = getFieldValue(mappingDetails, 'physicalDescriptions', 'subfields');
   const resourceType = getFieldValue(mappingDetails, 'instanceTypeId', 'value');
   const natureOfContentTerms = getFieldValue(mappingDetails, 'natureOfContentTermIds', 'subfields');
+  const natureOfContentTermsRepeatableAction = getFieldValue(mappingDetails,
+    'natureOfContentTermIds', 'repeatableFieldAction');
   const formats = getFieldValue(mappingDetails, 'instanceFormatIds', 'subfields');
   const languages = getFieldValue(mappingDetails, 'languages', 'subfields');
   const publicationFrequencies = getFieldValue(mappingDetails, 'publicationFrequency', 'subfields');
@@ -250,14 +253,14 @@ export const DescriptiveData = ({ mappingDetails }) => {
           xs={12}
           className={css.colWithTable}
         >
-          <KeyValue label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.natureOfContentTermsIds.legend`} />}>
-            <MultiColumnList
-              contentData={getContentData(natureOfContentTermsData)}
-              visibleColumns={natureOfContentTermsVisibleColumns}
-              columnMapping={natureOfContentTermsMapping}
-              formatter={natureOfContentTermsFormatter}
-            />
-          </KeyValue>
+          <ViewRepeatableField
+            repeatableAction={natureOfContentTermsRepeatableAction}
+            fieldData={natureOfContentTermsData}
+            visibleColumns={natureOfContentTermsVisibleColumns}
+            columnMapping={natureOfContentTermsMapping}
+            formatter={natureOfContentTermsFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.natureOfContentTermsIds.legend`}
+          />
         </Col>
       </Row>
       <Row left="xs">

--- a/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/InstanceRelationship.js
+++ b/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/InstanceRelationship.js
@@ -7,12 +7,11 @@ import {
   Row,
   Col,
   NoValue,
-  KeyValue,
-  MultiColumnList,
 } from '@folio/stripes/components';
 
+import { ViewRepeatableField } from '../ViewRepeatableField';
+
 import {
-  getContentData,
   getFieldValue,
   transformSubfieldsData,
 } from '../../utils';
@@ -25,7 +24,11 @@ export const InstanceRelationship = ({ mappingDetails }) => {
   const noValueElement = <NoValue />;
 
   const parentInstances = getFieldValue(mappingDetails, 'parentInstances', 'subfields');
+  const parentInstancesRepeatableAction = getFieldValue(mappingDetails,
+    'parentInstances', 'repeatableFieldAction');
   const childInstances = getFieldValue(mappingDetails, 'childInstances', 'subfields');
+  const childInstancesRepeatableAction = getFieldValue(mappingDetails,
+    'childInstances', 'repeatableFieldAction');
 
   const parentInstancesVisibleColumns = ['superInstanceId', 'instanceRelationshipTypeId'];
   const parentInstancesMapping = {
@@ -86,30 +89,29 @@ export const InstanceRelationship = ({ mappingDetails }) => {
           xs={12}
           className={css.colWithTable}
         >
-          <KeyValue label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.field.parentInstances.legend`} />}>
-            <MultiColumnList
-              contentData={getContentData(parentInstancesData)}
-              visibleColumns={parentInstancesVisibleColumns}
-              columnMapping={parentInstancesMapping}
-              formatter={parentInstancesFormatter}
-            />
-          </KeyValue>
+          <ViewRepeatableField
+            repeatableAction={parentInstancesRepeatableAction}
+            fieldData={parentInstancesData}
+            visibleColumns={parentInstancesVisibleColumns}
+            columnMapping={parentInstancesMapping}
+            formatter={parentInstancesFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.instance.field.parentInstances.legend`}
+          />
         </Col>
       </Row>
       <Row left="xs">
         <Col
           data-test-child-instances
           xs={12}
-          className={css.colWithTable}
         >
-          <KeyValue label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.field.childInstances.legend`} />}>
-            <MultiColumnList
-              contentData={getContentData(childInstancesData)}
-              visibleColumns={childInstancesVisibleColumns}
-              columnMapping={childInstancesMapping}
-              formatter={childInstancesFormatter}
-            />
-          </KeyValue>
+          <ViewRepeatableField
+            repeatableAction={childInstancesRepeatableAction}
+            fieldData={childInstancesData}
+            visibleColumns={childInstancesVisibleColumns}
+            columnMapping={childInstancesMapping}
+            formatter={childInstancesFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.instance.field.childInstances.legend`}
+          />
         </Col>
       </Row>
     </Accordion>

--- a/src/settings/MappingProfiles/detailsSections/view/ItemDetailSection/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/view/ItemDetailSection/AdministrativeData.js
@@ -7,17 +7,16 @@ import {
   Row,
   Col,
   KeyValue,
-  MultiColumnList,
   NoValue,
 } from '@folio/stripes/components';
 
 import { ProhibitionIcon } from '../../../../../components';
+import { ViewRepeatableField } from '../ViewRepeatableField';
 
 import {
   getFieldValue,
   getBooleanLabelId,
   getValueById,
-  getContentData,
   transformSubfieldsData,
 } from '../../utils';
 import { TRANSLATION_ID_PREFIX } from '../../constants';
@@ -34,7 +33,10 @@ export const AdministrativeData = ({ mappingDetails }) => {
   const accessionNumber = getFieldValue(mappingDetails, 'accessionNumber', 'value');
   const itemIdentifier = getFieldValue(mappingDetails, 'itemIdentifier', 'value');
   const formerIds = getFieldValue(mappingDetails, 'formerIds', 'subfields');
+  const formerIdsRepeatableAction = getFieldValue(mappingDetails, 'formerIds', 'repeatableFieldAction');
   const statisticalCodes = getFieldValue(mappingDetails, 'statisticalCodeIds', 'subfields');
+  const statisticalCodesRepeatableAction = getFieldValue(mappingDetails,
+    'statisticalCodeIds', 'repeatableFieldAction');
 
   const discoverySuppressLabelId = getBooleanLabelId(discoverySuppress);
   const discoverySuppressValue = getValueById(discoverySuppressLabelId);
@@ -130,14 +132,14 @@ export const AdministrativeData = ({ mappingDetails }) => {
           xs={12}
           className={css.colWithTable}
         >
-          <KeyValue label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.administrativeData.field.formerId.legend`} />}>
-            <MultiColumnList
-              contentData={getContentData(formerIdentifiersData)}
-              visibleColumns={formerIdentifiersVisibleColumns}
-              columnMapping={formerIdentifiersMapping}
-              formatter={formerIdentifiersFormatter}
-            />
-          </KeyValue>
+          <ViewRepeatableField
+            repeatableAction={formerIdsRepeatableAction}
+            fieldData={formerIdentifiersData}
+            visibleColumns={formerIdentifiersVisibleColumns}
+            columnMapping={formerIdentifiersMapping}
+            formatter={formerIdentifiersFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.item.administrativeData.field.formerId.legend`}
+          />
         </Col>
       </Row>
       <Row left="xs">
@@ -145,16 +147,15 @@ export const AdministrativeData = ({ mappingDetails }) => {
           data-test-statistical-codes
           id="section-statistical-code-ids"
           xs={12}
-          className={css.colWithTable}
         >
-          <KeyValue label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.legend`} />}>
-            <MultiColumnList
-              contentData={getContentData(statisticalCodesData)}
-              visibleColumns={statisticalCodesVisibleColumns}
-              columnMapping={statisticalCodesMapping}
-              formatter={statisticalCodesFormatter}
-            />
-          </KeyValue>
+          <ViewRepeatableField
+            repeatableAction={statisticalCodesRepeatableAction}
+            fieldData={statisticalCodesData}
+            visibleColumns={statisticalCodesVisibleColumns}
+            columnMapping={statisticalCodesMapping}
+            formatter={statisticalCodesFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.administrativeData.field.statisticalCodes.legend`}
+          />
         </Col>
       </Row>
     </Accordion>

--- a/src/settings/MappingProfiles/detailsSections/view/ItemDetailSection/ElectronicAccess.js
+++ b/src/settings/MappingProfiles/detailsSections/view/ItemDetailSection/ElectronicAccess.js
@@ -6,24 +6,24 @@ import {
   Accordion,
   Row,
   Col,
-  MultiColumnList,
   NoValue,
 } from '@folio/stripes/components';
 
+import { ViewRepeatableField } from '../ViewRepeatableField';
+
 import {
-  getContentData,
   getFieldValue,
   transformSubfieldsData,
 } from '../../utils';
 import { TRANSLATION_ID_PREFIX } from '../../constants';
 import { mappingProfileFieldShape } from '../../../../../utils';
 
-import css from '../../../MappingProfiles.css';
-
 export const ElectronicAccess = ({ mappingDetails }) => {
   const noValueElement = <NoValue />;
 
   const electronicAccess = getFieldValue(mappingDetails, 'electronicAccess', 'subfields');
+  const electronicAccessRepeatableAction = getFieldValue(mappingDetails,
+    'electronicAccess', 'repeatableFieldAction');
 
   const electronicAccessVisibleColumns = ['relationshipId', 'uri', 'linkText', 'materialsSpecification', 'publicNote'];
   const electronicAccessMapping = {
@@ -80,13 +80,14 @@ export const ElectronicAccess = ({ mappingDetails }) => {
           data-test-electronic-access
           id="section-electronic-access"
           xs={12}
-          className={css.colWithTable}
         >
-          <MultiColumnList
-            contentData={getContentData(electronicAccessData)}
+          <ViewRepeatableField
+            repeatableAction={electronicAccessRepeatableAction}
+            fieldData={electronicAccessData}
             visibleColumns={electronicAccessVisibleColumns}
             columnMapping={electronicAccessMapping}
             formatter={electronicAccessFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.EAccess.section`}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/view/ItemDetailSection/EnumerationData.js
+++ b/src/settings/MappingProfiles/detailsSections/view/ItemDetailSection/EnumerationData.js
@@ -8,18 +8,16 @@ import {
   Col,
   NoValue,
   KeyValue,
-  MultiColumnList,
 } from '@folio/stripes/components';
 
+import { ViewRepeatableField } from '../ViewRepeatableField';
+
 import {
-  getContentData,
   getFieldValue,
   transformSubfieldsData,
 } from '../../utils';
 import { TRANSLATION_ID_PREFIX } from '../../constants';
 import { mappingProfileFieldShape } from '../../../../../utils';
-
-import css from '../../../MappingProfiles.css';
 
 export const EnumerationData = ({ mappingDetails }) => {
   const noValueElement = <NoValue />;
@@ -28,6 +26,8 @@ export const EnumerationData = ({ mappingDetails }) => {
   const chronology = getFieldValue(mappingDetails, 'chronology', 'value');
   const volume = getFieldValue(mappingDetails, 'volume', 'value');
   const yearsAndCaptions = getFieldValue(mappingDetails, 'yearCaption', 'subfields');
+  const yearsAndCaptionsRepeatableAction = getFieldValue(mappingDetails,
+    'yearCaption', 'repeatableFieldAction');
 
   const yearsAndCaptionsVisibleColumns = ['yearCaption'];
   const yearsAndCaptionsMapping = {
@@ -85,16 +85,15 @@ export const EnumerationData = ({ mappingDetails }) => {
           data-test-years-and-captions
           id="section-year-caption"
           xs={12}
-          className={css.colWithTable}
         >
-          <KeyValue label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.enumerationData.field.yearCaption`} />}>
-            <MultiColumnList
-              contentData={getContentData(yearsAndCaptionsData)}
-              visibleColumns={yearsAndCaptionsVisibleColumns}
-              columnMapping={yearsAndCaptionsMapping}
-              formatter={yearsAndCaptionsFormatter}
-            />
-          </KeyValue>
+          <ViewRepeatableField
+            repeatableAction={yearsAndCaptionsRepeatableAction}
+            fieldData={yearsAndCaptionsData}
+            visibleColumns={yearsAndCaptionsVisibleColumns}
+            columnMapping={yearsAndCaptionsMapping}
+            formatter={yearsAndCaptionsFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.item.enumerationData.field.yearCaption`}
+          />
         </Col>
       </Row>
     </Accordion>

--- a/src/settings/MappingProfiles/detailsSections/view/ItemDetailSection/ItemNotes.js
+++ b/src/settings/MappingProfiles/detailsSections/view/ItemDetailSection/ItemNotes.js
@@ -6,13 +6,13 @@ import {
   Accordion,
   Row,
   Col,
-  MultiColumnList,
   NoValue,
 } from '@folio/stripes/components';
 
+import { ViewRepeatableField } from '../ViewRepeatableField';
+
 import {
   getBooleanLabelId,
-  getContentData,
   getFieldValue,
   getValueById,
   transformSubfieldsData,
@@ -24,6 +24,7 @@ export const ItemNotes = ({ mappingDetails }) => {
   const noValueElement = <NoValue />;
 
   const notes = getFieldValue(mappingDetails, 'notes', 'subfields');
+  const notesRepeatableAction = getFieldValue(mappingDetails, 'notes', 'repeatableFieldAction');
 
   const notesVisibleColumns = ['itemNoteTypeId', 'note', 'staffOnly'];
   const notesMapping = {
@@ -71,11 +72,13 @@ export const ItemNotes = ({ mappingDetails }) => {
           id="section-item-notes"
           xs={12}
         >
-          <MultiColumnList
-            contentData={getContentData(notesData)}
+          <ViewRepeatableField
+            repeatableAction={notesRepeatableAction}
+            fieldData={notesData}
             visibleColumns={notesVisibleColumns}
             columnMapping={notesMapping}
             formatter={notesFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.item.itemNotes.section`}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/view/ItemDetailSection/LoanAndAvailability.js
+++ b/src/settings/MappingProfiles/detailsSections/view/ItemDetailSection/LoanAndAvailability.js
@@ -8,20 +8,18 @@ import {
   Col,
   NoValue,
   KeyValue,
-  MultiColumnList,
 } from '@folio/stripes/components';
+
+import { ViewRepeatableField } from '../ViewRepeatableField';
 
 import {
   getBooleanLabelId,
-  getContentData,
   getFieldValue,
   getValueById,
   transformSubfieldsData,
 } from '../../utils';
 import { TRANSLATION_ID_PREFIX } from '../../constants';
 import { mappingProfileFieldShape } from '../../../../../utils';
-
-import css from '../../../MappingProfiles.css';
 
 export const LoanAndAvailability = ({ mappingDetails }) => {
   const noValueElement = <NoValue />;
@@ -30,6 +28,8 @@ export const LoanAndAvailability = ({ mappingDetails }) => {
   const temporaryLoanType = getFieldValue(mappingDetails, 'temporaryLoanType.id', 'value');
   const status = getFieldValue(mappingDetails, 'status.name', 'value');
   const circulationNotes = getFieldValue(mappingDetails, 'circulationNotes', 'subfields');
+  const circulationNotesRepeatableAction = getFieldValue(mappingDetails,
+    'circulationNotes', 'repeatableFieldAction');
 
   const circulationNotesVisibleColumns = ['noteType', 'note', 'staffOnly'];
   const circulationNotesMapping = {
@@ -109,16 +109,15 @@ export const LoanAndAvailability = ({ mappingDetails }) => {
           data-test-circulation-notes
           id="section-circulation-notes"
           xs={12}
-          className={css.colWithTable}
         >
-          <KeyValue label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.field.circulationNotes.legend`} />}>
-            <MultiColumnList
-              contentData={getContentData(circulationNotesData)}
-              visibleColumns={circulationNotesVisibleColumns}
-              columnMapping={circulationNotesMapping}
-              formatter={circulationNotesFormatter}
-            />
-          </KeyValue>
+          <ViewRepeatableField
+            repeatableAction={circulationNotesRepeatableAction}
+            fieldData={circulationNotesData}
+            visibleColumns={circulationNotesVisibleColumns}
+            columnMapping={circulationNotesMapping}
+            formatter={circulationNotesFormatter}
+            labelId={`${TRANSLATION_ID_PREFIX}.item.field.circulationNotes.legend`}
+          />
         </Col>
       </Row>
     </Accordion>

--- a/src/settings/MappingProfiles/detailsSections/view/ViewRepeatableField.js
+++ b/src/settings/MappingProfiles/detailsSections/view/ViewRepeatableField.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  KeyValue,
+  MultiColumnList,
+} from '@folio/stripes-components';
+
+import {
+  MAPPING_REPEATABLE_FIELD_ACTIONS,
+  REPEATABLE_ACTIONS,
+} from '../../../../utils';
+import { getContentData } from '../utils';
+
+export const ViewRepeatableField = ({
+  repeatableAction,
+  fieldData,
+  visibleColumns,
+  columnMapping,
+  formatter,
+  labelId,
+}) => {
+  const repeatableActionValue = MAPPING_REPEATABLE_FIELD_ACTIONS.find(action => action.value === repeatableAction)?.label;
+  const isTableVisible = repeatableAction !== REPEATABLE_ACTIONS.DELETE_EXISTING;
+
+  const renderTable = () => (
+    <MultiColumnList
+      contentData={getContentData(fieldData)}
+      visibleColumns={visibleColumns}
+      columnMapping={columnMapping}
+      formatter={formatter}
+    />
+  );
+
+  return (
+    <KeyValue label={<FormattedMessage id={labelId} />}>
+      {repeatableActionValue && <FormattedMessage id={repeatableActionValue} />}
+      {isTableVisible && renderTable()}
+    </KeyValue>
+  );
+};
+
+ViewRepeatableField.propTypes = {
+  visibleColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
+  columnMapping: PropTypes.object.isRequired,
+  labelId: PropTypes.string.isRequired,
+  repeatableAction: PropTypes.string,
+  fieldData: PropTypes.arrayOf(PropTypes.object),
+  formatter: PropTypes.object,
+};

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -309,6 +309,25 @@ export const FORMS_SETTINGS = {
   },
 };
 
+export const MAPPING_REPEATABLE_FIELD_ACTIONS = [
+  {
+    label: 'ui-data-import.settings.mappingProfiles.map.wrapper.repeatableActions.extendExisting',
+    value: REPEATABLE_ACTIONS.EXTEND_EXISTING,
+  },
+  {
+    label: 'ui-data-import.settings.mappingProfiles.map.wrapper.repeatableActions.deleteExisting',
+    value: REPEATABLE_ACTIONS.DELETE_EXISTING,
+  },
+  {
+    label: 'ui-data-import.settings.mappingProfiles.map.wrapper.repeatableActions.exchangeExisting',
+    value: REPEATABLE_ACTIONS.EXCHANGE_EXISTING,
+  },
+  {
+    label: 'ui-data-import.settings.mappingProfiles.map.wrapper.repeatableActions.deleteIncoming',
+    value: REPEATABLE_ACTIONS.DELETE_INCOMING,
+  },
+];
+
 export const PROFILE_LINKING_RULES = {
   allowDelete: false,
   deleteRecursive: false,


### PR DESCRIPTION
## Description
To update the view of the dropdown options for repeatable fields in the Instance, Holding, and Item field mapping profiles.

## Approach
* Create `ViewRepeatableField` component to render view of the dropdown options for repeatable fields.
* Display value of the dropdown option under a field label.
* If the dropdown option value is equal to `Delete all existing values` then disable displaying of MCL for the field.

## Issue
[UIDATIMP-555](https://issues.folio.org/browse/UIDATIMP-555)

## Screenshot
![view_repeatable](https://user-images.githubusercontent.com/55138456/90620405-0f7bfe00-e21b-11ea-9ce1-bc6ed3e68681.jpg)
