### PR TITLE
UIDATIMP-614: MARC Bib field mapping profile: details for Update Selected fields on View screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Update react-intl to v5 (UIDATIMP-643)
 * Relocate the file upload area on the Data Import landing page (UIDATIMP-633)
 * Sync with DTO updates. Modifying or updating the SRS MARC record (UIDATIMP-620)
+* MARC Bib field mapping profile: details for Update Selected fields on View screen (UIDATIMP-614)
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)

--- a/src/components/MARCTableView/MARCTableView.js
+++ b/src/components/MARCTableView/MARCTableView.js
@@ -8,10 +8,10 @@ import css from '../MARCTable/MARCTable.css';
 
 import { mappingMARCFieldShape } from '../../utils';
 
-export const MARCTableView = ({ fields }) => {
-  const columns = ['action', 'field', 'indicator1', 'indicator2',
-    'subfield', 'subaction', 'data', 'position'];
-
+export const MARCTableView = ({
+  columns,
+  fields,
+}) => {
   const columnWidths = {
     action: '90px',
     field: '90px',
@@ -33,6 +33,7 @@ export const MARCTableView = ({ fields }) => {
         columnWidths={columnWidths}
       />
       <MARCTableViewRowContainer
+        columns={columns}
         fields={fields}
         columnWidths={columnWidths}
       />
@@ -40,4 +41,7 @@ export const MARCTableView = ({ fields }) => {
   );
 };
 
-MARCTableView.propTypes = { fields: PropTypes.arrayOf(mappingMARCFieldShape.isRequired).isRequired };
+MARCTableView.propTypes = {
+  fields: PropTypes.arrayOf(mappingMARCFieldShape.isRequired).isRequired,
+  columns: PropTypes.arrayOf(PropTypes.string).isRequired,
+};

--- a/src/components/MARCTableView/MARCTableViewRow.js
+++ b/src/components/MARCTableView/MARCTableViewRow.js
@@ -4,6 +4,8 @@ import { FormattedMessage } from 'react-intl';
 
 import { isEmpty } from 'lodash';
 
+import { NoValue } from '@folio/stripes/components';
+
 import {
   MAPPING_DETAILS_ACTIONS,
   MAPPING_DETAILS_SUBACTIONS,
@@ -11,6 +13,7 @@ import {
   SUBACTION_OPTIONS,
   POSITION_OPTIONS,
   mappingMARCViewFieldShape,
+  getTrimmedValue,
 } from '../../utils';
 
 import css from '../MARCTable/MARCTable.css';
@@ -36,8 +39,14 @@ export const MARCTableViewRow = ({
     subaction,
   } = rowData;
 
+  const getCellValue = value => {
+    const formattedValue = getTrimmedValue(value);
+
+    return !isEmpty(formattedValue) ? formattedValue : <NoValue />;
+  };
+
   const renderCell = (key, i) => {
-    const cellData = rowData[key];
+    const cellData = getCellValue(rowData[key]);
     const cellStyle = { width: columnWidths[key] };
 
     const getCellContent = () => {
@@ -158,7 +167,7 @@ export const MARCTableViewRow = ({
         className={css.tableCell}
         style={cellStyle}
       >
-        {!isEmpty(cellData) && getCellContent()}
+        {getCellContent()}
       </div>
     );
   };

--- a/src/components/MARCTableView/MARCTableViewRowContainer.js
+++ b/src/components/MARCTableView/MARCTableViewRowContainer.js
@@ -8,6 +8,7 @@ import { mappingMARCFieldShape } from '../../utils';
 import css from '../MARCTable/MARCTable.css';
 
 export const MARCTableViewRowContainer = ({
+  columns,
   fields,
   columnWidths,
 }) => {
@@ -15,16 +16,23 @@ export const MARCTableViewRowContainer = ({
     const subfieldsData = data.field?.subfields;
     const containsSubsequentLines = subfieldsData?.length > 1;
 
-    const getRowData = index => ({
-      action: data.action,
-      field: data.field?.field,
-      indicator1: data.field?.indicator1,
-      indicator2: data.field?.indicator2,
-      subfield: subfieldsData?.[index].subfield,
-      subaction: subfieldsData?.[index].subaction,
-      data: subfieldsData?.[index].data,
-      position: subfieldsData?.[index].position,
-    });
+    const getRowData = index => {
+      const rowData = {
+        action: data.action,
+        field: data.field?.field,
+        indicator1: data.field?.indicator1,
+        indicator2: data.field?.indicator2,
+        subfield: subfieldsData?.[index].subfield,
+        subaction: subfieldsData?.[index].subaction,
+        data: subfieldsData?.[index].data,
+        position: subfieldsData?.[index].position,
+      };
+
+      return columns.reduce((acc, column) => ({
+        ...acc,
+        [column]: rowData[column],
+      }), {});
+    };
 
     return (
       <div
@@ -58,6 +66,7 @@ export const MARCTableViewRowContainer = ({
 };
 
 MARCTableViewRowContainer.propTypes = {
+  columns: PropTypes.arrayOf(PropTypes.string).isRequired,
   fields: PropTypes.arrayOf(mappingMARCFieldShape.isRequired).isRequired,
   columnWidths: PropTypes.object.isRequired,
 };

--- a/src/components/MatchCriterion/view/MARCFieldSection/MARCFieldSection.js
+++ b/src/components/MatchCriterion/view/MARCFieldSection/MARCFieldSection.js
@@ -10,6 +10,8 @@ import {
   NoValue,
 } from '@folio/stripes/components';
 
+import { getTrimmedValue } from '../../../../utils';
+
 import { Section } from '../../..';
 
 import css from '../ViewMatchCriterion.css';
@@ -21,7 +23,7 @@ export const MARCFieldSection = ({
 }) => {
   const getValue = fieldName => {
     const value = expressionDetails.fields?.find(field => field.label === fieldName)?.value;
-    const formattedValue = value && value.trim ? value.trim() : value;
+    const formattedValue = getTrimmedValue(value);
 
     return formattedValue || <NoValue />;
   };

--- a/src/settings/MappingProfiles/ViewMappingProfile.js
+++ b/src/settings/MappingProfiles/ViewMappingProfile.js
@@ -54,6 +54,8 @@ import {
   getEntity,
   getEntityTags,
   MARC_TYPES,
+  FIELD_MAPPINGS_FOR_MARC,
+  FIELD_MAPPINGS_FOR_MARC_OPTIONS,
 } from '../../utils';
 
 import sharedCss from '../../shared.css';
@@ -205,6 +207,7 @@ export class ViewMappingProfile extends Component {
       incomingRecordType,
       existingRecordType,
       mappingDetails,
+      mappingDetails: { marcMappingOption },
     } = mappingProfile;
 
     const associations = [
@@ -214,11 +217,26 @@ export class ViewMappingProfile extends Component {
 
     const isMARCRecord = existingRecordType === MARC_TYPES.MARC_BIBLIOGRAPHIC;
 
+    const renderMARCTableView = () => {
+      const defaultFieldMappingForMARCColumns = ['action', 'field', 'indicator1', 'indicator2',
+        'subfield', 'subaction', 'data', 'position'];
+      const updatesFieldMappingForMARCColumns = ['field', 'indicator1', 'indicator2', 'subfield'];
+
+      const fieldMappingForMARCColumns = { [FIELD_MAPPINGS_FOR_MARC.UPDATES]: updatesFieldMappingForMARCColumns };
+
+      return (
+        <MARCTableView
+          columns={fieldMappingForMARCColumns[marcMappingOption] || defaultFieldMappingForMARCColumns}
+          fields={mappingDetails?.marcMappingDetails}
+        />
+      );
+    };
+
     const renderDetails = {
       INSTANCE: <MappingInstanceDetails mappingDetails={mappingDetails?.mappingFields} />,
       HOLDINGS: <MappingHoldingsDetails mappingDetails={mappingDetails?.mappingFields} />,
       ITEM: <MappingItemDetails mappingDetails={mappingDetails?.mappingFields} />,
-      MARC_BIBLIOGRAPHIC: <MARCTableView fields={mappingDetails?.marcMappingDetails} />,
+      MARC_BIBLIOGRAPHIC: renderMARCTableView(),
     };
 
     return (
@@ -288,6 +306,7 @@ export class ViewMappingProfile extends Component {
                     <MappedHeader
                       mappedLabelId="ui-data-import.settings.profiles.select.mappingProfiles"
                       mappableLabelId={MAPPING_DETAILS_HEADLINE[existingRecordType]?.labelId}
+                      mappingTypeLabelId={FIELD_MAPPINGS_FOR_MARC_OPTIONS.find(option => option.value === marcMappingOption)?.label}
                       headlineProps={{ margin: 'small' }}
                     />
                   </Col>

--- a/src/utils/formValidators.js
+++ b/src/utils/formValidators.js
@@ -4,6 +4,8 @@ import { FormattedMessage } from 'react-intl';
 
 import { isEmpty } from 'lodash';
 
+import { getTrimmedValue } from '.';
+
 const REMOVE_OPTION_VALUE = '###REMOVE###';
 
 /**
@@ -79,7 +81,7 @@ export const validateFileExtension = value => {
  */
 export const validateAlphanumericOrAllowedValue = (value, allowedValue) => {
   const pattern = /^[a-zA-Z0-9]*$/;
-  const val = value && value.trim ? value.trim() : value;
+  const val = getTrimmedValue(value);
 
   if (isEmpty(val) || val === allowedValue || val.match(pattern)) {
     return null;
@@ -89,7 +91,7 @@ export const validateAlphanumericOrAllowedValue = (value, allowedValue) => {
 };
 
 export const validateValueLength = (value, maxLength) => {
-  const val = value && value.trim ? value.trim() : value;
+  const val = getTrimmedValue(value);
 
   if (!val || !val.length || val.length <= maxLength) {
     return null;
@@ -191,7 +193,7 @@ export const validateMARCWithDate = (value, isRemoveValueProhibited) => {
 };
 
 export const validateRepeatableActionsField = (value, hasFields) => {
-  const val = value && value.trim ? value.trim() : value;
+  const val = getTrimmedValue(value);
 
   if (!isEmpty(val) && !hasFields) {
     return <FormattedMessage id="ui-data-import.validation.chooseAtLeastOneValue" />;

--- a/src/utils/getTrimmedValue.js
+++ b/src/utils/getTrimmedValue.js
@@ -1,0 +1,3 @@
+export const getTrimmedValue = value => (
+  value && value.trim ? value.trim() : value
+);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -33,3 +33,4 @@ export * from './useForceUpdate';
 export * from './getDecoratorValue';
 export * from './updateValueWithTemplate';
 export * from './fillEmptyFieldsWithValue';
+export * from './getTrimmedValue';


### PR DESCRIPTION
## Purpose
To indicate that only certain fields in an SRS MARC record should be updated, instead of replacing the entire record, when a user is importing

## Approach
* Update logic of rendering cells in row to depend on passed headings
* Add `renderMARCTableView` method to `ViewMappingProfile` component
* Add `getCellValue` method to `MARCTableViewRow` component

## Ticket
[UIDATIMP-614](https://issues.folio.org/browse/UIDATIMP-614)

## Screenshot

![image](https://user-images.githubusercontent.com/40805351/92597428-0c22e200-f2b0-11ea-8243-cc6464908364.png)




