### PR TITLE
Settings/Field mapping/MARC mods - "Position" in MCL View is not justified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)
 * Fix for validation function `validateRequiredFields` (UIDATIMP-645)
 * Fix `SyntaxError: Unexpected token 'export'` error when running tests (UIDATIMP-667)
+* Fix "Position" in MCL View is not left justified (UIDATIMP-657)
 
 ## [2.1.4](https://github.com/folio-org/ui-data-import/tree/v2.1.4) (2020-08-13)
 

--- a/src/components/MARCTable/MARCTable.js
+++ b/src/components/MARCTable/MARCTable.js
@@ -222,7 +222,7 @@ MARCTable.defaultProps = {
     indicator2: '93px',
     subfield: '93px',
     subaction: '140px',
-    data: '200px',
+    data: '340px',
     position: '140px',
     addRemove: '70px',
   },

--- a/src/components/MARCTableView/MARCTableView.js
+++ b/src/components/MARCTableView/MARCTableView.js
@@ -46,6 +46,6 @@ MARCTableView.defaultProps = {
     subfield: '93px',
     subaction: '140px',
     data: '340px',
-    position: '100px',
+    position: '140px',
   },
 };

--- a/src/components/MARCTableView/MARCTableViewRow.js
+++ b/src/components/MARCTableView/MARCTableViewRow.js
@@ -47,7 +47,10 @@ export const MARCTableViewRow = ({
 
   const renderCell = (key, i) => {
     const cellData = getCellValue(rowData[key]);
-    const cellStyle = { width: columnWidths[key] };
+    const cellStyle = {
+      width: columnWidths[key],
+      flexGrow: (key === 'data') && 1,
+    };
 
     const getCellContent = () => {
       const actionField = ACTION_OPTIONS.find(option => option.value === cellData);


### PR DESCRIPTION
## Description
Position in MCL View is not justified

## Approach
Fix styles

## Ticket
[UIDATIMP-657](https://issues.folio.org/browse/UIDATIMP-657)

## Screenshot
![image](https://user-images.githubusercontent.com/40805351/95082856-5dde5100-0724-11eb-9f3e-7d5a89df22ea.png)

