### PR TITLE
UIDATIMP-802: Fund distribution section should be visible only when Not prorated option in Pro rate select is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Match profile: Add validation to "Existing record" details (UIDATIMP-782)
 * Data Import Field Mapping Profile details: Create/Edit Invoice and Invoice line from EDIFACT Invoice (UIDATIMP-296)
 * Data Import Field Mapping Profile details: Toggles should display currency selected in Currency select in Extended information accordion(UIDATIMP-801)
+* Data Import Field Mapping Profile details: Fund distribution section should be visible only when "Not prorated" option in Pro rate select is selected (UIDATIMP-802)
 
 ### Bugs fixed:
 * Fix Accessibility problems for settings/data-import/match-profiles (lists must only directly contain li elements) (UIDATIMP-452)

--- a/src/components/AcceptedValuesField/AcceptedValuesField.js
+++ b/src/components/AcceptedValuesField/AcceptedValuesField.js
@@ -131,6 +131,7 @@ export const AcceptedValuesField = ({
       wrappedComponent={component}
       wrapperLabel={wrapperLabel}
       validate={[validateAcceptedValueField, memoizedValidation]}
+      onFieldChange={onChange}
       {...dataAttributes}
     />
   );
@@ -143,7 +144,7 @@ export const AcceptedValuesField = ({
         wrappedComponent={component}
         dataOptions={listOptions}
         value={componentValue}
-        onChange={onChange}
+        onFieldChange={onChange}
         label={label}
         wrapperLabel={wrapperLabel}
         optionValue={optionValue}

--- a/src/components/withReferenceValues/withReferenceValues.js
+++ b/src/components/withReferenceValues/withReferenceValues.js
@@ -21,7 +21,7 @@ export const withReferenceValues = memo(({
   id,
   input,
   value,
-  onChange,
+  onFieldChange,
   dataOptions,
   optionValue,
   optionLabel,
@@ -45,8 +45,8 @@ export const withReferenceValues = memo(({
       input.onChange(e);
     }
 
-    if (typeof onChange === 'function') {
-      onChange(val);
+    if (typeof onFieldChange === 'function') {
+      onFieldChange(val);
     }
   };
 
@@ -107,7 +107,7 @@ withReferenceValues.propTypes = {
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   }),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  onChange: PropTypes.func,
+  onFieldChange: PropTypes.func,
   id: PropTypes.string,
   wrapperLabel: PropTypes.oneOfType([PropTypes.string, Node]),
   disabled: PropTypes.bool,

--- a/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceAdjustments.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceAdjustments.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   useIntl,
@@ -26,6 +26,7 @@ import {
   getSubfieldName,
   getInnerSubfieldName,
   getInnerRepeatableAcceptedValuesPath,
+  getFundDistributionFieldsPath,
   updateInitialFields,
 } from '../../utils';
 import { TRANSLATION_ID_PREFIX } from '../../constants';
@@ -33,6 +34,7 @@ import {
   createOptionsList,
   mappingProfileSubfieldShape,
   okapiShape,
+  PRORATE_OPTIONS,
   INOVOICE_ADJUSTMENTS_PRORATE_OPTIONS,
   INOVOICE_ADJUSTMENTS_RELATION_TO_TOTAL_OPTIONS,
 } from '../../../../../utils';
@@ -47,8 +49,19 @@ export const InvoiceAdjustments = ({
 }) => {
   const { formatMessage } = useIntl();
 
+  const [isFundDistribution, setIsFundDistribution] = useState(false);
+
   const prorateList = createOptionsList(INOVOICE_ADJUSTMENTS_PRORATE_OPTIONS, formatMessage);
   const relationToTotalList = createOptionsList(INOVOICE_ADJUSTMENTS_RELATION_TO_TOTAL_OPTIONS, formatMessage);
+
+  const handleProRateChange = index => value => {
+    if (value === `"${PRORATE_OPTIONS.NOT_PRORATED}"`) {
+      setIsFundDistribution(true);
+    } else {
+      setIsFundDistribution(false);
+      setReferenceTables(getFundDistributionFieldsPath(15, index, 6), []);
+    }
+  };
 
   const renderFundDistributionFields = (mappingFieldIndex, mappingSubfieldFieldIndex, mappingSubfieldIndex) => {
     const currentInitialFundDistribution = initialFundDistribution[mappingSubfieldFieldIndex];
@@ -56,7 +69,7 @@ export const InvoiceAdjustments = ({
     const fundDistributions = adjustments[mappingSubfieldIndex].fields[mappingSubfieldFieldIndex].subfields;
     const fundDistributionInitialFields = { [currentInitialFundDistribution.name]: currentInitialFundDistribution.subfields[0] };
 
-    const getActualPath = curentIndex => `profile.mappingDetails.mappingFields[${mappingFieldIndex}].subfields[${mappingSubfieldIndex}].fields[${curentIndex}].subfields`;
+    const getActualPath = curentIndex => getFundDistributionFieldsPath(mappingFieldIndex, mappingSubfieldIndex, curentIndex);
 
     return (
       <RepeatableField
@@ -64,6 +77,7 @@ export const InvoiceAdjustments = ({
         addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.invoice.invoiceAdjustments.adjustments.fundDistribution.addLabel`} />}
         onAdd={() => onAdd(fundDistributions, 'fundDistributions', mappingSubfieldFieldIndex, fundDistributionInitialFields, setReferenceTables, 'order', getActualPath)}
         onRemove={index => onRemove(index, fundDistributions, mappingSubfieldFieldIndex, setReferenceTables, 'order', getActualPath)}
+        canAdd={isFundDistribution}
         renderField={(field, index) => (
           <Row left="xs">
             <Col xs={3}>
@@ -186,6 +200,7 @@ export const InvoiceAdjustments = ({
               isRemoveValueAllowed
               wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
               acceptedValuesList={prorateList}
+              onChange={handleProRateChange(index)}
               okapi={okapi}
             />
           </Col>

--- a/src/settings/MappingProfiles/detailsSections/utils.js
+++ b/src/settings/MappingProfiles/detailsSections/utils.js
@@ -48,6 +48,10 @@ export const getInnerRepeatableAcceptedValuesPath = (mappingFieldIndex, mappingS
   return `${FIELD_NAME_PREFIX}[${mappingFieldIndex}].subfields[${mappingSubfieldIndex}].fields[${mappingSubfieldFieldIndex}].subfields[${innerSubfieldIndex}].fields[${innerFieldIndex}].acceptedValues`;
 };
 
+export const getFundDistributionFieldsPath = (mappingFieldIndex, mappingSubfieldIndex, mappingSubfieldFieldIndex) => {
+  return `${FIELD_NAME_PREFIX}[${mappingFieldIndex}].subfields[${mappingSubfieldIndex}].fields[${mappingSubfieldFieldIndex}].subfields`;
+};
+
 export const onAdd = (refTable, fieldName, fieldIndex, initialFields, callback, incrementalField, getPath) => {
   const fieldsPath = getPath ? getPath(fieldIndex) : `profile.mappingDetails.mappingFields[${fieldIndex}].subfields`;
   let newInitRow = { ...initialFields[fieldName] };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -477,6 +477,13 @@ export const MAPPING_DETAILS_POSITION = {
   NEW_SUBFIELD: 'NEW_SUBFIELD',
 };
 
+export const PRORATE_OPTIONS = {
+  BY_LINE: 'By line',
+  BY_AMOUNT: 'By amount',
+  BY_QUANTITY: 'By quantity',
+  NOT_PRORATED: 'Not prorated',
+};
+
 export const ACTION_OPTIONS = [
   {
     value: MAPPING_DETAILS_ACTIONS.ADD,
@@ -582,16 +589,16 @@ export const ITEM_STATUS_OPTIONS = [
 
 export const INOVOICE_ADJUSTMENTS_PRORATE_OPTIONS = [
   {
-    value: 'By line',
+    value: PRORATE_OPTIONS.BY_LINE,
     label: 'ui-data-import.settings.mappingProfiles.map.invoice.invoiceAdjustments.field.prorate.ByLine',
   }, {
-    value: 'By amount',
+    value: PRORATE_OPTIONS.BY_AMOUNT,
     label: 'ui-data-import.settings.mappingProfiles.map.invoice.invoiceAdjustments.field.prorate.ByAmount',
   }, {
-    value: 'By quantity',
+    value: PRORATE_OPTIONS.BY_QUANTITY,
     label: 'ui-data-import.settings.mappingProfiles.map.invoice.invoiceAdjustments.field.prorate.ByQuantity',
   }, {
-    value: 'Not prorated',
+    value: PRORATE_OPTIONS.NOT_PRORATED,
     label: 'ui-data-import.settings.mappingProfiles.map.invoice.invoiceAdjustments.field.prorate.NotProrated',
   },
 ];


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Fund distribution section should be visible only when "Not prorated" option in Pro rate select is selected in Invoice adjustments accordion

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add `onFieldChange` prop for  `AcceptedValuesField` component to be able to pass additional change handler to `Field`
- Add `handleProRateChange` handler to `InvoiceAdjustments` component

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-296

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![wIJ4bVMU3L](https://user-images.githubusercontent.com/40805351/102336334-b4c09c00-3f99-11eb-857e-6f1861d82b31.gif)


