### PR TITLE
UIDATIMP-893 Suppress quickMARC derive job profile from the Choose jobs list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features added:
 * Update the UI options for the repurposed quickMARC derive profile (UIDATIMP-890)
+* Suppress quickMARC derive job profile from the Choose jobs list (UIDATIMP-893)
 
 ## [4.0.2](https://github.com/folio-org/ui-data-import/tree/v4.0.2) (2021-04-14)
 

--- a/src/settings/JobProfiles/JobProfiles.js
+++ b/src/settings/JobProfiles/JobProfiles.js
@@ -19,6 +19,7 @@ import {
   FIND_ALL_CQL,
   OCLC_CREATE_INSTANCE_JOB_ID,
   OCLC_UPDATE_INSTANCE_JOB_ID,
+  QUICKMARK_DERIVE_CREATE_JOB_ID,
 } from '../../utils';
 import {
   ListView,
@@ -166,7 +167,7 @@ export const createJobProfiles = (chooseJobProfile = false, dataTypeQuery = '', 
             ? `dataType==${dataTypeQuery}`
             : FIND_ALL_CQL;
           const withoutDefaultProfiles = hideDefaultProfiles
-            ? `AND (id="" NOT id=="${OCLC_CREATE_INSTANCE_JOB_ID}") AND (id="" NOT id=="${OCLC_UPDATE_INSTANCE_JOB_ID}")`
+            ? `AND (id="" NOT id=="${OCLC_CREATE_INSTANCE_JOB_ID}") AND (id="" NOT id=="${OCLC_UPDATE_INSTANCE_JOB_ID}") AND (id="" NOT id=="${QUICKMARK_DERIVE_CREATE_JOB_ID}")`
             : '';
           const queryTemplate = chooseJobProfile
             ? 'AND (name="%{query.query}*" OR tags.tagList="%{query.query}*" OR description="%{query.query}*")'


### PR DESCRIPTION
## Purpose
Since the quickMARC derive job profiles is only used by the system (when triggered by an action from quickMARC), it should not display on the Choose jobs page after a user has uploaded a file for import.

## Approach
- extend query string to exclude appropriate profiles
- 
## Refs
https://issues.folio.org/browse/UIDATIMP-893