### PR TITLE
UIDATIMP-675: Job profile create-edit screen: change unusable options to disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * MARC Bib field mapping profile: EXCEPTION details for Override protected fields on Create/Edit screen (UIDATIMP-662)
 * MARC Bib field mapping profile: EXCEPTION details for Override protected fields on View screen (UIDATIMP-663)
 * Field mapping profile create-edit screen: change unuseable options to disabled (UIDATIMP-674)
+* Job profile create-edit screen: change unusable options to disabled (UIDATIMP-675)
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)

--- a/src/settings/JobProfiles/JobProfilesForm.js
+++ b/src/settings/JobProfiles/JobProfilesForm.js
@@ -40,6 +40,8 @@ const formName = 'jobProfilesForm';
 const dataTypes = DATA_TYPES.map(dataType => ({
   value: dataType,
   label: dataType,
+  // TODO: Disabling options should be removed after implentation is done
+  disabled: dataType === 'EDIFACT',
 }));
 
 export const JobProfilesFormComponent = ({


### PR DESCRIPTION
## Purpose
To provide a visual cue for options that are not yet useable in the Job profile

## Approach
- Add functionality of disabling options in `JobProfilesForm` component

## Ticket
[UIDATIMP-675](https://issues.folio.org/browse/UIDATIMP-675)

## Screenshot
![image](https://user-images.githubusercontent.com/40805351/95726164-3f76d900-0c81-11eb-8fdd-c0618bfc9d8b.png)





