### PR TITLE
UIDATIMP-673: Action profile create-edit screen: change unusable options to disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,10 @@
 * MARC Bib field mapping profile: details for Update-Overrides on View screen (UIDATIMP-632)
 * Change "Check in/out note" value to "Check in/out" for items (UIDATIMP-679)
 * Add capability to remove jobs that are stuck in "Running" area of Data Import landing page first pane (UIDATIMP-651)
-* Match profile create-edit & view screens: change unuseable options to disabled (UIDATIMP-676)
+* Match profile create-edit & view screens: change unusable options to disabled (UIDATIMP-676)
 * MARC Bib field mapping profile: EXCEPTION details for Update Selected fields on Create/Edit screen (UIDATIMP-660)
 * MARC Bib field mapping profile: EXCEPTION details for Update Selected fields on View screen (UIDATIMP-661)
+* Action profile create-edit screen: change unusable options to disabled (UIDATIMP-673)
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)

--- a/src/settings/ActionProfiles/ActionProfilesForm.js
+++ b/src/settings/ActionProfiles/ActionProfilesForm.js
@@ -43,6 +43,7 @@ import {
   ENTITY_KEYS,
   LAYER_TYPES,
   PROFILE_TYPES,
+  FOLIO_RECORD_TYPES_TO_DISABLE,
 } from '../../utils';
 import {
   FolioRecordTypeSelect,
@@ -131,10 +132,16 @@ export const ActionProfilesFormComponent = ({
   };
 
   const getFolioRecordTypesDataOptions = () => Object.entries(getFilteredFolioRecordTypes())
-    .map(([recordType, { captionId }]) => ({
-      value: recordType,
-      label: formatMessage({ id: captionId }),
-    }));
+    .map(([recordType, { captionId }]) => {
+      // TODO: Disabling options should be removed after implentation is done
+      const isOptionDisabled = FOLIO_RECORD_TYPES_TO_DISABLE.some(option => option === recordType);
+
+      return {
+        value: recordType,
+        label: formatMessage({ id: captionId }),
+        disabled: isOptionDisabled,
+      };
+    });
   const actionsDataOptions = useMemo(getActionsDataOptions, [folioRecord]);
   const folioRecordTypesDataOptions = useMemo(getFolioRecordTypesDataOptions, [action]);
   const { layer } = queryString.parse(search);


### PR DESCRIPTION
## Purpose
To provide a visual cue for options that are not yet useable in the Action profile

## Approach
- Add functionality of disabling options in `ActionProfilesForm` component

## Ticket
[UIDATIMP-673](https://issues.folio.org/browse/UIDATIMP-673)

## Screenshot
![image](https://user-images.githubusercontent.com/40805351/95336395-4e444100-08b9-11eb-9c6f-e687b4ede9b2.png)



