### PR TITLE
UIDATIMP-747: Fix matching by id for Holdings and Item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix Accessibility problems for settings/data-import/{...-profiles} (Form elements must have labels) (UIDATIMP-457)
 * Fix Accessibility problems in ProfileLinker Component (settings/data-import/job-profiles) (UIDATIMP-434)
 * Cannot delete an import stuck in "Running" (UIDATIMP-738)
+* Fix matching by `id` for Holdings and Item (UIDATIMP-747)
 
 ## [3.0.1](https://github.com/folio-org/ui-data-import/tree/v3.0.1) (2020-10-27)
 

--- a/src/components/MatchCriterion/edit/ExistingRecordSections/ExistingSectionFolio.js
+++ b/src/components/MatchCriterion/edit/ExistingRecordSections/ExistingSectionFolio.js
@@ -12,7 +12,10 @@ import {
   Selection,
 } from '@folio/stripes/components';
 
-import { Section } from '../../..';
+import {
+  Section,
+  FOLIO_RECORD_TYPES,
+} from '../../..';
 
 import {
   fieldsConfig,
@@ -26,6 +29,7 @@ export const ExistingSectionFolio = ({
   existingRecordFieldLabel,
   existingRecordFields,
   existingRecordFieldsValue,
+  existingRecordType,
   dispatchFormChange,
 }) => {
   const [isDirty, setDirty] = useState(false);
@@ -35,7 +39,7 @@ export const ExistingSectionFolio = ({
   const handleExistingRecordSelect = value => {
     const fieldToChangeName = `profile.matchDetails[${repeatableIndex}].existingMatchExpression.fields`;
     const fieldId = existingRecordFields.find(item => item.value === value)?.id;
-    const fieldFromConfig = fieldsConfig.find(item => item.id === fieldId);
+    const fieldFromConfig = fieldsConfig.find(item => item.id === fieldId && item.recordType === existingRecordType);
     const fieldToChangeValue = [{
       label: MARC_FIELD_CONSTITUENT.FIELD,
       value: fieldFromConfig?.value,
@@ -83,6 +87,7 @@ export const ExistingSectionFolio = ({
 ExistingSectionFolio.propTypes = {
   repeatableIndex: PropTypes.number.isRequired,
   existingRecordFieldsValue: PropTypes.arrayOf(PropTypes.object).isRequired,
+  existingRecordType: PropTypes.oneOf(Object.keys(FOLIO_RECORD_TYPES)).isRequired,
   existingRecordFields: PropTypes.arrayOf(PropTypes.shape({
     value: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,

--- a/src/components/MatchCriterion/edit/MatchCriterion.js
+++ b/src/components/MatchCriterion/edit/MatchCriterion.js
@@ -131,6 +131,7 @@ export const MatchCriterion = ({
       existingRecordFieldLabel={existingRecordFieldLbl}
       existingRecordFields={existingRecordFields}
       existingRecordFieldsValue={existingMatchExpression.fields}
+      existingRecordType={existingRecordType}
       dispatchFormChange={dispatchFormChange}
     />
   );


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
When creating a new match profile with existing record type = `Holdings` or `Item` and selecting a match by `Holdings UUID` or `Item UUID` and saving the profile, it is created with a match by `Instance UUID`. It happens because the value for the selected option from a dropdown is retrieved from `formConfig` config by key `id` and for `Instance`, `Holdings` or `Item` this key is the same, so the first entry (for `Instance`) is returned.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Find the selected option in `formConfig` config by `id` key and `existingRecordType` key so it is unique.

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
[UIDATIMP-747](https://issues.folio.org/browse/UIDATIMP-747)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![sO3g2VH3yd](https://user-images.githubusercontent.com/55138456/98228252-03bdef00-1f61-11eb-90f0-f13c14526e5d.gif)

