### PR TITLE
UIDATIMP-858: MARC Updates field mapping profile: be able to collapse/expand accordions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Adjust the UI for action profiles when linked to job profiles (UIDATIMP-749)
 * Adjust the UI for action profiles when linked to field mapping profiles (UIDATIMP-870)
 * Cover `<ProhibitionIcon>` component with unit tests (UIDATIMP-719)
+* MARC Updates field mapping profile: be able to collapse/expand accordions (UIDATIMP-858)
 
 ## [4.0.0](https://github.com/folio-org/ui-data-import/tree/v4.0.0) (2021-03-18)
 

--- a/src/components/OverrideProtectedFieldsTable/OverrideProtectedFieldsTable.js
+++ b/src/components/OverrideProtectedFieldsTable/OverrideProtectedFieldsTable.js
@@ -14,6 +14,7 @@ import {
   MultiColumnList,
   Checkbox,
   NoValue,
+  Accordion,
 } from '@folio/stripes/components';
 
 import { MappedHeader } from '..';
@@ -88,25 +89,28 @@ export const OverrideProtectedFieldsTable = ({
   };
   const editModeIdPrefix = isEditable ? 'edit-' : '';
 
+  const header = (
+    <MappedHeader
+      headersToSeparate={[
+        'ui-data-import.settings.profiles.select.mappingProfiles',
+        MAPPING_DETAILS_HEADLINE.MARC_BIBLIOGRAPHIC.labelId,
+        'ui-data-import.fieldMappingsForMarc.overrideProtected',
+      ]}
+    />
+  );
+
   return (
-    <>
+    <Accordion
+      id={`${editModeIdPrefix}override-protected-section`}
+      label={header}
+      separator={false}
+      closedByDefault={!isEditable && noProtectedFieldsDefined}
+    >
       <Row
         between="xs"
-        style={{
-          marginTop: '20px',
-          marginLeft: 0,
-          marginRight: 0,
-        }}
+        style={{ margin: 0 }}
       >
         <Col>
-          <MappedHeader
-            headersToSeparate={[
-              'ui-data-import.settings.profiles.select.mappingProfiles',
-              MAPPING_DETAILS_HEADLINE.MARC_BIBLIOGRAPHIC.labelId,
-              'ui-data-import.fieldMappingsForMarc.overrideProtected',
-            ]}
-            headlineProps={{ margin: 'small' }}
-          />
           {isEditable && !noProtectedFieldsDefined && (
             <span>
               <FormattedMessage id="ui-data-import.fieldMappingsForMarc.updatesOverrides.subtext" />
@@ -122,7 +126,7 @@ export const OverrideProtectedFieldsTable = ({
         formatter={formatter}
         isEmptyMessage={emptyTableMessage}
       />
-    </>
+    </Accordion>
   );
 };
 

--- a/src/settings/MappingProfiles/MappingProfilesForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm.js
@@ -395,28 +395,24 @@ export const MappingProfilesFormComponent = ({
                     between="xs"
                     style={{ margin: 0 }}
                   >
-                    <Col>
-                      <MappedHeader
-                        headersToSeparate={[
-                          'ui-data-import.settings.profiles.select.mappingProfiles',
-                          MAPPING_DETAILS_HEADLINE[folioRecordType]?.labelId,
-                          FIELD_MAPPINGS_FOR_MARC_OPTIONS.find(option => option.value === fieldMappingsForMARC)?.label,
-                        ]}
-                        headlineProps={{ margin: 'small' }}
-                      />
-
-                      {(fieldMappingsForMARC === FIELD_MAPPINGS_FOR_MARC.UPDATES) && (
-                        <span>
-                          <FormattedMessage id="ui-data-import.fieldMappingsForMarc.updates.subtext" />
-                        </span>
-                      )}
-                    </Col>
                     {!isMARCType(folioRecordType) && (
-                      <Col>
-                        <div data-test-expand-all-button>
-                          <ExpandAllButton />
-                        </div>
-                      </Col>
+                      <>
+                        <Col>
+                          <MappedHeader
+                            headersToSeparate={[
+                              'ui-data-import.settings.profiles.select.mappingProfiles',
+                              MAPPING_DETAILS_HEADLINE[folioRecordType]?.labelId,
+                              FIELD_MAPPINGS_FOR_MARC_OPTIONS.find(option => option.value === fieldMappingsForMARC)?.label,
+                            ]}
+                            headlineProps={{ margin: 'small' }}
+                          />
+                        </Col>
+                        <Col>
+                          <div data-test-expand-all-button>
+                            <ExpandAllButton />
+                          </div>
+                        </Col>
+                      </>
                     )}
                   </Row>
                   {renderDetails[folioRecordType]}

--- a/src/settings/MappingProfiles/ViewMappingProfile.js
+++ b/src/settings/MappingProfiles/ViewMappingProfile.js
@@ -314,6 +314,7 @@ export class ViewMappingProfile extends Component {
           <Accordion
             id="view-mapping-profile-details"
             label={<FormattedMessage id="ui-data-import.details" />}
+            separator={false}
           >
             {existingRecordType && (
               <AccordionStatus>
@@ -321,22 +322,24 @@ export class ViewMappingProfile extends Component {
                   between="xs"
                   style={{ margin: 0 }}
                 >
-                  <Col>
-                    <MappedHeader
-                      headersToSeparate={[
-                        'ui-data-import.settings.profiles.select.mappingProfiles',
-                        MAPPING_DETAILS_HEADLINE[existingRecordType]?.labelId,
-                        marcMappingOptionLabel,
-                      ]}
-                      headlineProps={{ margin: 'small' }}
-                    />
-                  </Col>
                   {!isMARCRecord && (
-                    <Col>
-                      <div data-test-expand-all-button>
-                        <ExpandAllButton />
-                      </div>
-                    </Col>
+                    <>
+                      <Col>
+                        <MappedHeader
+                          headersToSeparate={[
+                            'ui-data-import.settings.profiles.select.mappingProfiles',
+                            MAPPING_DETAILS_HEADLINE[existingRecordType]?.labelId,
+                            marcMappingOptionLabel,
+                          ]}
+                          headlineProps={{ margin: 'small' }}
+                        />
+                      </Col>
+                      <Col>
+                        <div data-test-expand-all-button>
+                          <ExpandAllButton />
+                        </div>
+                      </Col>
+                    </>
                   )}
                 </Row>
                 {renderDetails[existingRecordType]}

--- a/src/settings/MappingProfiles/detailsSections/edit/MappingMARCBibDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/MappingMARCBibDetails.js
@@ -3,15 +3,22 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { isEmpty } from 'lodash';
 
-import { Button } from '@folio/stripes-components';
+import {
+  AccordionSet,
+  Accordion,
+  Button,
+} from '@folio/stripes-components';
 
 import {
   MARCTable,
   OverrideProtectedFieldsTable,
+  MappedHeader,
 } from '../../../../components';
 
 import {
   FIELD_MAPPINGS_FOR_MARC,
+  MAPPING_DETAILS_HEADLINE,
+  FIELD_MAPPINGS_FOR_MARC_OPTIONS,
   marcFieldProtectionSettingsShape,
 } from '../../../../utils';
 
@@ -27,6 +34,16 @@ export const MappingMARCBibDetails = ({
 }) => {
   const defaultFieldMappingForMARCColumns = ['arrows', 'action', 'field', 'indicator1', 'indicator2',
     'subfield', 'subaction', 'data', 'position', 'addRemove'];
+
+  const header = (
+    <MappedHeader
+      headersToSeparate={[
+        'ui-data-import.settings.profiles.select.mappingProfiles',
+        MAPPING_DETAILS_HEADLINE.MARC_BIBLIOGRAPHIC.labelId,
+        FIELD_MAPPINGS_FOR_MARC_OPTIONS.find(option => option.value === fieldMappingsForMARCField)?.label,
+      ]}
+    />
+  );
 
   const renderUpdatesDetails = () => {
     const updatesFieldMappingForMARCColumns = ['arrows', 'field', 'indicator1', 'indicator2', 'subfield', 'addRemove'];
@@ -53,7 +70,16 @@ export const MappingMARCBibDetails = ({
 
     return (
       <>
-        {isEmpty(marcMappingDetails) ? addFieldButton : renderMARCUpdatesTable()}
+        <Accordion
+          id="edit-field-mappings-for-marc-updates"
+          label={header}
+          separator={false}
+        >
+          <div style={{ paddingTop: '10px' }}>
+            <FormattedMessage id="ui-data-import.fieldMappingsForMarc.updates.subtext" />
+          </div>
+          {isEmpty(marcMappingDetails) ? addFieldButton : renderMARCUpdatesTable()}
+        </Accordion>
         <OverrideProtectedFieldsTable
           marcFieldProtectionFields={marcFieldProtectionFields}
           mappingMarcFieldProtectionFields={mappingMarcFieldProtectionFields}
@@ -70,15 +96,25 @@ export const MappingMARCBibDetails = ({
     }
 
     return (
-      <MARCTable
-        columns={defaultFieldMappingForMARCColumns}
-        fields={marcMappingDetails}
-        onChange={setReferenceTables}
-      />
+      <Accordion
+        id="edit-field-mappings-for-marc-modifications"
+        label={header}
+        separator={false}
+      >
+        <MARCTable
+          columns={defaultFieldMappingForMARCColumns}
+          fields={marcMappingDetails}
+          onChange={setReferenceTables}
+        />
+      </Accordion>
     );
   };
 
-  return fieldMappingsForMARCField && renderMappingMARCBibDetails();
+  return fieldMappingsForMARCField && (
+    <AccordionSet>
+      {renderMappingMARCBibDetails()}
+    </AccordionSet>
+  );
 };
 
 MappingMARCBibDetails.propTypes = {

--- a/src/settings/MappingProfiles/detailsSections/view/MappingMARCBibDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/view/MappingMARCBibDetails.js
@@ -2,15 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
 
-import { NoValue } from '@folio/stripes/components';
+import {
+  AccordionSet,
+  Accordion,
+  NoValue,
+} from '@folio/stripes/components';
 
 import {
   MARCTableView,
   OverrideProtectedFieldsTable,
+  MappedHeader,
 } from '../../../../components';
 
 import {
   FIELD_MAPPINGS_FOR_MARC,
+  MAPPING_DETAILS_HEADLINE,
+  FIELD_MAPPINGS_FOR_MARC_OPTIONS,
   marcFieldProtectionSettingsShape,
   mappingMARCFieldShape,
 } from '../../../../utils';
@@ -24,6 +31,16 @@ export const MappingMARCBibDetails = ({
   const defaultFieldMappingForMARCColumns = ['action', 'field', 'indicator1', 'indicator2',
     'subfield', 'subaction', 'data', 'position'];
 
+  const header = (
+    <MappedHeader
+      headersToSeparate={[
+        'ui-data-import.settings.profiles.select.mappingProfiles',
+        MAPPING_DETAILS_HEADLINE.MARC_BIBLIOGRAPHIC.labelId,
+        FIELD_MAPPINGS_FOR_MARC_OPTIONS.find(option => option.value === marcMappingOption)?.label,
+      ]}
+    />
+  );
+
   const renderUpdatesDetails = () => {
     const updatesFieldMappingForMARCColumns = ['field', 'indicator1', 'indicator2', 'subfield'];
 
@@ -36,7 +53,13 @@ export const MappingMARCBibDetails = ({
 
     return (
       <>
-        {!isEmpty(marcMappingDetails) ? renderMARCUpdatesTable() : <NoValue />}
+        <Accordion
+          id="view-field-mappings-for-marc-updates"
+          label={header}
+          separator={false}
+        >
+          {!isEmpty(marcMappingDetails) ? renderMARCUpdatesTable() : <NoValue />}
+        </Accordion>
         <OverrideProtectedFieldsTable
           marcFieldProtectionFields={marcFieldProtectionFields}
           mappingMarcFieldProtectionFields={mappingMarcFieldProtectionFields}
@@ -51,14 +74,24 @@ export const MappingMARCBibDetails = ({
     }
 
     return (
-      <MARCTableView
-        columns={defaultFieldMappingForMARCColumns}
-        fields={marcMappingDetails}
-      />
+      <Accordion
+        id="view-field-mappings-for-marc-modifications"
+        label={header}
+        separator={false}
+      >
+        <MARCTableView
+          columns={defaultFieldMappingForMARCColumns}
+          fields={marcMappingDetails}
+        />
+      </Accordion>
     );
   };
 
-  return renderMappingMARCBibDetails();
+  return (
+    <AccordionSet>
+      {renderMappingMARCBibDetails()}
+    </AccordionSet>
+  );
 };
 
 MappingMARCBibDetails.propTypes = {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
To make the accordions in the MARC update field mapping profile more responsive and efficient

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

- Split `OverrideProtectedFieldsTable` and `MARCTable` into two different accrodions

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-858

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://user-images.githubusercontent.com/40805351/112156943-66054c80-8bef-11eb-972e-6023f12ff3e9.png)

