### PR TITLE
UIDATIMP-849 - protection fields in field mapping profile only lists 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * Remove validation error message from invoice field mapping screen (UIDATIMP-814)
 * Cannot view log for OCLC Single record import jobs. Fixed (UIDATIMP-848)
 * Create/Edit Match Profile WCAG 2.1 AA - Color Contrast violation (UIDATIMP-818)
+* Protection fields in field mapping profile only lists 10. Fixed (UIDATIMP-849)
 
 ## [3.0.3](https://github.com/folio-org/ui-data-import/tree/v3.0.3) (2020-11-13)
 

--- a/src/settings/MappingProfiles/MappingProfiles.js
+++ b/src/settings/MappingProfiles/MappingProfiles.js
@@ -171,7 +171,7 @@ export class MappingProfiles extends Component {
       path: 'field-protection-settings/marc',
       records: 'marcFieldProtectionSettings',
       throwErrors: false,
-      GET: { path: 'field-protection-settings/marc?query=source=USER' },
+      GET: { path: 'field-protection-settings/marc?query=source=USER&limit=1000' },
     },
   });
 


### PR DESCRIPTION
## Overview
When we have more than 10 fields protected in MARC field protection Settings, only 10 appear for override in the field mapping profile (bibliographic, updates), with no option to scroll.

## Approach
- query string has been extended with 'limit' param

## Refs
https://issues.folio.org/browse/UIDATIMP-849
