### PR TITLE
UIDATIMP-676: Match profile create-edit & view screens: change unusable options to disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * MARC Bib field mapping profile: details for Update-Overrides on View screen (UIDATIMP-632)
 * Change "Check in/out note" value to "Check in/out" for items (UIDATIMP-679)
 * Add capability to remove jobs that are stuck in "Running" area of Data Import landing page first pane (UIDATIMP-651)
+* Match profile create-edit & view screens: change unuseable options to disabled (UIDATIMP-676)
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)

--- a/src/components/RecordTypesSelect/RecordTypesSelect.css
+++ b/src/components/RecordTypesSelect/RecordTypesSelect.css
@@ -54,6 +54,13 @@
   background-color: color(var(--primary) whiteness(30%))
 }
 
+.disabledItem {
+  background-color: #ccc;
+  color: var(--color-text-p2);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 .headingCell {
   composes: display-flex centerContent from "@folio/stripes-components/lib/Layout/Layout.css";
   border-bottom: 1px solid var(--color-border);

--- a/src/components/RecordTypesSelect/components/RecordItem.js
+++ b/src/components/RecordTypesSelect/components/RecordItem.js
@@ -12,6 +12,8 @@ import classNames from 'classnames';
 import { Dropdown } from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes/core';
 
+import { FOLIO_RECORD_TYPES_TO_DISABLE } from '../../../utils';
+
 import { IncomingRecordMenu } from './IncomingRecordMenu';
 import { IncomingRecordTrigger } from './IncomingRecordTrigger';
 
@@ -56,13 +58,21 @@ export const RecordItem = memo(({
     />
   );
 
+  // TODO: Disabling options should be removed after implentation is done
+  const isOptionDisabled = FOLIO_RECORD_TYPES_TO_DISABLE.some(option => option === item.type);
+
   const initialButton = (
     <div // eslint-disable-line jsx-a11y/click-events-have-key-events
       data-test-record-item
       tabIndex="0"
       role="button"
       id={incomingRecord.type}
-      className={classNames(css.item, { [css.clickableItem]: isEditable }, className)}
+      className={classNames(
+        css.item,
+        { [css.clickableItem]: isEditable },
+        className,
+        isOptionDisabled && css.disabledItem,
+      )}
       style={style}
       ref={ref}
       onClick={() => (isEditable ? onClick(incomingRecord) : noop)}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -604,3 +604,7 @@ export const MARC_FIELD_PROTECTION_SOURCE = {
     labelId: 'ui-data-import.settings.marcFieldProtection.user',
   },
 };
+
+// TODO: Options to disable until functionality is not implemented.
+// Should be removed in the future
+export const FOLIO_RECORD_TYPES_TO_DISABLE = ['MARC_HOLDINGS', 'ORDER', 'INVOICE', 'MARC_AUTHORITY'];


### PR DESCRIPTION
## Purpose
To provide a visual cue for options that are not yet useable in the Job profile

## Approach
- Add array to `constants` with disabled Folio record types
- Add styles and functionality of disabling options in `RecordItem` component

## Ticket
[UIDATIMP-676](https://issues.folio.org/browse/UIDATIMP-676)

## Screenshot
![image](https://user-images.githubusercontent.com/40805351/95315990-e16e7e00-089b-11eb-8cc6-52c31db50e28.png)
![image](https://user-images.githubusercontent.com/40805351/95316042-f2b78a80-089b-11eb-8432-4a7fd56aebca.png)


