### PR TITLE
UIDATIMP-887 FOLIO record type dropdown issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features added:
 * Add required field indication and validation to invoice field mapping profile (UIDATIMP-877)
+
+### Bugs fixed:
 * Numeric subfield mappings are not working. Fixed (UIDATIMP-885)
 * FOLIO record type dropdown issue. Fixed (UIDATIMP-887)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features added:
 * Add required field indication and validation to invoice field mapping profile (UIDATIMP-877)
 * Numeric subfield mappings are not working. Fixed (UIDATIMP-885)
+* FOLIO record type dropdown issue. Fixed (UIDATIMP-887)
 
 ## [4.0.1](https://github.com/folio-org/ui-data-import/tree/v4.0.1) (2021-04-02)
 

--- a/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceLineInformation.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceLineInformation.js
@@ -53,7 +53,7 @@ export const InvoiceLineInformation = ({
 }) => {
   const { formatMessage } = useIntl();
 
-  const releaseEncumbranceCheckbox = mappingFields?.[26].subfields[0].fields[13].booleanFieldAction;
+  const releaseEncumbranceCheckbox = mappingFields?.[26].subfields[0]?.fields[13].booleanFieldAction;
   const vendorRefTypesList = createOptionsList(REF_NUMBER_TYPE_OPTIONS, formatMessage, 'labelId');
 
   const getPathToAddField = currentIndex => getInnerSubfieldsPath(currentIndex, 0, 4);


### PR DESCRIPTION
## Overwiew
during profile creation, changing type of FOLIO record leads to error page

## Approach
Optional chaining operator has been added to releaseEncumbranceCheckbox determination

## Refs
https://issues.folio.org/browse/UIDATIMP-887