### PR TITLE
UIDATIMP-700: Cover <BooleanActionField> component with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Reuse `<Preloader>` component from `stripes-data-transfer-components` rep (UIDATIMP-580)
 * Reuse utils from `stripes-data-transfer-components` rep (UIDATIMP-576)
 * Reuse `<SearchResults>` component from `stripes-data-transfer-components` rep (UIDATIMP-581)
+* Cover <BooleanActionField> component with tests (UIDATIMP-700)
 
 ### Bugs fixed:
 * Fix Accessibility problems for settings/data-import/match-profiles (lists must only directly contain li elements) (UIDATIMP-452)

--- a/src/components/BooleanActionField/BooleanActionField.test.js
+++ b/src/components/BooleanActionField/BooleanActionField.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import '../../../test/jest/__mock__';
+import { reduxFormMock } from '../../../test/jest/__mock__/reduxForm.mock';
+import { renderWithIntl } from '../../../test/jest/helpers';
+
+import { BooleanActionField } from './BooleanActionField';
+
+const renderBooleanActionField = ({ placeholder }) => {
+  const component = () => (
+    <BooleanActionField
+      label="testLabel"
+      name="testField"
+      placeholder={placeholder}
+    />
+  );
+
+  return renderWithIntl(reduxFormMock(component));
+};
+
+describe('Boolean action field component', () => {
+  describe('when a form has wrapped component', () => {
+    it('then the wrapped component should be rendered', () => {
+      expect(renderBooleanActionField({})).toBeDefined();
+    });
+
+    it('then the wrapped component should render label', () => {
+      const { getByLabelText } = renderBooleanActionField({});
+
+      expect(getByLabelText('testLabel')).toBeDefined();
+    });
+  });
+
+  describe('when "placeholder" prop is not passed', () => {
+    it('then component should render default placeholder', () => {
+      const { getByText } = renderBooleanActionField({});
+
+      expect(getByText('Select сheckbox field mapping')).toBeDefined();
+    });
+  });
+
+  describe('when "placeholder" prop is passed', () => {
+    it('then component should render the passed placeholder', () => {
+      const { getByText } = renderBooleanActionField({ placeholder: 'testPlaceholder' });
+
+      expect(getByText('testPlaceholder')).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
To cover <BooleanActionField> component with tests using RTL+Jest.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

- Cover `BooleanActionField` with tests

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-700

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

![image](https://user-images.githubusercontent.com/40805351/98803122-f56a4a00-241c-11eb-867f-12b0818960c6.png)

