### PR TITLE
UIDATIMP-691 filling new rows with wildcard symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * Job profile create-edit screen: change unusable options to disabled (UIDATIMP-675)
 * Replace hyphens with `<NoValue>` component (UIDATIMP-628)
 * Data Import App: Consume {{FormattedDate}} and {{FormattedTime}} via stripes-component (UIDATIMP-665)
+* In1, In2, Subfield defaults for subsequent update fields do not default to * (UIDATIMP-691)
 
 ### Bugs fixed:
 * Fix rendering qualifier sections with old data in match profiles details (UIDATIMP-481)

--- a/src/components/MARCTable/MARCTable.js
+++ b/src/components/MARCTable/MARCTable.js
@@ -16,7 +16,10 @@ import {
 
 import css from './MARCTable.css';
 
-import { mappingMARCFieldShape } from '../../utils';
+import {
+  fillEmptyFieldsWithValue,
+  mappingMARCFieldShape,
+} from '../../utils';
 
 export const MARCTable = ({
   columns,
@@ -24,6 +27,7 @@ export const MARCTable = ({
   onChange,
   columnWidths,
   isFirstRowRemovable,
+  fillNewRowFieldsWithDefaultValue,
 }) => {
   const [rows, setRows] = useState([]);
 
@@ -41,9 +45,12 @@ export const MARCTable = ({
       order: index,
       field: { subfields: [{}] },
     };
+    const updatedField = fillEmptyFieldsWithValue(newRow,
+      ['field.indicator1', 'field.indicator2', 'field.subfields[0].subfield'], '*');
+
     const updatedRows = [
       ...rows.slice(0, index),
-      newRow,
+      fillNewRowFieldsWithDefaultValue ? updatedField : newRow,
       ...rows.slice(index).map(incrementOrders),
     ];
 
@@ -214,6 +221,7 @@ MARCTable.propTypes = {
   columnWidths: PropTypes.object,
   onChange: PropTypes.func,
   isFirstRowRemovable: PropTypes.bool,
+  fillNewRowFieldsWithDefaultValue: PropTypes.bool,
 };
 
 MARCTable.defaultProps = {
@@ -230,4 +238,5 @@ MARCTable.defaultProps = {
     addRemove: '70px',
   },
   isFirstRowRemovable: false,
+  fillNewRowFieldsWithDefaultValue: false,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/MappingMARCBibDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/MappingMARCBibDetails.js
@@ -47,6 +47,7 @@ export const MappingMARCBibDetails = ({
         fields={marcMappingDetails}
         onChange={setReferenceTables}
         isFirstRowRemovable
+        fillNewRowFieldsWithDefaultValue
       />
     );
 


### PR DESCRIPTION
## Overview
When adding subsequent rows to the MARC fields to be updated, the subsequent rows do not default to * for Ind 1, Ind 2, Subfield

## Approach
- add 'fillNewRowFieldsWithDefaultValue' property to the 'MARCTable' component
- add new logic to 'addNewRow' function

## Refs
https://issues.folio.org/browse/UIDATIMP-691