### PR TITLE
UIDATIMP-661: Render hyphen when MARC mapping details are empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * Add capability to remove jobs that are stuck in "Running" area of Data Import landing page first pane (UIDATIMP-651)
 * Match profile create-edit & view screens: change unuseable options to disabled (UIDATIMP-676)
 * MARC Bib field mapping profile: EXCEPTION details for Update Selected fields on Create/Edit screen (UIDATIMP-660)
+* MARC Bib field mapping profile: EXCEPTION details for Update Selected fields on View screen (UIDATIMP-661)
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)

--- a/src/settings/MappingProfiles/detailsSections/view/MappingMARCBibDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/view/MappingMARCBibDetails.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { isEmpty } from 'lodash';
+
+import { NoValue } from '@folio/stripes/components';
 
 import {
   MARCTableView,
@@ -24,12 +27,16 @@ export const MappingMARCBibDetails = ({
   const renderUpdatesDetails = () => {
     const updatesFieldMappingForMARCColumns = ['field', 'indicator1', 'indicator2', 'subfield'];
 
+    const renderMARCUpdatesTable = () => (
+      <MARCTableView
+        columns={updatesFieldMappingForMARCColumns}
+        fields={marcMappingDetails}
+      />
+    );
+
     return (
       <>
-        <MARCTableView
-          columns={updatesFieldMappingForMARCColumns}
-          fields={marcMappingDetails}
-        />
+        {!isEmpty(marcMappingDetails) ? renderMARCUpdatesTable() : <NoValue />}
         <OverrideProtectedFieldsTable
           marcFieldProtectionFields={marcFieldProtectionFields}
           mappingMarcFieldProtectionFields={mappingMarcFieldProtectionFields}


### PR DESCRIPTION
## Description
Render hyphen on the view screen instead of a table when there are no MARC mapping details.

## Approach
- Check if `marcMappingDetails` is empty.
- If yes - render `<NoValue>` component.
- If no - render `<MARCTableView>` component.

## Ticket
[UIDATIMP-661](https://issues.folio.org/browse/UIDATIMP-661)

## Screenshot
![MARC_Updates_view](https://user-images.githubusercontent.com/55138456/95325710-429d4e00-08aa-11eb-95a0-73a263d91f12.jpg)
