### PR TITLE
UIDATIMP-891 Suppress quickMARC derive action and field mapping profiles from each other's associated profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features added:
 * Update the UI options for the repurposed quickMARC derive profile (UIDATIMP-890)
+* Suppress quickMARC derive action and field mapping profiles from each other's associated profiles (UIDATIMP-891)
 
 ## [4.0.2](https://github.com/folio-org/ui-data-import/tree/v4.0.2) (2021-04-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features added:
 * Update the UI options for the repurposed quickMARC derive profile (UIDATIMP-890)
 * Suppress quickMARC derive action and field mapping profiles from each other's associated profiles (UIDATIMP-891)
+* Suppress quickMARC derive action profile from Job profile create/update (UIDATIMP-892)
 
 ## [4.0.2](https://github.com/folio-org/ui-data-import/tree/v4.0.2) (2021-04-14)
 

--- a/src/settings/ActionProfiles/ActionProfiles.js
+++ b/src/settings/ActionProfiles/ActionProfiles.js
@@ -68,7 +68,7 @@ export const actionProfilesShape = {
         const notIdOclcUpdateInstanceAction = `(id="" NOT id=="${OCLC_UPDATE_INSTANCE_ACTION_ID}")`;
         const notIdMarcBibCreateAction = `(id="" NOT id=="${OCLC_CREATE_MARC_BIB_ACTION_ID}")`;
         const notIdQuickMarcDeriveCreateAction = `(id="" NOT id=="${QUICKMARK_DERIVE_CREATE_ACTION_ID}")`;
-        
+
         const withoutDefaultProfiles = `AND ${notIdOclcCreateInstanceAction} AND ${notIdOclcUpdateInstanceAction} 
         AND ${notIdMarcBibCreateAction} AND ${notIdQuickMarcDeriveCreateAction}`;
         const query = `${FIND_ALL_CQL} ${withoutDefaultProfiles} ${searchQuery} ${sortQuery}`;

--- a/src/settings/ActionProfiles/ActionProfiles.js
+++ b/src/settings/ActionProfiles/ActionProfiles.js
@@ -69,8 +69,7 @@ export const actionProfilesShape = {
         const notIdMarcBibCreateAction = `(id="" NOT id=="${OCLC_CREATE_MARC_BIB_ACTION_ID}")`;
         const notIdQuickMarcDeriveCreateAction = `(id="" NOT id=="${QUICKMARK_DERIVE_CREATE_ACTION_ID}")`;
 
-        const withoutDefaultProfiles = `AND ${notIdOclcCreateInstanceAction} AND ${notIdOclcUpdateInstanceAction} 
-        AND ${notIdMarcBibCreateAction} AND ${notIdQuickMarcDeriveCreateAction}`;
+        const withoutDefaultProfiles = `AND ${notIdOclcCreateInstanceAction} AND ${notIdOclcUpdateInstanceAction} AND ${notIdMarcBibCreateAction} AND ${notIdQuickMarcDeriveCreateAction}`;
         const query = `${FIND_ALL_CQL} ${withoutDefaultProfiles} ${searchQuery} ${sortQuery}`;
 
         return { query };

--- a/src/settings/ActionProfiles/ActionProfiles.js
+++ b/src/settings/ActionProfiles/ActionProfiles.js
@@ -64,7 +64,13 @@ export const actionProfilesShape = {
         const search = _r?.query?.query;
         const sortQuery = sort ? `sortBy ${getSortQuery(sortMap, sort)}` : '';
         const searchQuery = search ? `AND ${getSearchQuery(queryTemplate, search)}` : '';
-        const withoutDefaultProfiles = `AND (id="" NOT id=="${OCLC_CREATE_INSTANCE_ACTION_ID}") AND (id="" NOT id=="${OCLC_UPDATE_INSTANCE_ACTION_ID}") AND (id="" NOT id=="${OCLC_CREATE_MARC_BIB_ACTION_ID}") AND (id="" NOT id=="${QUICKMARK_DERIVE_CREATE_ACTION_ID}")`;
+        const notIdOclcCreateInstanceAction = `(id="" NOT id=="${OCLC_CREATE_INSTANCE_ACTION_ID}")`;
+        const notIdOclcUpdateInstanceAction = `(id="" NOT id=="${OCLC_UPDATE_INSTANCE_ACTION_ID}")`;
+        const notIdMarcBibCreateAction = `(id="" NOT id=="${OCLC_CREATE_MARC_BIB_ACTION_ID}")`;
+        const notIdQuickMarcDeriveCreateAction = `(id="" NOT id=="${QUICKMARK_DERIVE_CREATE_ACTION_ID}")`;
+        
+        const withoutDefaultProfiles = `AND ${notIdOclcCreateInstanceAction} AND ${notIdOclcUpdateInstanceAction} 
+        AND ${notIdMarcBibCreateAction} AND ${notIdQuickMarcDeriveCreateAction}`;
         const query = `${FIND_ALL_CQL} ${withoutDefaultProfiles} ${searchQuery} ${sortQuery}`;
 
         return { query };

--- a/src/settings/ActionProfiles/ActionProfiles.js
+++ b/src/settings/ActionProfiles/ActionProfiles.js
@@ -20,6 +20,7 @@ import {
   OCLC_CREATE_INSTANCE_ACTION_ID,
   OCLC_UPDATE_INSTANCE_ACTION_ID,
   OCLC_CREATE_MARC_BIB_ACTION_ID,
+  QUICKMARK_DERIVE_CREATE_ACTION_ID,
 } from '../../utils';
 import { ListView } from '../../components';
 import { CheckboxHeader } from '../../components/ListTemplate/HeaderTemplates';
@@ -63,7 +64,7 @@ export const actionProfilesShape = {
         const search = _r?.query?.query;
         const sortQuery = sort ? `sortBy ${getSortQuery(sortMap, sort)}` : '';
         const searchQuery = search ? `AND ${getSearchQuery(queryTemplate, search)}` : '';
-        const withoutDefaultProfiles = `AND (id="" NOT id=="${OCLC_CREATE_INSTANCE_ACTION_ID}") AND (id="" NOT id=="${OCLC_UPDATE_INSTANCE_ACTION_ID}") AND (id="" NOT id=="${OCLC_CREATE_MARC_BIB_ACTION_ID}")`;
+        const withoutDefaultProfiles = `AND (id="" NOT id=="${OCLC_CREATE_INSTANCE_ACTION_ID}") AND (id="" NOT id=="${OCLC_UPDATE_INSTANCE_ACTION_ID}") AND (id="" NOT id=="${OCLC_CREATE_MARC_BIB_ACTION_ID}") AND (id="" NOT id=="${QUICKMARK_DERIVE_CREATE_ACTION_ID}")`;
         const query = `${FIND_ALL_CQL} ${withoutDefaultProfiles} ${searchQuery} ${sortQuery}`;
 
         return { query };

--- a/src/settings/MappingProfiles/MappingProfiles.js
+++ b/src/settings/MappingProfiles/MappingProfiles.js
@@ -19,6 +19,7 @@ import {
   OCLC_CREATE_INSTANCE_MAPPING_ID,
   OCLC_UPDATE_INSTANCE_MAPPING_ID,
   OCLC_CREATE_MARC_BIB_MAPPING_ID,
+  QUICKMARK_DERIVE_CREATE_MAPPING_ID,
   ENTITY_KEYS,
   FIND_ALL_CQL,
 } from '../../utils';
@@ -64,7 +65,7 @@ export const mappingProfilesShape = {
         const search = _r?.query?.query;
         const sortQuery = sort ? `sortBy ${getSortQuery(sortMap, sort)}` : '';
         const searchQuery = search ? `AND ${getSearchQuery(queryTemplate, search)}` : '';
-        const withoutDefaultProfiles = `AND (id="" NOT id=="${OCLC_CREATE_INSTANCE_MAPPING_ID}") AND (id="" NOT id=="${OCLC_UPDATE_INSTANCE_MAPPING_ID}") AND (id="" NOT id=="${OCLC_CREATE_MARC_BIB_MAPPING_ID}")`;
+        const withoutDefaultProfiles = `AND (id="" NOT id=="${OCLC_CREATE_INSTANCE_MAPPING_ID}") AND (id="" NOT id=="${OCLC_UPDATE_INSTANCE_MAPPING_ID}") AND (id="" NOT id=="${OCLC_CREATE_MARC_BIB_MAPPING_ID}") AND (id="" NOT id=="${QUICKMARK_DERIVE_CREATE_MAPPING_ID}")`;
         const query = `${FIND_ALL_CQL} ${withoutDefaultProfiles} ${searchQuery} ${sortQuery}`;
 
         return { query };

--- a/src/settings/MappingProfiles/MappingProfiles.js
+++ b/src/settings/MappingProfiles/MappingProfiles.js
@@ -70,8 +70,7 @@ export const mappingProfilesShape = {
         const notIdMarcBibCreateMapping = `(id="" NOT id=="${OCLC_CREATE_MARC_BIB_MAPPING_ID}")`;
         const notIdQuickMarcDeriveCreateMapping = `(id="" NOT id=="${QUICKMARK_DERIVE_CREATE_MAPPING_ID}")`;
 
-        const withoutDefaultProfiles = `AND ${notIdOclcCreateInstanceMapping} AND ${notIdOclcUpdateInstanceMapping} 
-        AND ${notIdMarcBibCreateMapping} AND ${notIdQuickMarcDeriveCreateMapping}`;
+        const withoutDefaultProfiles = `AND ${notIdOclcCreateInstanceMapping} AND ${notIdOclcUpdateInstanceMapping} AND ${notIdMarcBibCreateMapping} AND ${notIdQuickMarcDeriveCreateMapping}`;
         const query = `${FIND_ALL_CQL} ${withoutDefaultProfiles} ${searchQuery} ${sortQuery}`;
 
         return { query };

--- a/src/settings/MappingProfiles/MappingProfiles.js
+++ b/src/settings/MappingProfiles/MappingProfiles.js
@@ -65,7 +65,13 @@ export const mappingProfilesShape = {
         const search = _r?.query?.query;
         const sortQuery = sort ? `sortBy ${getSortQuery(sortMap, sort)}` : '';
         const searchQuery = search ? `AND ${getSearchQuery(queryTemplate, search)}` : '';
-        const withoutDefaultProfiles = `AND (id="" NOT id=="${OCLC_CREATE_INSTANCE_MAPPING_ID}") AND (id="" NOT id=="${OCLC_UPDATE_INSTANCE_MAPPING_ID}") AND (id="" NOT id=="${OCLC_CREATE_MARC_BIB_MAPPING_ID}") AND (id="" NOT id=="${QUICKMARK_DERIVE_CREATE_MAPPING_ID}")`;
+        const notIdOclcCreateInstanceMapping = `(id="" NOT id=="${OCLC_CREATE_INSTANCE_MAPPING_ID}")`;
+        const notIdOclcUpdateInstanceMapping = `(id="" NOT id=="${OCLC_UPDATE_INSTANCE_MAPPING_ID}")`;
+        const notIdMarcBibCreateMapping = `(id="" NOT id=="${OCLC_CREATE_MARC_BIB_MAPPING_ID}")`;
+        const notIdQuickMarcDeriveCreateMapping = `(id="" NOT id=="${QUICKMARK_DERIVE_CREATE_MAPPING_ID}")`;
+
+        const withoutDefaultProfiles = `AND ${notIdOclcCreateInstanceMapping} AND ${notIdOclcUpdateInstanceMapping} 
+        AND ${notIdMarcBibCreateMapping} AND ${notIdQuickMarcDeriveCreateMapping}`;
         const query = `${FIND_ALL_CQL} ${withoutDefaultProfiles} ${searchQuery} ${sortQuery}`;
 
         return { query };


### PR DESCRIPTION
## Purpose
Since the quickMARC derive action profile and field mapping profile should only be linked to each other, suppress them from displaying when associating a user-created action profile with a user-created field mapping profile and vice versa.

Since the quickMARC derive action profile should only be used for the system quickMARC derive job profile, disallow it from being linked to any user-created job profiles.

## Approach
- extend query string to exclude appropriate profiles

## Refs
https://issues.folio.org/browse/UIDATIMP-891
https://issues.folio.org/browse/UIDATIMP-892