### PR TITLE
UIDATIMP-681: Newly-created file extension settings do not file in alphabetical order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 * An error message appears when linking a match profile with Existing record field = "Identifier: ..." to a job profile (UIDATIMP-687)
 * Only import MatchingFieldsManager once (UIDATIMP-689)
 * Tweak syntax that caused ESLint to die early, allowing it complete, and find bugs like UIDATIMP-689 (UIDATIMP-690)
+* Fix sorting newly-created file extension settings in alphabetical order (UIDATIMP-681)
 
 ## [2.1.4](https://github.com/folio-org/ui-data-import/tree/v2.1.4) (2020-08-13)
 

--- a/src/components/ListView/ListView.js
+++ b/src/components/ListView/ListView.js
@@ -59,6 +59,7 @@ export class ListView extends Component {
     initialValues: PropTypes.object.isRequired,
     renderHeaders: PropTypes.func.isRequired,
     isFullScreen: PropTypes.bool,
+    defaultSort: PropTypes.string,
   };
 
   static defaultProps = {
@@ -72,6 +73,7 @@ export class ListView extends Component {
       hasLoaded: false,
     },
     checkboxList: {},
+    defaultSort: 'name',
   };
 
   state = {
@@ -207,6 +209,7 @@ export class ListView extends Component {
       renderHeaders,
       actionMenuItems,
       isFullScreen,
+      defaultSort,
     } = this.props;
     const { showRestoreModal } = this.state;
 
@@ -237,7 +240,7 @@ export class ListView extends Component {
               searchLabelKey={`ui-data-import.settings.${ENTITY_KEY}.title`}
               resultCountMessageKey={`ui-data-import.settings.${ENTITY_KEY}.count`}
               resultsLabel={label}
-              defaultSort="name"
+              defaultSort={defaultSort}
               actionMenu={actionMenu}
               visibleColumns={visibleColumns}
               columnWidths={columnWidths}

--- a/src/settings/FileExtensions/FileExtensions.js
+++ b/src/settings/FileExtensions/FileExtensions.js
@@ -110,6 +110,7 @@ export class FileExtensions extends Component {
     actionMenuItems: PropTypes.arrayOf(PropTypes.string),
     visibleColumns: PropTypes.arrayOf(PropTypes.string),
     initialValues: PropTypes.object,
+    defaultSort: PropTypes.string,
   };
 
   static defaultProps = {
@@ -129,6 +130,7 @@ export class FileExtensions extends Component {
       'updated',
       'updatedBy',
     ],
+    defaultSort: 'extension',
     initialValues: {
       importBlocked: false,
       description: '',


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

To sort Newly-created file extension settings in alphabetical order

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Set  prop `defaultSort: 'extension',` for `FileExtensions` component
<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
[UIDATIMP-681](https://issues.folio.org/browse/UIDATIMP-681)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://user-images.githubusercontent.com/40805351/95962646-51868200-0e0f-11eb-9d6a-aa55107bd531.png)

