### PR TITLE
only import MatchingFieldsManager once

### DIFF
--- a/src/settings/MatchProfiles/MatchProfilesForm.js
+++ b/src/settings/MatchProfiles/MatchProfilesForm.js
@@ -35,7 +35,6 @@ import {
   RecordTypesSelect,
   MatchingFieldsManager,
 } from '../../components';
-import { MatchingFieldsManager } from '../../components/MatchingFieldsManager';
 import { MatchCriterion } from '../../components/MatchCriterion/edit';
 
 import {


### PR DESCRIPTION
`MatchingFieldsManager` was imported twice.