### PR TITLE
UIDATIMP-928: Update jest-related configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Data Import Settings > Apply baseline shortcut keys for Action profile (UIDATIMP-900)
 * Data Import Settings > Apply baseline shortcut keys for Match profile (UIDATIMP-899)
 * Data Import Settings > Apply baseline shortcut keys for Field Mapping profile (UIDATIMP-901)
+* Update jest-related configs (UIDATIMP-928)
 
 ### Bugs fixed:
 * folio-testing UI is completely broken for all apps (UIDATIMP-915)

--- a/test/jest/babel.config.js
+++ b/test/jest/babel.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   presets: [
     '@babel/preset-env',
-    '@babel/preset-react',
+    ['@babel/preset-react', { runtime: 'automatic' }],
   ],
   plugins: [
     ['@babel/plugin-proposal-decorators', { legacy: true }],


### PR DESCRIPTION
Update jest babel config to avoid errors related to: `ReferenceError: React is not defined`