### PR TITLE
UIDATIMP-667: Fix `SyntaxError: Unexpected token 'export'` error when running unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)
 * Fix for validation function `validateRequiredFields` (UIDATIMP-645)
+* Fix `SyntaxError: Unexpected token 'export'` error when running tests (UIDATIMP-667)
 
 ## [2.1.4](https://github.com/folio-org/ui-data-import/tree/v2.1.4) (2020-08-13)
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
   coverageReporters: ['lcov'],
   reporters: ['jest-junit', 'default'],
   transform: { '^.+\\.(js|jsx)$': path.join(__dirname, './test/jest/jest-transformer.js') },
-  transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
+  transformIgnorePatterns: [`/node_modules/(?!${esModules}|ky)`],
   moduleNameMapper: {
     '^.+\\.(css)$': 'identity-obj-proxy',
     '^.+\\.(svg)$': 'identity-obj-proxy',


### PR DESCRIPTION
## Description
When running unit tests there is an error. This is caused because a file with the error is not being correctly transpiled, so jest cannot interpret it properly.
```
/home/jenkins/workspace/folio-org_ui-data-import_PR-687/project/node_modules/ky/index.js:523
    export default createInstance();
    ^^^^^^

    SyntaxError: Unexpected token 'export'
        at compileFunction (<anonymous>)

      2 | 
      3 | jest.mock('@folio/stripes/core', () => ({
    > 4 |   ...jest.requireActual('@folio/stripes/core'),
        |           ^
      5 |   stripesConnect: Component => props => <Component {...props} />,
      6 | 
      7 |   Pluggable: props => <>{props.children}</>,

      at Runtime._execModule (node_modules/jest-runtime/build/index.js:1179:56)
      at Object.<anonymous> (node_modules/@folio/stripes-core/src/useOkapiKy.js:1:1)
      at Object.<anonymous> (node_modules/@folio/stripes-core/index.js:12:1)
      at Object.<anonymous> (node_modules/@folio/stripes/core/index.js:1:1)
      at _getJestObj.mock.virtual (test/jest/__mock__/stripesCore.mock.js:4:11)
      at Object.<anonymous> (src/utils/generateSettingsLabel.js:4:1)
      at Object.<anonymous> (src/utils/index.js:22:1)
      at Object.<anonymous> (src/components/MARCTable/MARCTableRow.js:25:1)
      at Object.<anonymous> (src/components/MARCTable/MARCTableRow.test.js:8:1)
```

## Approach
Add a path to the file with the error to `transformIgnorePatterns` in `jest.config.js`

## Ticket
[UIDATIMP-667](https://issues.folio.org/browse/UIDATIMP-667)