### PR TITLE
UIDATIMP-625: MARC Bib field mapping profile: add option for Modify o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Handle import of stripes-acq-components to modules and platform (UISACQCOMP-3)
 * Add validation rules for Move action for the MARC modifications table fields (UIDATIMP-492)
 * Add validation rules for Edit action for the MARC modifications table fields (UIDATIMP-489)
-* Increment `@folio/stripes` to `v5` and update dependency on `react-router`.
+* Increment `@folio/stripes` to `v5` and update dependency on `react-router` (UIDATIMP-656)
 * Reuse `<EndOfItem>` component from `stripes-data-transfer-components` repository (UIDATIMP-571)
 * Fix field mapping for Item record check in/check out note (UIDATIMP-554)
 * Field mappings: Repeatable field dropdown Validation (UIDATIMP-508)
@@ -43,6 +43,7 @@
 * Add column for Job status and Resequence columns (UIDATIMP-615)
 * Match Profiles: Remove EDIFACT invoice as a match option (UIDATIMP-353)
 * Add Public/Staff field for Holdings Statement Notes (UIDATIMP-642)
+* MARC Bib field mapping profile: add option for Modify or Update to View screen (UIDATIMP-625)
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)

--- a/src/settings/MappingProfiles/ViewMappingProfile.js
+++ b/src/settings/MappingProfiles/ViewMappingProfile.js
@@ -217,6 +217,8 @@ export class ViewMappingProfile extends Component {
 
     const isMARCRecord = existingRecordType === MARC_TYPES.MARC_BIBLIOGRAPHIC;
 
+    const marcMappingOptionLabel = FIELD_MAPPINGS_FOR_MARC_OPTIONS.find(option => option.value === marcMappingOption)?.label;
+
     const renderMARCTableView = () => {
       const defaultFieldMappingForMARCColumns = ['action', 'field', 'indicator1', 'indicator2',
         'subfield', 'subaction', 'data', 'position'];
@@ -280,6 +282,13 @@ export class ViewMappingProfile extends Component {
                 <FormattedMessage id={FOLIO_RECORD_TYPES[existingRecordType].captionId} />
               </div>
             </KeyValue>
+            {isMARCRecord && (
+              <KeyValue label={<FormattedMessage id="ui-data-import.fieldMappingsForMarc" />}>
+                <div data-test-field-mapping-for-marc-field>
+                  <FormattedMessage id={marcMappingOptionLabel} />
+                </div>
+              </KeyValue>
+            )}
             <KeyValue label={<FormattedMessage id="ui-data-import.description" />}>
               <div data-test-description>{mappingProfile.description || <NoValue />}</div>
             </KeyValue>
@@ -306,7 +315,7 @@ export class ViewMappingProfile extends Component {
                     <MappedHeader
                       mappedLabelId="ui-data-import.settings.profiles.select.mappingProfiles"
                       mappableLabelId={MAPPING_DETAILS_HEADLINE[existingRecordType]?.labelId}
-                      mappingTypeLabelId={FIELD_MAPPINGS_FOR_MARC_OPTIONS.find(option => option.value === marcMappingOption)?.label}
+                      mappingTypeLabelId={marcMappingOptionLabel}
                       headlineProps={{ margin: 'small' }}
                     />
                   </Col>


### PR DESCRIPTION
## Purpose
To show different field mappings based on whether the user is modifying or updating the SRS MARC record

## Approach
- Add `Field mappings for MARC` field to view mapping profile screen
- Determination of field mappings option has been moved to 'marcMappingOptionLabel' constant

## Ticket
[UIDATIMP-625](https://issues.folio.org/browse/UIDATIMP-625)

## Screenshots
![updates](https://user-images.githubusercontent.com/63101175/93570458-b5966180-f99b-11ea-9a1c-f276999ae07a.png)
