### PR TITLE
UIDATIMP-690 prevent ESLint from dying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@
 * Fix `SyntaxError: Unexpected token 'export'` error when running tests (UIDATIMP-667)
 * Fix "Position" in MCL View is not left justified (UIDATIMP-657)
 * An error message appears when linking a match profile with Existing record field = "Identifier: ..." to a job profile (UIDATIMP-687)
+* Only import MatchingFieldsManager once (UIDATIMP-689)
+* Tweak syntax that caused ESLint to die early, allowing it complete, and find bugs like UIDATIMP-689 (UIDATIMP-690)
 
 ## [2.1.4](https://github.com/folio-org/ui-data-import/tree/v2.1.4) (2020-08-13)
 

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/LoanAndAvailability.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/LoanAndAvailability.js
@@ -56,8 +56,9 @@ export const LoanAndAvailability = ({
     const currentValue = circulationNotes[index]?.fields.find(item => item.name === 'noteType').value;
     const isDirty = currentValue !== initialValue;
 
-    const updatedValue = circulationNotesList.find(item => `"${item.value}"` === currentValue)?.label;
-    const value = updatedValue ? `"${updatedValue}"` : currentValue;
+    const updatedValue = circulationNotesList.find(item => `"${item.value}"` === currentValue);
+    const updatedValueLabel = updatedValue?.label;
+    const value = updatedValueLabel ? `"${updatedValueLabel}"` : currentValue;
 
     return {
       value,


### PR DESCRIPTION
Due to a [bug in jsx-exlint](https://github.com/jsx-eslint/jsx-ast-utils/issues/103), the changed line causes ESLint to die. The bug [has been fixed](https://github.com/jsx-eslint/jsx-ast-utils/pull/102) but hasn't made its way into a release yet, and it would be really nice to have lint working again!

Refs [UIDATIMP-690](https://issues.folio.org/browse/UIDATIMP-690)