### PR TITLE
UIDATIMP-558 Add hover text for "Cannot be mapped" icon in field mapp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,15 +31,25 @@
 * Update the available Data type options for File extension settings (UIDATIMP-626)
 * Connect MARC field protection settings to the server (UIDATIMP-621)
 * Field mappings: Item - update reference dropdown list for Item status (UIDATIMP-529)
+* Add hover text for "Cannot be mapped" icon in field mappings (UIDATIMP-558)
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)
+
+## [2.1.4](https://github.com/folio-org/ui-data-import/tree/v2.1.4) (2020-08-13)
+
+### Bugs fixed:
+* Cannot create a holdings field mapping profile on Goldenrod bugfest, hotfix (UIDATIMP-619)
+
+## [2.1.3](https://github.com/folio-org/ui-data-import/tree/v2.1.3) (2020-08-11)
+
+### Bugs fixed:
+* Fix saving subfield information of match profile, hotfix (UIDATIMP-604)
 
 ## [2.1.2](https://github.com/folio-org/ui-data-import/tree/v2.1.2) (2020-08-11)
 
 ### Bugs fixed:
 * Fix Inconsistent in Holding schema between UI and Backend (UIDATIMP-596)
-* Fix saving subfield information of match profile (UIDATIMP-604)
 * Fix optional sections of match profile do not clear out when removed (UIDATIMP-597)
 
 ## [2.1.1](https://github.com/folio-org/ui-data-import/tree/v2.1.1) (2020-07-09)
@@ -50,7 +60,6 @@
 ### Bugs fixed:
 * Fix deletion repeatable fields in Field mapping profile (UIDATIMP-482)
 * Fix assigning and unassigning tags to data import profiles (UIDATIMP-499)
-* Fix failing tests and turn on tests on CI (UIDATIMP-556)
 
 ## [2.1.0](https://github.com/folio-org/ui-data-import/tree/v2.1.0) (2020-06-25)
 

--- a/src/components/ProhibitionIcon/ProhibitionIcon.css
+++ b/src/components/ProhibitionIcon/ProhibitionIcon.css
@@ -1,3 +1,6 @@
 .noValueAllowed {
   padding: 0 8px;
 }
+.iconContainer {
+  display: inline-block;
+}

--- a/src/components/ProhibitionIcon/ProhibitionIcon.js
+++ b/src/components/ProhibitionIcon/ProhibitionIcon.js
@@ -2,29 +2,47 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
+import { Tooltip } from '@folio/stripes-components';
+
 import css from './ProhibitionIcon.css';
 
 /**
  * Component for rendering the circle backslash character with given message as an aria-label
  *
  * @param {string} [ariaLabel] - A label or a translation id for the aria-label attribute
+ * @param {string} fieldName - field name for creation of required tooltip id attribute
  * @returns {{}}
  */
