### PR TITLE
UIDATIMP-749 Adjust the UI for action profiles when linked to job pro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change history for ui-data-import
 
 ## **4.1.0** (in progress)
+### Features added:
+* Adjust the UI for action profiles when linked to job profiles (UIDATIMP-749)
+* Adjust the UI for action profiles when linked to field mapping profiles (UIDATIMP-870)
 
 ## [4.0.0](https://github.com/folio-org/ui-data-import/tree/v4.0.0) (2021-03-18)
 

--- a/src/components/ListTemplate/listTemplate.js
+++ b/src/components/ListTemplate/listTemplate.js
@@ -14,7 +14,6 @@ import {
 } from './ColumnTemplates';
 import {
   formatUserName,
-  ENTITY_KEYS,
   FILE_STATUSES,
 } from '../../utils';
 
@@ -76,13 +75,6 @@ export const listTemplate = ({
   action: record => (
     <ActionColumn
       record={record}
-      searchTerm={searchTerm}
-    />
-  ),
-  mapping: record => (
-    <DefaultColumn
-      iconKey={ENTITY_KEYS.MAPPING_PROFILES}
-      value={record.mapping || ''}
       searchTerm={searchTerm}
     />
   ),

--- a/src/components/ProfileTree/ProfileTree.css
+++ b/src/components/ProfileTree/ProfileTree.css
@@ -18,7 +18,13 @@
   border: 1px solid rgba(0, 0, 0, 0.2);
   border-radius: 5px;
   background-color: var(--color-fill);
-  & .record-container {padding: 7px;}
+  & .record-container {
+      padding: 7px;
+      & [class|=button] {
+          text-align: left;
+          white-space: normal;
+      }
+  }
   & .buttons-container {
     display: flex;
     justify-content: space-between;

--- a/src/settings/ActionProfiles/ActionProfiles.js
+++ b/src/settings/ActionProfiles/ActionProfiles.js
@@ -33,13 +33,11 @@ const queryTemplate = `(
   name="%{query.query}*" OR
   action="%{query.query}*" OR
   folioRecord="%{query.query}*" OR
-  mapping="%{query.query}*" OR
   tags.tagList="%{query.query}*"
 )`;
 const sortMap = {
   name: 'name',
   action: 'action folioRecord',
-  mapping: 'mapping',
   tags: 'tags.tagList',
   updated: 'metadata.updatedDate',
   updatedBy: 'userInfo.firstName userInfo.lastName userInfo.userName',
@@ -75,7 +73,6 @@ export const actionProfilesShape = {
   visibleColumns: [
     'name',
     'action',
-    'mapping',
     'tags',
     'updated',
     'updatedBy',
@@ -93,7 +90,6 @@ export const actionProfilesShape = {
     let headers = {
       name: <FormattedMessage id="ui-data-import.name" />,
       action: <FormattedMessage id="ui-data-import.action" />,
-      mapping: <FormattedMessage id="ui-data-import.mapping" />,
       tags: <FormattedMessage id="ui-data-import.tags" />,
       updated: <FormattedMessage id="ui-data-import.updated" />,
       updatedBy: <FormattedMessage id="ui-data-import.updatedBy" />,

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -382,7 +382,6 @@ export const PROFILE_LINKING_RULES = {
     [ENTITY_KEYS.ACTION_PROFILES]: [
       'name',
       'action',
-      'mapping',
     ],
   },
   childrenAllowed: [ENTITY_KEYS.MATCH_PROFILES],


### PR DESCRIPTION
UIDATIMP-749 Adjust the UI for action profiles when linked to job profiles
UIDATIMP-870 Adjust the UI for action profiles when linked to field mapping profiles
## Purpose
To get rid of stray punctuation for action profiles attached to job profiles and unused column for action profiles that are linked to field mapping profiles

## Refs
https://issues.folio.org/browse/UIDATIMP-749
https://issues.folio.org/browse/UIDATIMP-870

## Screenshots
### Before
![before1](https://user-images.githubusercontent.com/63101175/111775839-eeb37e00-88b9-11eb-9d2a-3f59c3f5ea39.png)
![before2](https://user-images.githubusercontent.com/63101175/111776031-31755600-88ba-11eb-87f5-787637225d9b.png)
### After
![after1](https://user-images.githubusercontent.com/63101175/111776435-b06a8e80-88ba-11eb-94ab-fc7343c4a456.png)
![after2](https://user-images.githubusercontent.com/63101175/111776122-4c47ca80-88ba-11eb-8f29-1d2bc224ad3e.png)

