### PR TITLE
UIDATIMP-758 Status descending sort on Data Import home page not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Fix Accessibility problems in ProfileLinker Component (settings/data-import/job-profiles) (UIDATIMP-434)
 * Fix an error occurred while searching for associated profiles (UIDATIMP-769)
 * Add "Load more" button to View all log page (UIDATIMP-755)
+* Status descending sort on Data Import home page not working. Fixed (UIDATIMP-758)
 
 ## [3.0.3](https://github.com/folio-org/ui-data-import/tree/v3.0.3) (2020-11-13)
 

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -1,17 +1,18 @@
-import React, { useRef } from 'react';
+import React from 'react';
+import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import {
   useJobLogsProperties,
   useJobLogsListFormatter,
 } from '@folio/stripes-data-transfer-components';
-import {
-  Button,
-  Callout,
-} from '@folio/stripes/components';
+import { Button } from '@folio/stripes/components';
 
 import { listTemplate } from '../ListTemplate';
-import { DEFAULT_JOB_LOG_COLUMNS } from '../../utils';
+import {
+  DEFAULT_JOB_LOG_COLUMNS,
+  FILE_STATUSES,
+} from '../../utils';
 
 import sharedCss from '../../shared.css';
 
@@ -38,7 +39,7 @@ export const JobLogsContainer = props => {
     ...rest
   } = props;
 
-  const calloutRef = useRef(null);
+  const { formatMessage } = useIntl();
 
   const fileNameCellFormatter = record => (
     <Button
@@ -52,11 +53,29 @@ export const JobLogsContainer = props => {
     </Button>
   );
 
+  const statusCellFormatter = record => {
+    const {
+      status,
+      progress,
+    } = record;
+
+    if (status === FILE_STATUSES.ERROR) {
+      if (progress && progress.current > 0) {
+        return formatMessage({ id: 'ui-data-import.completedWithErrors' });
+      }
+
+      return formatMessage({ id: 'ui-data-import.failed' });
+    }
+
+    return formatMessage({ id: 'ui-data-import.completed' });
+  };
+
   const listProps = {
     ...useJobLogsProperties(customProperties),
     resultsFormatter: useJobLogsListFormatter(
       {
         ...listTemplate({}),
+        status: statusCellFormatter,
         fileName: fileNameCellFormatter,
       },
     ),
@@ -68,7 +87,6 @@ export const JobLogsContainer = props => {
         listProps,
         ...rest,
       })}
-      <Callout ref={calloutRef} />
     </>
   );
 };

--- a/src/components/ListTemplate/listTemplate.js
+++ b/src/components/ListTemplate/listTemplate.js
@@ -15,7 +15,7 @@ import {
 import {
   formatUserName,
   ENTITY_KEYS,
-  STATUS_ERROR,
+  FILE_STATUSES,
 } from '../../utils';
 
 /**
@@ -126,7 +126,7 @@ export const listTemplate = ({
       progress,
     } = record;
 
-    if (status === STATUS_ERROR) {
+    if (status === FILE_STATUSES.ERROR) {
       if (progress && progress.current > 0) {
         return <FormattedMessage id="ui-data-import.completedWithErrors" />;
       }

--- a/src/components/RecentJobLogs/RecentJobLogs.js
+++ b/src/components/RecentJobLogs/RecentJobLogs.js
@@ -18,7 +18,7 @@ const sortColumns = {
   },
   status: {
     sortFn: sortStrings,
-    useFormatterFn: false,
+    useFormatterFn: true,
   },
 };
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,7 +1,5 @@
 export const FIND_ALL_CQL = 'cql.allRecords=1';
 
-export const STATUS_ERROR = 'ERROR';
-
 export const DEFAULT_TIMEOUT_BEFORE_FILE_DELETION = 0;
 
 export const DEFAULT_TIMEOUT_BEFORE_JOB_DELETION = 10000;


### PR DESCRIPTION
## Overview
on the Data Import landing page, the status sort ascending works, but not descending

## Approach
custom cell formatter has been applied for status cell

## Refs
[UIDATIMP-758](https://issues.folio.org/browse/UIDATIMP-758)