-export const ProhibitionIcon = ({ ariaLabel }) => {
+export const ProhibitionIcon = ({
+  ariaLabel, fieldName,
+}) => {
   const ariaLabelIsTranslationId = ariaLabel && ariaLabel.includes('ui-');
   const ariaLabelIsMessageString = ariaLabel && !ariaLabel.includes('ui-');
-  const translationId = ariaLabelIsTranslationId ? ariaLabel : 'ui-data-import.noValueAllowed';
+  const translationId = ariaLabelIsTranslationId ? ariaLabel : 'ui-data-import.settings.mappingProfiles.canNotBeMapped';
 
   const getIcon = message => (
-    <span
-      /* eslint-disable-next-line jsx-a11y/aria-role */
-      role="text"
-      aria-label={message}
-      className={css.noValueAllowed}
-      data-test-no-value-allowed
-    >
-      &#8416;
-    </span>
+    <div className={css.iconContainer}>
+      <Tooltip
+        id={fieldName}
+        text={message || <FormattedMessage id="ui-data-import.settings.mappingProfiles.canNotBeMapped" />}
+      >
+        {({
+          ref, ariaIds,
+        }) => (
+          <span
+            /* eslint-disable-next-line jsx-a11y/aria-role */
+            role="text"
+            aria-label={message}
+            aria-labelledby={ariaIds.text}
+            ref={ref}
+            className={css.noValueAllowed}
+            data-test-no-value-allowed
+          >
+            &#8416;
+          </span>
+        )}
+      </Tooltip>
+    </div>
   );
 
   const renderIcon = () => {
@@ -42,4 +60,7 @@ export const ProhibitionIcon = ({ ariaLabel }) => {
   return renderIcon();
 };
 
-ProhibitionIcon.propTypes = { ariaLabel: PropTypes.string };
+ProhibitionIcon.propTypes = {
+  ariaLabel: PropTypes.string,
+  fieldName: PropTypes.string,
+};

--- a/src/components/ProhibitionIcon/ProhibitionIcon.js
+++ b/src/components/ProhibitionIcon/ProhibitionIcon.js
@@ -14,7 +14,8 @@ import css from './ProhibitionIcon.css';
  * @returns {{}}
  */
 export const ProhibitionIcon = ({
-  ariaLabel, fieldName,
+  ariaLabel,
+  fieldName,
 }) => {
   const ariaLabelIsTranslationId = ariaLabel && ariaLabel.includes('ui-');
   const ariaLabelIsMessageString = ariaLabel && !ariaLabel.includes('ui-');
@@ -27,7 +28,8 @@ export const ProhibitionIcon = ({
         text={message || <FormattedMessage id="ui-data-import.settings.mappingProfiles.canNotBeMapped" />}
       >
         {({
-          ref, ariaIds,
+          ref,
+          ariaIds,
         }) => (
           <span
             /* eslint-disable-next-line jsx-a11y/aria-role */
@@ -62,5 +64,5 @@ export const ProhibitionIcon = ({
 
 ProhibitionIcon.propTypes = {
   ariaLabel: PropTypes.string,
-  fieldName: PropTypes.string,
+  fieldName: PropTypes.string.isRequired,
 };

--- a/src/components/ProhibitionIcon/ProhibitionIcon.js
+++ b/src/components/ProhibitionIcon/ProhibitionIcon.js
@@ -32,8 +32,6 @@ export const ProhibitionIcon = ({
           ariaIds,
         }) => (
           <span
-            /* eslint-disable-next-line jsx-a11y/aria-role */
-            role="text"
             aria-label={message}
             aria-labelledby={ariaIds.text}
             ref={ref}

--- a/src/settings/MappingProfiles/detailsSections/utils.js
+++ b/src/settings/MappingProfiles/detailsSections/utils.js
@@ -81,7 +81,7 @@ export const getFieldValue = (details, fieldName, key) => details.find(item => i
 
 export const getValueById = id => (id ? <FormattedMessage id={id} /> : <NoValue />);
 
-export const getUnmappableValueById = id => (id ? <FormattedMessage id={id} /> : <ProhibitionIcon />);
+export const getUnmappableValueById = (id, fieldName) => (id ? <FormattedMessage id={id} /> : <ProhibitionIcon fieldName={fieldName} />);
 
 export const transformSubfieldsData = (subfields, columns) => subfields?.map(item => {
   return columns.reduce((acc, column) => {

--- a/src/settings/MappingProfiles/detailsSections/view/HoldingsDetailsSections/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/view/HoldingsDetailsSections/AdministrativeData.js
@@ -91,7 +91,7 @@ export const AdministrativeData = ({ mappingDetails }) => {
         >
           <KeyValue
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.administrativeData.field.hrid`} />}
-            value={holdingsHrid || <ProhibitionIcon />}
+            value={holdingsHrid || <ProhibitionIcon fieldName="administrative-data-hrid" />}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/AdministrativeData.js
@@ -24,7 +24,7 @@ import { mappingProfileFieldShape } from '../../../../../utils';
 
 export const AdministrativeData = ({ mappingDetails }) => {
   const noValueElement = <NoValue />;
-  const prohibitionIconElement = <ProhibitionIcon />;
+  const prohibitionIconElement = fieldName => <ProhibitionIcon fieldName={fieldName} />;
 
   const discoverySuppress = getFieldValue(mappingDetails, 'discoverySuppress', 'booleanFieldAction');
   const staffSuppress = getFieldValue(mappingDetails, 'staffSuppress', 'booleanFieldAction');
@@ -101,7 +101,7 @@ export const AdministrativeData = ({ mappingDetails }) => {
         >
           <KeyValue
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.administrationData.field.hrid`} />}
-            value={instanceHrid || prohibitionIconElement}
+            value={instanceHrid || prohibitionIconElement('instance-hrid')}
           />
         </Col>
         <Col
@@ -110,7 +110,7 @@ export const AdministrativeData = ({ mappingDetails }) => {
         >
           <KeyValue
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.administrationData.field.source`} />}
-            value={metadataSource || prohibitionIconElement}
+            value={metadataSource || prohibitionIconElement('instance-source')}
           />
         </Col>
       </Row>
@@ -143,7 +143,7 @@ export const AdministrativeData = ({ mappingDetails }) => {
         >
           <KeyValue
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.administrationData.field.modeOfIssuanceId`} />}
-            value={modeOfIssuance || prohibitionIconElement}
+            value={modeOfIssuance || prohibitionIconElement('instance-mode-of-issuance-id')}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/Classification.js
+++ b/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/Classification.js
@@ -20,7 +20,7 @@ import { TRANSLATION_ID_PREFIX } from '../../constants';
 import { mappingProfileFieldShape } from '../../../../../utils';
 
 export const Classification = ({ mappingDetails }) => {
-  const prohibitionIconElement = <ProhibitionIcon />;
+  const prohibitionIconElement = fieldName => <ProhibitionIcon fieldName={fieldName} />;
 
   const classifications = getFieldValue(mappingDetails, 'classifications', 'subfields');
 
@@ -34,8 +34,8 @@ export const Classification = ({ mappingDetails }) => {
     ),
   };
   const classificationsFormatter = {
-    classificationTypeId: x => x?.classificationTypeId || prohibitionIconElement,
-    classificationNumber: x => x?.classificationNumber || prohibitionIconElement,
+    classificationTypeId: x => x?.classificationTypeId || prohibitionIconElement('classification-type-id'),
+    classificationNumber: x => x?.classificationNumber || prohibitionIconElement('classification-number'),
   };
   const classificationsFieldsMap = [
     {

--- a/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/Contributor.js
+++ b/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/Contributor.js
@@ -24,7 +24,7 @@ import { mappingProfileFieldShape } from '../../../../../utils';
 import css from '../../../MappingProfiles.css';
 
 export const Contributor = ({ mappingDetails }) => {
-  const prohibitionIconElement = <ProhibitionIcon />;
+  const prohibitionIconElement = fieldName => <ProhibitionIcon fieldName={fieldName} />;
 
   const contributors = getFieldValue(mappingDetails, 'contributors', 'subfields');
 
@@ -48,14 +48,14 @@ export const Contributor = ({ mappingDetails }) => {
     ),
   };
   const contributorsFormatter = {
-    contributorName: x => x?.contributorName || prohibitionIconElement,
-    contributorNameTypeId: x => x?.contributorNameTypeId || prohibitionIconElement,
-    contributorTypeId: x => x?.contributorTypeId || prohibitionIconElement,
-    contributorTypeText: x => x?.contributorTypeText || prohibitionIconElement,
+    contributorName: x => x?.contributorName || prohibitionIconElement('contributor-name'),
+    contributorNameTypeId: x => x?.contributorNameTypeId || prohibitionIconElement('contributor-name-type-id'),
+    contributorTypeId: x => x?.contributorTypeId || prohibitionIconElement('contributor-type-id'),
+    contributorTypeText: x => x?.contributorTypeText || prohibitionIconElement('contributor-type-text'),
     primary: x => {
       const primaryLabelId = getBooleanLabelId(x?.primary);
 
-      return getUnmappableValueById(primaryLabelId);
+      return getUnmappableValueById(primaryLabelId, 'contributor-primary');
     },
   };
   const contributorsFieldsMap = [

--- a/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/DescriptiveData.js
+++ b/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/DescriptiveData.js
@@ -26,7 +26,7 @@ import css from '../../../MappingProfiles.css';
 
 export const DescriptiveData = ({ mappingDetails }) => {
   const noValueElement = <NoValue />;
-  const prohibitionIconElement = <ProhibitionIcon />;
+  const prohibitionIconElement = fieldName => <ProhibitionIcon fieldName={fieldName} />;
 
   const publications = getFieldValue(mappingDetails, 'publication', 'subfields');
   const editions = getFieldValue(mappingDetails, 'editions', 'subfields');
@@ -56,10 +56,10 @@ export const DescriptiveData = ({ mappingDetails }) => {
     ),
   };
   const publicationsFormatter = {
-    publisher: x => x?.publisher || prohibitionIconElement,
-    role: x => x?.role || prohibitionIconElement,
-    place: x => x?.place || prohibitionIconElement,
-    dateOfPublication: x => x?.dateOfPublication || prohibitionIconElement,
+    publisher: x => x?.publisher || prohibitionIconElement('publication-publisher'),
+    role: x => x?.role || prohibitionIconElement('publication-role'),
+    place: x => x?.place || prohibitionIconElement('publication-place'),
+    dateOfPublication: x => x?.dateOfPublication || prohibitionIconElement('publication-date-of-publication'),
   };
   const publicationsFieldsMap = [
     {
@@ -84,7 +84,7 @@ export const DescriptiveData = ({ mappingDetails }) => {
       <FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.edition`} />
     ),
   };
-  const editionsFormatter = { edition: x => x?.edition || prohibitionIconElement };
+  const editionsFormatter = { edition: x => x?.edition || prohibitionIconElement('edition') };
   const editionsFieldsMap = [
     {
       field: 'edition',
@@ -99,7 +99,7 @@ export const DescriptiveData = ({ mappingDetails }) => {
       <FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.physicalDescription`} />
     ),
   };
-  const physicalDescriptionsFormatter = { physicalDescription: x => x?.physicalDescription || prohibitionIconElement };
+  const physicalDescriptionsFormatter = { physicalDescription: x => x?.physicalDescription || prohibitionIconElement('physical-description') };
   const physicalDescriptionsFieldsMap = [
     {
       field: 'physicalDescription',
@@ -129,7 +129,7 @@ export const DescriptiveData = ({ mappingDetails }) => {
       <FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.instanceFormatId`} />
     ),
   };
-  const formatsFormatter = { instanceFormatId: x => x?.instanceFormatId || prohibitionIconElement };
+  const formatsFormatter = { instanceFormatId: x => x?.instanceFormatId || prohibitionIconElement('instance-format-id') };
   const formatsFieldsMap = [
     {
       field: 'instanceFormatId',
@@ -144,7 +144,7 @@ export const DescriptiveData = ({ mappingDetails }) => {
       <FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.languageId`} />
     ),
   };
-  const languagesFormatter = { languageId: x => x?.languageId || prohibitionIconElement };
+  const languagesFormatter = { languageId: x => x?.languageId || prohibitionIconElement('language-id') };
   const languagesFieldsMap = [
     {
       field: 'languageId',
@@ -159,7 +159,7 @@ export const DescriptiveData = ({ mappingDetails }) => {
       <FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.publicationFrequency`} />
     ),
   };
-  const publicationFrequenciesFormatter = { publicationFrequency: x => x?.publicationFrequency || prohibitionIconElement };
+  const publicationFrequenciesFormatter = { publicationFrequency: x => x?.publicationFrequency || prohibitionIconElement('publication-frequency') };
   const publicationFrequenciesFieldsMap = [
     {
       field: 'publicationFrequency',
@@ -174,7 +174,7 @@ export const DescriptiveData = ({ mappingDetails }) => {
       <FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.publicationRange`} />
     ),
   };
-  const publicationRangeFormatter = { publicationRange: x => x?.publicationRange || prohibitionIconElement };
+  const publicationRangeFormatter = { publicationRange: x => x?.publicationRange || prohibitionIconElement('publication-range') };
   const publicationRangeFieldsMap = [
     {
       field: 'publicationRange',
@@ -243,7 +243,7 @@ export const DescriptiveData = ({ mappingDetails }) => {
         >
           <KeyValue
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.instanceTypeId`} />}
-            value={resourceType || prohibitionIconElement}
+            value={resourceType || prohibitionIconElement('resource-type')}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/ElectronicAccess.js
+++ b/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/ElectronicAccess.js
@@ -22,7 +22,7 @@ import { mappingProfileFieldShape } from '../../../../../utils';
 import css from '../../../MappingProfiles.css';
 
 export const ElectronicAccess = ({ mappingDetails }) => {
-  const prohibitionIconElement = <ProhibitionIcon />;
+  const prohibitionIconElement = fieldName => <ProhibitionIcon fieldName={fieldName} />;
 
   const electronicAccess = getFieldValue(mappingDetails, 'electronicAccess', 'subfields');
 
@@ -45,11 +45,11 @@ export const ElectronicAccess = ({ mappingDetails }) => {
     ),
   };
   const electronicAccessFormatter = {
-    relationshipId: x => x?.relationshipId || prohibitionIconElement,
-    uri: x => x?.uri || prohibitionIconElement,
-    linkText: x => x?.linkText || prohibitionIconElement,
-    materialsSpecification: x => x?.materialsSpecification || prohibitionIconElement,
-    publicNote: x => x?.publicNote || prohibitionIconElement,
+    relationshipId: x => x?.relationshipId || prohibitionIconElement('electronic-access-relationship-id'),
+    uri: x => x?.uri || prohibitionIconElement('electronic-access-uri'),
+    linkText: x => x?.linkText || prohibitionIconElement('electronic-access-link-text'),
+    materialsSpecification: x => x?.materialsSpecification || prohibitionIconElement('electronic-materials-specification'),
+    publicNote: x => x?.publicNote || prohibitionIconElement('electronic-public-note'),
   };
   const electronicAccessFieldsMap = [
     {

--- a/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/Identifier.js
+++ b/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/Identifier.js
@@ -22,7 +22,7 @@ import { mappingProfileFieldShape } from '../../../../../utils';
 import css from '../../../MappingProfiles.css';
 
 export const Identifier = ({ mappingDetails }) => {
-  const prohibitionIconElement = <ProhibitionIcon />;
+  const prohibitionIconElement = fieldName => <ProhibitionIcon fieldName={fieldName} />;
 
   const identifiers = getFieldValue(mappingDetails, 'identifiers', 'subfields');
 
@@ -36,8 +36,8 @@ export const Identifier = ({ mappingDetails }) => {
     ),
   };
   const identifiersFormatter = {
-    identifierTypeId: x => x?.identifierTypeId || prohibitionIconElement,
-    value: x => x?.value || prohibitionIconElement,
+    identifierTypeId: x => x?.identifierTypeId || prohibitionIconElement('identifier-type-id'),
+    value: x => x?.value || prohibitionIconElement('identifier-value'),
   };
   const identifiersFieldsMap = [
     {

--- a/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/InstanceNotes.js
+++ b/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/InstanceNotes.js
@@ -23,7 +23,7 @@ import { mappingProfileFieldShape } from '../../../../../utils';
 import css from '../../../MappingProfiles.css';
 
 export const InstanceNotes = ({ mappingDetails }) => {
-  const prohibitionIconElement = <ProhibitionIcon />;
+  const prohibitionIconElement = fieldName => <ProhibitionIcon fieldName={fieldName} />;
 
   const notes = getFieldValue(mappingDetails, 'notes', 'subfields');
 
@@ -40,12 +40,12 @@ export const InstanceNotes = ({ mappingDetails }) => {
     ),
   };
   const notesFormatter = {
-    noteType: x => x?.noteType || prohibitionIconElement,
-    note: x => x?.note || prohibitionIconElement,
+    noteType: x => x?.noteType || prohibitionIconElement('notes-note-type'),
+    note: x => x?.note || prohibitionIconElement('notes-note'),
     staffOnly: x => {
       const staffOnlyLabelId = getBooleanLabelId(x?.staffOnly);
 
-      return getUnmappableValueById(staffOnlyLabelId);
+      return getUnmappableValueById(staffOnlyLabelId, 'notes-staff-only');
     },
   };
   const notesFieldsMap = [

--- a/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/Subject.js
+++ b/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/Subject.js
@@ -20,7 +20,7 @@ import { TRANSLATION_ID_PREFIX } from '../../constants';
 import { mappingProfileFieldShape } from '../../../../../utils';
 
 export const Subject = ({ mappingDetails }) => {
-  const prohibitionIconElement = <ProhibitionIcon />;
+  const prohibitionIconElement = fieldName => <ProhibitionIcon fieldName={fieldName} />;
 
   const subjects = getFieldValue(mappingDetails, 'subjects', 'subfields');
 
@@ -30,7 +30,7 @@ export const Subject = ({ mappingDetails }) => {
       <FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.descriptiveData.field.subjects`} />
     ),
   };
-  const subjectsFormatter = { subject: x => x?.noteType || prohibitionIconElement };
+  const subjectsFormatter = { subject: x => x?.noteType || prohibitionIconElement('subject-note-type') };
   const subjectsFieldsMap = [
     {
       field: 'subject',

--- a/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/TitleData.js
+++ b/src/settings/MappingProfiles/detailsSections/view/InstanceDetailsSection/TitleData.js
@@ -23,7 +23,7 @@ import { mappingProfileFieldShape } from '../../../../../utils';
 import css from '../../../MappingProfiles.css';
 
 export const TitleData = ({ mappingDetails }) => {
-  const prohibitionIconElement = <ProhibitionIcon />;
+  const prohibitionIconElement = fieldName => <ProhibitionIcon fieldName={fieldName} />;
 
   const resourceTitle = getFieldValue(mappingDetails, 'title', 'value');
   const alternativeTitles = getFieldValue(mappingDetails, 'alternativeTitles', 'subfields');
@@ -42,8 +42,8 @@ export const TitleData = ({ mappingDetails }) => {
     ),
   };
   const alternativeTitlesFormatter = {
-    alternativeTitleTypeId: x => x?.alternativeTitleTypeId || prohibitionIconElement,
-    alternativeTitle: x => x?.alternativeTitle || prohibitionIconElement,
+    alternativeTitleTypeId: x => x?.alternativeTitleTypeId || prohibitionIconElement('alternative-title-type-id'),
+    alternativeTitle: x => x?.alternativeTitle || prohibitionIconElement('alternative-title'),
   };
   const alternativeTitlesFieldsMap = [
     {
@@ -62,7 +62,7 @@ export const TitleData = ({ mappingDetails }) => {
       <FormattedMessage id={`${TRANSLATION_ID_PREFIX}.titleData.series.field.series`} />
     ),
   };
-  const seriesStatementsFormatter = { source: x => x?.source || prohibitionIconElement };
+  const seriesStatementsFormatter = { source: x => x?.source || prohibitionIconElement('series-statements-source') };
   const seriesStatementsFieldsMap = [
     {
       field: 'source',
@@ -88,10 +88,10 @@ export const TitleData = ({ mappingDetails }) => {
     ),
   };
   const precedingTitlesFormatter = {
-    precedingTitlesTitle: x => x?.precedingTitlesTitle || prohibitionIconElement,
-    precedingTitlesHrid: x => x?.precedingTitlesHrid || prohibitionIconElement,
-    precedingTitlesIsbn: x => x?.precedingTitlesIsbn || prohibitionIconElement,
-    precedingTitlesIssn: x => x?.precedingTitlesIssn || prohibitionIconElement,
+    precedingTitlesTitle: x => x?.precedingTitlesTitle || prohibitionIconElement('preceding-titles-title'),
+    precedingTitlesHrid: x => x?.precedingTitlesHrid || prohibitionIconElement('preceding-titles-hrid'),
+    precedingTitlesIsbn: x => x?.precedingTitlesIsbn || prohibitionIconElement('preceding-titles-isbn'),
+    precedingTitlesIssn: x => x?.precedingTitlesIssn || prohibitionIconElement('preceding-titles-issn'),
   };
   const precedingTitlesFieldsMap = [
     {
@@ -127,10 +127,10 @@ export const TitleData = ({ mappingDetails }) => {
     ),
   };
   const succeedingTitlesFormatter = {
-    succeedingTitlesTitle: x => x?.succeedingTitlesTitle || prohibitionIconElement,
-    succeedingTitlesHrid: x => x?.succeedingTitlesHrid || prohibitionIconElement,
-    succeedingTitlesIsbn: x => x?.succeedingTitlesIsbn || prohibitionIconElement,
-    succeedingTitlesIssn: x => x?.succeedingTitlesIssn || prohibitionIconElement,
+    succeedingTitlesTitle: x => x?.succeedingTitlesTitle || prohibitionIconElement('succeeding-titles-title'),
+    succeedingTitlesHrid: x => x?.succeedingTitlesHrid || prohibitionIconElement('succeeding-titles-hrid'),
+    succeedingTitlesIsbn: x => x?.succeedingTitlesIsbn || prohibitionIconElement('succeeding-titles-isbn'),
+    succeedingTitlesIssn: x => x?.succeedingTitlesIssn || prohibitionIconElement('succeeding-titles-issn'),
   };
   const succeedingTitlesFieldsMap = [
     {
@@ -161,7 +161,7 @@ export const TitleData = ({ mappingDetails }) => {
         >
           <KeyValue
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.titleData.field.title`} />}
-            value={resourceTitle || prohibitionIconElement}
+            value={resourceTitle || prohibitionIconElement('title-data-resource-title')}
           />
         </Col>
       </Row>
@@ -189,7 +189,7 @@ export const TitleData = ({ mappingDetails }) => {
         >
           <KeyValue
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.titleData.field.indexTitle`} />}
-            value={indexTitle || prohibitionIconElement}
+            value={indexTitle || prohibitionIconElement('title-data-index-title')}
           />
         </Col>
       </Row>

--- a/src/settings/MappingProfiles/detailsSections/view/ItemDetailSection/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/view/ItemDetailSection/AdministrativeData.js
@@ -94,7 +94,7 @@ export const AdministrativeData = ({ mappingDetails }) => {
         >
           <KeyValue
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.item.administrativeData.field.hrid`} />}
-            value={itemHrid || <ProhibitionIcon />}
+            value={itemHrid || <ProhibitionIcon fieldName="administrative-data-hrid" />}
           />
         </Col>
         <Col

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -9,7 +9,6 @@
   "runningJobs": "Running",
   "noPreviewsJobsMessage": "No previews to show",
   "noRunningJobsMessage": "No running jobs to show",
-  "noValueAllowed": "No value allowed",
   "readyForPreview": "Ready for preview",
   "previewNow": "Preview now",
   "triggeredBy": "Triggered by {userName}",

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -467,6 +467,7 @@
   "settings.mappingProfiles.title": "Field mapping profiles",
   "settings.mappingProfiles.count": "{count, number} field mapping {count, plural, one {profile} other {profiles}}",
   "settings.mappingProfiles.new": "New field mapping profile",
+  "settings.mappingProfiles.canNotBeMapped": "Cannot be mapped",
   "settings.mappingProfiles.exceptionModal.label": "Cannot delete field mapping profile",
   "settings.mappingProfiles.exceptionModal.message": "This field mapping profile cannot be deleted, as it is in use by one or more action profiles.",
   "settings.mappingProfiles.map.wrapper.acceptedValues": "Accepted values",


### PR DESCRIPTION
## Purpose
To add hover text to the "cannot be mapped" icon, to help distinguish from the icon for not mapped

## Approach
1. Extend ProhibitionIcon component and getUnmappableValueById util function with receiving fieldName prop
2. Update all necessary calls of those functions.

## Tickets
[UIDATIMP-558](https://issues.folio.org/browse/UIDATIMP-558)

## Screenshot
![tooltip](https://user-images.githubusercontent.com/63101175/91154431-311d2f80-e6ca-11ea-8f11-f7cc64fb7809.gif)

