### PR TITLE
UIDATIMP-687: Fix linking a match profile to a job profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * Fix for validation function `validateRequiredFields` (UIDATIMP-645)
 * Fix `SyntaxError: Unexpected token 'export'` error when running tests (UIDATIMP-667)
 * Fix "Position" in MCL View is not left justified (UIDATIMP-657)
+* An error message appears when linking a match profile with Existing record field = "Identifier: ..." to a job profile (UIDATIMP-687)
 
 ## [2.1.4](https://github.com/folio-org/ui-data-import/tree/v2.1.4) (2020-08-13)
 

--- a/src/components/ProfileTree/ProfileBranch.js
+++ b/src/components/ProfileTree/ProfileBranch.js
@@ -47,6 +47,7 @@ export const ProfileBranch = memo(({
   onDelete,
   dataAttributes,
   showLabelsAsHotLink,
+  resources,
 }) => {
   const {
     childrenAllowed,
@@ -122,6 +123,7 @@ export const ProfileBranch = memo(({
         onUnlink={onUnlink}
         onDelete={onDelete}
         showLabelsAsHotLink={showLabelsAsHotLink}
+        resources={resources}
       />
       {childrenSectionAllowed && (
         <div className={css['branch-container']}>
@@ -152,6 +154,7 @@ export const ProfileBranch = memo(({
                     onUnlink={onUnlink}
                     onDelete={onDelete}
                     showLabelsAsHotLink={showLabelsAsHotLink}
+                    resources={resources}
                   />
                 )) : (
                   <div>
@@ -216,6 +219,7 @@ export const ProfileBranch = memo(({
                     onUnlink={onUnlink}
                     onDelete={onDelete}
                     showLabelsAsHotLink={showLabelsAsHotLink}
+                    resources={resources}
                   />
                 )) : (
                   <div>
@@ -273,6 +277,7 @@ ProfileBranch.propTypes = {
     token: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
   }).isRequired,
+  resources: PropTypes.object.isRequired,
   record: PropTypes.object,
   className: PropTypes.string,
   onChange: PropTypes.func,

--- a/src/components/ProfileTree/ProfileLabel.js
+++ b/src/components/ProfileTree/ProfileLabel.js
@@ -41,6 +41,7 @@ export const ProfileLabel = memo(({
   onDelete,
   dataAttributes,
   showLabelsAsHotLink,
+  resources,
 }) => {
   const {
     columnsAllowed,
@@ -63,6 +64,7 @@ export const ProfileLabel = memo(({
     entityKey,
     customValue: label,
     showLabelsAsHotLink,
+    resources,
   });
   const columns = columnsAllowed[entityKey];
 
@@ -94,7 +96,7 @@ export const ProfileLabel = memo(({
 
           return (
             <>
-              <span key={`label-item-${i}`}>{templates[item](recordData)}</span>
+              <span key={`label-item-${i}`}>{templates[item](recordData.content)}</span>
               {needSeparator && <span>&nbsp;&middot;&nbsp;</span>}
             </>
           );
@@ -185,6 +187,7 @@ ProfileLabel.propTypes = {
   parentSectionKey: PropTypes.string.isRequired,
   parentSectionData: PropTypes.arrayOf(PropTypes.object).isRequired,
   setParentSectionData: PropTypes.func.isRequired,
+  resources: PropTypes.object.isRequired,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   reactTo: PropTypes.string,
   record: PropTypes.object,

--- a/src/components/ProfileTree/ProfileTree.js
+++ b/src/components/ProfileTree/ProfileTree.js
@@ -39,6 +39,7 @@ export const ProfileTree = memo(({
   className,
   dataAttributes,
   showLabelsAsHotLink,
+  resources,
 }) => {
   const { siblingsProhibited } = linkingRules;
 
@@ -158,6 +159,7 @@ export const ProfileTree = memo(({
                 onDelete={remove}
                 okapi={okapi}
                 showLabelsAsHotLink={showLabelsAsHotLink}
+                resources={resources}
               />
             ))
           ) : (
@@ -198,6 +200,7 @@ ProfileTree.propTypes = {
     token: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
   }).isRequired,
+  resources: PropTypes.object.isRequired,
   parentId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   relationsToAdd: PropTypes.arrayOf(PropTypes.object),
   relationsToDelete: PropTypes.arrayOf(PropTypes.object),

--- a/src/settings/JobProfiles/JobProfiles.js
+++ b/src/settings/JobProfiles/JobProfiles.js
@@ -189,6 +189,11 @@ export const createJobProfiles = (chooseJobProfile = false, dataTypeQuery = '') 
           staticFallback: { params: {} },
         },
       },
+      identifierTypes: {
+        type: 'okapi',
+        records: 'identifierTypes',
+        path: 'identifier-types?limit=1000&query=cql.allRecords=1 sortby name',
+      },
     });
 
     static propTypes = {

--- a/src/settings/JobProfiles/JobProfilesForm.js
+++ b/src/settings/JobProfiles/JobProfilesForm.js
@@ -51,6 +51,7 @@ export const JobProfilesFormComponent = ({
   onCancel,
   dispatch,
   stripes,
+  parentResources,
 }) => {
   const { okapi } = stripes;
   const { profile } = initialValues;
@@ -165,6 +166,7 @@ export const JobProfilesFormComponent = ({
               onLink={setAddedRelations}
               onUnlink={setDeletedRelations}
               okapi={okapi}
+              resources={parentResources}
             />
           </Accordion>
         </div>
@@ -195,6 +197,7 @@ JobProfilesFormComponent.propTypes = {
       }),
     }),
   ).isRequired,
+  parentResources: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = state => {

--- a/src/settings/MatchProfiles/MatchProfiles.js
+++ b/src/settings/MatchProfiles/MatchProfiles.js
@@ -184,6 +184,11 @@ export const matchProfilesShape = {
         return { query };
       },
     },
+    identifierTypes: {
+      type: 'okapi',
+      records: 'identifierTypes',
+      path: 'identifier-types?limit=1000&query=cql.allRecords=1 sortby name',
+    },
   },
   visibleColumns: [
     'name',


### PR DESCRIPTION
## Description
When trying to link a match profile where Existing record field = "Identifier: ..." to a job profile, an error message appears.

## Approach
- Add missed `resources` prop to `ProfileTree` component

## Ticket
[UIDATIMP-687](https://issues.folio.org/browse/UIDATIMP-687)