### PR TITLE
UIDATIMP-867: Match profile: form values are reset on page resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * Protection fields in field mapping profile only lists 10. Fixed (UIDATIMP-849)
 * Invoice field mapping: Lock total checkbox is not working properly. Fixed (UIDATIMP-857)
 * Invoice field mapping: Exchange rate checkbox is not being saved. Fixed (UIDATIMP-864)
+* Match profile: form values are reset on page resize (UIDATIMP-867)
 
 ## [3.0.3](https://github.com/folio-org/ui-data-import/tree/v3.0.3) (2020-11-13)
 

--- a/src/settings/MatchProfiles/MatchProfilesForm.js
+++ b/src/settings/MatchProfiles/MatchProfilesForm.js
@@ -12,6 +12,7 @@ import { Field } from 'react-final-form';
 import {
   get,
   isEmpty,
+  isEqual,
   noop,
 } from 'lodash';
 
@@ -346,5 +347,6 @@ export const MatchProfilesForm = compose(
   stripesFinalForm({
     navigationCheck: true,
     destroyOnUnregister: true,
+    initialValuesEqual: isEqual,
   }),
 )(MatchProfilesFormComponent);


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
When a page is resized for a new match profile, all form values are reset.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add the `initialValuesEqual` option to the `stripesFinalForm` decorator.

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-867

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![261v0bakBE](https://user-images.githubusercontent.com/55138456/110935490-22315e00-8338-11eb-8bb4-6aeafda12877.gif)

