### PR TITLE
Import RootCloseWrapper through stripes

### DIFF
--- a/src/components/FlexibleForm/ControlDecorators/partials/TextDate.js
+++ b/src/components/FlexibleForm/ControlDecorators/partials/TextDate.js
@@ -1,7 +1,6 @@
 import React, { createRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import RootCloseWrapper from '@folio/stripes/components/RootCloseWrapper';
 
 import moment from 'moment-timezone';
 import contains from 'dom-helpers/query/contains';
@@ -13,6 +12,7 @@ import {
 import {
   Popper,
   IconButton,
+  RootCloseWrapper,
   TextField,
 } from '@folio/stripes/components';
 import { AVAILABLE_PLACEMENTS } from '@folio/stripes-components/lib/Popper';

--- a/src/components/FlexibleForm/ControlDecorators/partials/TextDate.js
+++ b/src/components/FlexibleForm/ControlDecorators/partials/TextDate.js
@@ -1,7 +1,7 @@
 import React, { createRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
+import RootCloseWrapper from '@folio/stripes/components/RootCloseWrapper';
 
 import moment from 'moment-timezone';
 import contains from 'dom-helpers/query/contains';


### PR DESCRIPTION
With the recent, much-needed upgrade to react-overlays, the RootCloseWrapper was changed to a hook. We now re-export it in its component form through `stripes-components`

I'm a bit curious as to how eslint let you get away with such an import - reaching into the directory structure of a dependency that wasn't in the package.json is usually a major gripe.