### PR TITLE
UIDATIMP-835 Allow 005 to be a protected field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Update stripes to v6 (UIDATIMP-815)
 * Suppress OCLC Single record import job profiles from the Choose jobs list (UIDATIMP-819)
 * Refactor File Extensions view to use final-form instead of redux-form (UIDATIMP-825)
+* Allow 005 to be a protected field (UIDATIMP-835)
 
 ### Bugs fixed:
 * Fix Accessibility problems for settings/data-import/match-profiles (lists must only directly contain li elements) (UIDATIMP-452)

--- a/src/settings/MARCFieldProtection/MARCFieldProtection.js
+++ b/src/settings/MARCFieldProtection/MARCFieldProtection.js
@@ -8,14 +8,17 @@ import {
 import { stripesConnect } from '@folio/stripes/core';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 
-import { MARC_FIELD_PROTECTION_SOURCE } from '../../utils';
+import {
+  MARC_FIELD_PROTECTION_SOURCE,
+  MARC_FIELD_PROTECTION_ALLOWED_FIELD_VALUES,
+} from '../../utils';
 
 const validateField = value => {
   const checkFieldRange = () => {
     return value.length === 3 && parseInt(value, 10) >= 10 && parseInt(value, 10) <= 999;
   };
 
-  if (value && (value === '*' || checkFieldRange())) {
+  if (value && (MARC_FIELD_PROTECTION_ALLOWED_FIELD_VALUES.includes(value) || checkFieldRange())) {
     return null;
   }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -666,6 +666,8 @@ export const MARC_FIELD_PROTECTION_SOURCE = {
   },
 };
 
+export const MARC_FIELD_PROTECTION_ALLOWED_FIELD_VALUES = ['*', '005'];
+
 // TODO: Options to disable until functionality is not implemented.
 // Should be removed in the future
 export const FOLIO_RECORD_TYPES_TO_DISABLE = ['MARC_HOLDINGS', 'ORDER', 'MARC_AUTHORITY'];


### PR DESCRIPTION
## Overview
When trying to set the 005 field to a protected field, it is not allowed

## Approach
- Add constant MARC_FIELD_PROTECTION_ALLOWED_FIELD_VALUES;
- Update validation logic for validateField

## Refs
https://issues.folio.org/browse/UIDATIMP-835

## Screenshots
![before](https://user-images.githubusercontent.com/63101175/106869900-22a35d00-66d9-11eb-934d-79c48b06128a.png)
![after](https://user-images.githubusercontent.com/63101175/106869957-2fc04c00-66d9-11eb-8135-09083cc80d9a.png)

