### PR TITLE
UIDATIMP-704: Cover `<DatePickerDecorator>` component with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Add "Load more" button to an Individual job's log details page (UIDATIMP-756)
 * Log lite - import job summary page, from View all page (UIDATIMP-762)
 * Enable EDIFACT invoice options in various settings (UIDATIMP-778)
+* Cover `<DatePickerDecorator>` component with tests (UIDATIMP-704)
 
 ### Bugs fixed:
 * Fix Accessibility problems for settings/data-import/match-profiles (lists must only directly contain li elements) (UIDATIMP-452)

--- a/src/components/DatePickerDecorator/DatePickerDecorator.js
+++ b/src/components/DatePickerDecorator/DatePickerDecorator.js
@@ -117,6 +117,7 @@ export const DatePickerDecorator = memo(props => {
   return (
     <div
       data-test-date-picker
+      data-testid="date-picker-decorator"
       className={styles.decorator}
     >
       <Component

--- a/src/components/DatePickerDecorator/DatePickerDecorator.test.js
+++ b/src/components/DatePickerDecorator/DatePickerDecorator.test.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+
+import '../../../test/jest/__mock__';
+import { translationsProperties } from '../../../test/jest/helpers';
+
+import { DatePickerDecorator } from './DatePickerDecorator';
+
+const onChange = jest.fn();
+
+const renderDatePickerDecorator = () => {
+  const wrappedComponent = () => <input />;
+  const component = (
+    <DatePickerDecorator
+      wrappedComponent={wrappedComponent}
+      wrapperLabel="datePickerLabel"
+      input={{
+        value: '',
+        onChange,
+      }}
+    />
+  );
+
+  return renderWithIntl(component, translationsProperties);
+};
+
+describe('Date picker decorator component', () => {
+  afterEach(() => {
+    onChange.mockClear();
+  });
+
+  describe('rendering Date picker decorator', () => {
+    it('should be visible', () => {
+      const { getByTestId } = renderDatePickerDecorator();
+
+      expect(getByTestId('date-picker-decorator')).toBeDefined();
+    });
+
+    it('should display correct label for the dropdown', () => {
+      const { getByLabelText } = renderDatePickerDecorator();
+
+      expect(getByLabelText('datePickerLabel')).toBeDefined();
+    });
+
+    it('should have options "Today" and "Choose date"', () => {
+      const {
+        getByLabelText,
+        getByText,
+      } = renderDatePickerDecorator();
+
+      fireEvent.click(getByLabelText('datePickerLabel'));
+
+      expect(getByText('Today')).toBeDefined();
+      expect(getByText('Choose date')).toBeDefined();
+    });
+
+    describe('when "Today" option selected', () => {
+      it('then ###TODAY### value should be added to input', () => {
+        const {
+          getByLabelText,
+          getByText,
+        } = renderDatePickerDecorator();
+
+        fireEvent.click(getByLabelText('datePickerLabel'));
+        fireEvent.click(getByText('Today'));
+
+        expect(onChange).toHaveBeenCalledWith('###TODAY###');
+      });
+    });
+
+    describe('when "Choose date" option selected', () => {
+      it('then date picker should be rendered', () => {
+        const {
+          getByLabelText,
+          getByText,
+          getByTestId,
+        } = renderDatePickerDecorator();
+
+        fireEvent.click(getByLabelText('datePickerLabel'));
+        fireEvent.click(getByText('Choose date'));
+
+        expect(getByTestId('date-picker')).toBeDefined();
+      });
+    });
+  });
+});

--- a/src/components/TextDate/TextDate.js
+++ b/src/components/TextDate/TextDate.js
@@ -232,6 +232,7 @@ const TextDateField = ({
 
   return (
     <div
+      data-testid="date-picker"
       className={css.container}
       {...pickDataProps(props)}
     >


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
To cover `<DatePickerDecorator>` component with tests

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
[UIDATIMP-704](https://issues.folio.org/browse/UIDATIMP-704)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![date_picker_coverage](https://user-images.githubusercontent.com/55138456/101176532-4998d080-364f-11eb-965f-04e9c32cf76a.png)

