### PR TITLE
UIDATIMP-674: Field mapping profile create-edit screen: change unuseable options to disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * Action profile create-edit screen: change unusable options to disabled (UIDATIMP-673)
 * MARC Bib field mapping profile: EXCEPTION details for Override protected fields on Create/Edit screen (UIDATIMP-662)
 * MARC Bib field mapping profile: EXCEPTION details for Override protected fields on View screen (UIDATIMP-663)
+* Field mapping profile create-edit screen: change unuseable options to disabled (UIDATIMP-674)
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)

--- a/src/components/ListTemplate/incomingRecordTypes.js
+++ b/src/components/ListTemplate/incomingRecordTypes.js
@@ -4,4 +4,9 @@ export const INCOMING_RECORD_TYPES = {
   MARC_BIBLIOGRAPHIC: FOLIO_RECORD_TYPES.MARC_BIBLIOGRAPHIC,
   MARC_HOLDINGS: FOLIO_RECORD_TYPES.MARC_HOLDINGS,
   MARC_AUTHORITY: FOLIO_RECORD_TYPES.MARC_AUTHORITY,
+  EDIFACT_INVOICE: {
+    type: 'EDIFACT_INVOICE',
+    captionId: 'ui-data-import.incomingRecordTypes.edifact-invoice',
+    iconKey: 'invoices',
+  },
 };

--- a/src/components/RecordTypesSelect/components/IncomingRecordMenu.js
+++ b/src/components/RecordTypesSelect/components/IncomingRecordMenu.js
@@ -7,6 +7,8 @@ import {
   DropdownMenu,
 } from '@folio/stripes-components';
 
+import { INCOMING_RECORD_TYPES_TO_DISABLE } from '../../../utils';
+
 import { MATCH_INCOMING_RECORD_TYPES } from '../../ListTemplate';
 
 export const IncomingRecordMenu = ({
@@ -25,16 +27,22 @@ export const IncomingRecordMenu = ({
     open={open}
     minWidth="auto"
   >
-    {Object.keys(MATCH_INCOMING_RECORD_TYPES).map((recordType, i) => (
-      <Button
-        key={i}
-        buttonStyle="dropdownItem"
-        onClick={() => onClick(MATCH_INCOMING_RECORD_TYPES[recordType])}
-        {...dataAttributes}
-      >
-        <FormattedMessage id={MATCH_INCOMING_RECORD_TYPES[recordType].captionId} />
-      </Button>
-    ))}
+    {Object.keys(MATCH_INCOMING_RECORD_TYPES).map((recordType, i) => {
+      // TODO: Disabling options should be removed after implentation is done
+      const isOptionDisabled = INCOMING_RECORD_TYPES_TO_DISABLE.some(option => option === recordType);
+
+      return (
+        <Button
+          key={i}
+          buttonStyle="dropdownItem"
+          onClick={() => onClick(MATCH_INCOMING_RECORD_TYPES[recordType])}
+          disabled={isOptionDisabled}
+          {...dataAttributes}
+        >
+          <FormattedMessage id={MATCH_INCOMING_RECORD_TYPES[recordType].captionId} />
+        </Button>
+      );
+    })}
   </DropdownMenu>
 );
 

--- a/src/settings/MappingProfiles/MappingProfilesForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm.js
@@ -68,6 +68,8 @@ import {
   fillEmptyFieldsWithValue,
   marcFieldProtectionSettingsShape,
   createOptionsList,
+  FOLIO_RECORD_TYPES_TO_DISABLE,
+  INCOMING_RECORD_TYPES_TO_DISABLE,
 } from '../../utils';
 
 import styles from './MappingProfiles.css';
@@ -167,15 +169,27 @@ export const MappingProfilesFormComponent = ({
   const initialFields = getInitialFields(folioRecordType);
 
   const getIncomingRecordTypesDataOptions = () => Object.entries(INCOMING_RECORD_TYPES)
-    .map(([recordType, { captionId }]) => ({
-      value: recordType,
-      label: formatMessage({ id: captionId }),
-    }));
+    .map(([recordType, { captionId }]) => {
+      // TODO: Disabling options should be removed after implentation is done
+      const isOptionDisabled = INCOMING_RECORD_TYPES_TO_DISABLE.some(option => option === recordType);
+
+      return {
+        value: recordType,
+        label: formatMessage({ id: captionId }),
+        disabled: isOptionDisabled,
+      };
+    });
   const getFolioRecordTypesDataOptions = () => Object.entries(FOLIO_RECORD_TYPES)
-    .map(([recordType, { captionId }]) => ({
-      value: recordType,
-      label: formatMessage({ id: captionId }),
-    }));
+    .map(([recordType, { captionId }]) => {
+      // TODO: Disabling options should be removed after implentation is done
+      const isOptionDisabled = FOLIO_RECORD_TYPES_TO_DISABLE.some(option => option === recordType);
+
+      return {
+        value: recordType,
+        label: formatMessage({ id: captionId }),
+        disabled: isOptionDisabled,
+      };
+    });
 
   const folioRecordTypesDataOptions = useMemo(getFolioRecordTypesDataOptions, []);
   const incomingRecordTypesDataOptions = useMemo(getIncomingRecordTypesDataOptions, []);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -608,3 +608,4 @@ export const MARC_FIELD_PROTECTION_SOURCE = {
 // TODO: Options to disable until functionality is not implemented.
 // Should be removed in the future
 export const FOLIO_RECORD_TYPES_TO_DISABLE = ['MARC_HOLDINGS', 'ORDER', 'INVOICE', 'MARC_AUTHORITY'];
+export const INCOMING_RECORD_TYPES_TO_DISABLE = ['MARC_HOLDINGS', 'MARC_AUTHORITY', 'EDIFACT_INVOICE'];


### PR DESCRIPTION
## Purpose
To provide a visual cue for options that are not yet useable in the Field mapping profile

## Approach
- Add functionality of disabling options in `IncomingRecordMenu` and `MappingProfilesForm` component

## Ticket
[UIDATIMP-674](https://issues.folio.org/browse/UIDATIMP-674)

## Screenshot
![image](https://user-images.githubusercontent.com/40805351/95720335-c4f68b00-0c79-11eb-9662-d92f480ced4e.png)
![image](https://user-images.githubusercontent.com/40805351/95720356-ce7ff300-0c79-11eb-9c47-aa3e79147b11.png)




