### PR TITLE
UIDATIMP-920: For Holdings and Items, add validation for the "Staff only" field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Rename constant "MARC" to "MARC_BIB" (UIDATIMP-917)
 * Data Import Settings > Apply baseline shortcut keys for File Extension (UIDATIMP-879)
 * Update version of interfaces due to supporting MARC Authority records (UIDATIMP-933)
+* Field Mapping profiles: For Holdings and Items, add validation for the "Staff only" field (UIDATIMP-920)
 
 ### Bugs fixed:
 * folio-testing UI is completely broken for all apps (UIDATIMP-915)

--- a/src/components/BooleanActionField/BooleanActionField.js
+++ b/src/components/BooleanActionField/BooleanActionField.js
@@ -15,6 +15,7 @@ export const BooleanActionField = ({
   name,
   label,
   placeholder,
+  required,
   disabled,
 }) => {
   const intl = useIntl();
@@ -36,6 +37,7 @@ export const BooleanActionField = ({
       label={label}
       placeholder={checkboxPlaceholder}
       dataOptions={dataOptions}
+      required={required}
       disabled={disabled}
     />
   );
@@ -46,6 +48,7 @@ BooleanActionField.propTypes = {
   id: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   placeholder: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  required: PropTypes.bool,
   disabled: PropTypes.bool,
 };
 
@@ -53,5 +56,6 @@ BooleanActionField.defaultProps = {
   id: '',
   label: '',
   placeholder: '',
+  required: false,
   disabled: false,
 };

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsNotes.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsNotes.js
@@ -104,6 +104,7 @@ export const HoldingsNotes = ({
                       <BooleanActionField
                         label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.staffOnly`} />}
                         name={getBoolSubfieldName(21, 2, index)}
+                        required
                       />
                     </Col>
                   </Row>

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/ItemNotes.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/ItemNotes.js
@@ -104,6 +104,7 @@ export const ItemNotes = ({
                       <BooleanActionField
                         label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.staffOnly`} />}
                         name={getBoolSubfieldName(24, 2, index)}
+                        required
                       />
                     </Col>
                   </Row>

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/LoanAndAvailability.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/LoanAndAvailability.js
@@ -197,6 +197,7 @@ export const LoanAndAvailability = ({
                       <BooleanActionField
                         label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.staffOnly`} />}
                         name={getBoolSubfieldName(28, 2, index)}
+                        required
                       />
                     </Col>
                   </Row>


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Inventory Holdings and Item records have notes fields which include a checkbox for staff only or not. If a field mapping profile is created, and no value is selected for the "staff only" checkbox, then the import will error. This story adds validation to that portion of the notes field in the field mapping profiles UI, to reduce the chance of making errors when creating or updating a field mapping profile.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add `required` prop to the `Field`

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-920

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://user-images.githubusercontent.com/55138456/120809743-11694080-c553-11eb-88a0-383e691ec9cb.png)

![image](https://user-images.githubusercontent.com/55138456/120809694-044c5180-c553-11eb-9a93-bc3a26b5224c.png)

![image](https://user-images.githubusercontent.com/55138456/120809643-f7c7f900-c552-11eb-87ff-472099425056.png)

