### PR TITLE
UIDATIMP-645: Validation function validateRequiredFields works incorrectly after latest update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)
+* Fix for validation function `validateRequiredFields` (UIDATIMP-645)
 
 ## [2.1.4](https://github.com/folio-org/ui-data-import/tree/v2.1.4) (2020-08-13)
 

--- a/src/settings/MARCFieldProtection/MARCFieldProtection.js
+++ b/src/settings/MARCFieldProtection/MARCFieldProtection.js
@@ -8,10 +8,7 @@ import {
 import { stripesConnect } from '@folio/stripes/core';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 
-import {
-  MARC_FIELD_PROTECTION_SOURCE,
-  validateRequiredField,
-} from '../../utils';
+import { MARC_FIELD_PROTECTION_SOURCE } from '../../utils';
 
 const validateField = value => {
   const checkFieldRange = () => {
@@ -39,12 +36,16 @@ const validateSubfield = (subfieldValue, fieldValue) => {
   let pattern = /^[*\w]$/;
   let errorMessage = <FormattedMessage id="ui-data-import.validation.enterAsteriskOrAlphanumeric" />;
 
-  if (fieldValue === '*') {
+  if (!subfieldValue) {
+    errorMessage = <FormattedMessage id="stripes-core.label.missingRequiredField" />;
+  }
+
+  if (subfieldValue && fieldValue === '*') {
     pattern = /^\w$/;
     errorMessage = <FormattedMessage id="ui-data-import.validation.valueType" />;
   }
 
-  if (!subfieldValue || subfieldValue.match(pattern)) {
+  if (subfieldValue.match(pattern)) {
     return null;
   }
 
@@ -76,17 +77,13 @@ export class MARCFieldProtection extends Component {
 
   suppressDelete = ({ source }) => source === MARC_FIELD_PROTECTION_SOURCE.SYSTEM.value;
 
-  validateFields = item => {
-    const requiredFieldErrorMessage = <FormattedMessage id="stripes-core.label.missingRequiredField" />;
-
-    return {
-      field: validateField(item.field),
-      indicator1: validateAlphanumeric(item.indicator1),
-      indicator2: validateAlphanumeric(item.indicator2),
-      subfield: validateRequiredField(item.subfield, requiredFieldErrorMessage) || validateSubfield(item.subfield, item.field),
-      data: validateData(item.data),
-    };
-  };
+  validateFields = item => ({
+    field: validateField(item.field),
+    indicator1: validateAlphanumeric(item.indicator1),
+    indicator2: validateAlphanumeric(item.indicator2),
+    subfield: validateSubfield(item.subfield, item.field),
+    data: validateData(item.data),
+  });
 
   render() {
     const {

--- a/src/utils/formValidators.js
+++ b/src/utils/formValidators.js
@@ -13,14 +13,14 @@ const REMOVE_OPTION_VALUE = '###REMOVE###';
  * @param {string|Object} [errorMessage] Validation error message
  * @return {null|*} Validation message
  */
-export const validateRequiredField = (value, errorMessage) => {
+export const validateRequiredField = value => {
   const isValid = !isEmpty(value);
 
   if (isValid) {
     return null;
   }
 
-  return errorMessage || <FormattedMessage id="ui-data-import.validation.enterValue" />;
+  return <FormattedMessage id="ui-data-import.validation.enterValue" />;
 };
 
 /**


### PR DESCRIPTION
## Purpose
To fix `validateRequiredFields` function

## Approach
- Update validation for subfield field for `MARCFieldProtection` component
- revert changes for common `validateRequiredFields` function

## Tickets
[UIDATIMP-645](https://issues.folio.org/browse/UIDATIMP-645)
