### PR TITLE
UIDATIMP-755: Add "Load more" button to View all log page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Fix Accessibility problems for settings/data-import/{...-profiles} (Form elements must have labels) (UIDATIMP-457)
 * Fix Accessibility problems in ProfileLinker Component (settings/data-import/job-profiles) (UIDATIMP-434)
 * Fix an error occurred while searching for associated profiles (UIDATIMP-769)
+* Add "Load more" button to View all log page (UIDATIMP-755)
 
 ## [3.0.3](https://github.com/folio-org/ui-data-import/tree/v3.0.3) (2020-11-13)
 

--- a/src/routes/ViewAllLogs/ViewAllLogs.js
+++ b/src/routes/ViewAllLogs/ViewAllLogs.js
@@ -58,6 +58,7 @@ const visibleColumns = [
   'hrId',
 ];
 
+const INITIAL_RESULT_COUNT = 100;
 const RESULT_COUNT_INCREMENT = 100;
 
 @stripesConnect
@@ -84,7 +85,7 @@ class ViewAllLogs extends Component {
         sort: '-completedDate',
       },
     },
-    resultCount: { initialValue: RESULT_COUNT_INCREMENT },
+    resultCount: { initialValue: INITIAL_RESULT_COUNT },
     records: {
       type: 'okapi',
       clear: true,
@@ -215,7 +216,7 @@ class ViewAllLogs extends Component {
           packageInfo={this.props.packageInfo || packageInfo}
           objectName="job-logs"
           baseRoute={packageInfo.stripes.route}
-          initialResultCount={RESULT_COUNT_INCREMENT}
+          initialResultCount={INITIAL_RESULT_COUNT}
           resultCountIncrement={RESULT_COUNT_INCREMENT}
           visibleColumns={visibleColumns}
           columnMapping={columnMapping}

--- a/src/routes/ViewAllLogs/ViewAllLogs.js
+++ b/src/routes/ViewAllLogs/ViewAllLogs.js
@@ -58,8 +58,7 @@ const visibleColumns = [
   'hrId',
 ];
 
-const INITIAL_RESULT_COUNT = 25;
-const RESULT_COUNT_INCREMENT = 25;
+const RESULT_COUNT_INCREMENT = 100;
 
 @stripesConnect
 class ViewAllLogs extends Component {
@@ -85,7 +84,7 @@ class ViewAllLogs extends Component {
         sort: '-completedDate',
       },
     },
-    resultCount: { initialValue: INITIAL_RESULT_COUNT },
+    resultCount: { initialValue: RESULT_COUNT_INCREMENT },
     records: {
       type: 'okapi',
       clear: true,
@@ -216,7 +215,7 @@ class ViewAllLogs extends Component {
           packageInfo={this.props.packageInfo || packageInfo}
           objectName="job-logs"
           baseRoute={packageInfo.stripes.route}
-          initialResultCount={INITIAL_RESULT_COUNT}
+          initialResultCount={RESULT_COUNT_INCREMENT}
           resultCountIncrement={RESULT_COUNT_INCREMENT}
           visibleColumns={visibleColumns}
           columnMapping={columnMapping}
@@ -235,6 +234,8 @@ class ViewAllLogs extends Component {
           renderFilters={this.renderFilters}
           onFilterChange={this.handleFilterChange}
           onChangeIndex={this.changeSearchIndex}
+          pagingType="click"
+          pageAmount={RESULT_COUNT_INCREMENT}
           title={<FormattedMessage id="ui-data-import.logsPaneTitle" />}
         />
       </div>


### PR DESCRIPTION
## Purpose
To have a better UI for loading log entries
As a staff person working with data import logs
I want to be able to scroll through all the logs on the View all log page
So that I can find one that I want even if I don't know the exact name or date

## Approach
- property INITIAL_RESULT_COUNT has been substituted with RESULT_COUNT_INCREMENT for ViewAllLogs component;
- properties pagingType and pageAmount has been added to ViewAllLogs component configuration

## Refs
https://issues.folio.org/browse/UIDATIMP-755

## Screenshots
![Load_more](https://user-images.githubusercontent.com/63101175/99942337-309f3e00-2d78-11eb-81b8-007604373028.png)
