### PR TITLE
UIDATIMP-950 Ensure that the most recent 25 import logs display on the Data Import Landing Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * prefer @folio/stripes exports to private paths when importing TextDate component (UIDATIMP-941)
 * Cover `<WithTranslation>` component with unit tests (UIDATIMP-733)
 * Cover `<OptionsList>` component with unit tests (UIDATIMP-714)
+* Ensure that the most recent 25 import logs display on the Data Import Landing Page (UIDATIMP-950)
 
 ## [4.1.1](https://github.com/folio-org/ui-data-import/tree/v4.1.1) (2021-06-25)
 

--- a/src/components/DataFetcher/DataFetcher.js
+++ b/src/components/DataFetcher/DataFetcher.js
@@ -35,7 +35,10 @@ const jobsUrl = createUrl('metadata-provider/jobExecutions', {
 }, false);
 
 const logsUrl = createUrl('metadata-provider/jobExecutions', {
-  query: `(status any "${COMMITTED} ${ERROR}") sortBy completedDate/sort.descending`,
+  query: `(status any "${COMMITTED} ${ERROR}") 
+  AND (jobProfileInfo="\\“id\\“==" NOT jobProfileInfo="\\“id\\“=="d0ebb7b0-2f0f-11eb-adc1-0242ac120002") 
+  AND (jobProfileInfo="\\“id\\“==" NOT jobProfileInfo="\\“id\\“=="91f9b8d6-d80e-4727-9783-73fb53e3c786"") 
+  sortBy completedDate/sort.descending`,
   limit: 25,
 }, false);
 

--- a/src/components/DataFetcher/DataFetcher.js
+++ b/src/components/DataFetcher/DataFetcher.js
@@ -13,6 +13,8 @@ import { jobExecutionPropTypes } from '../Jobs/components/Job/jobExecutionPropTy
 import {
   JOB_STATUSES,
   FILE_STATUSES,
+  OCLC_CREATE_INSTANCE_JOB_ID,
+  OCLC_UPDATE_INSTANCE_JOB_ID,
 } from '../../utils';
 
 import { DataFetcherContext } from '.';
@@ -36,8 +38,8 @@ const jobsUrl = createUrl('metadata-provider/jobExecutions', {
 
 const logsUrl = createUrl('metadata-provider/jobExecutions', {
   query: `(status any "${COMMITTED} ${ERROR}") 
-  AND (jobProfileInfo="\\“id\\“==" NOT jobProfileInfo="\\“id\\“=="d0ebb7b0-2f0f-11eb-adc1-0242ac120002") 
-  AND (jobProfileInfo="\\“id\\“==" NOT jobProfileInfo="\\“id\\“=="91f9b8d6-d80e-4727-9783-73fb53e3c786"") 
+  AND (jobProfileInfo="\\“id\\“==" NOT jobProfileInfo="\\“id\\“=="${OCLC_CREATE_INSTANCE_JOB_ID}") 
+  AND (jobProfileInfo="\\“id\\“==" NOT jobProfileInfo="\\“id\\“=="${OCLC_UPDATE_INSTANCE_JOB_ID}") 
   sortBy completedDate/sort.descending`,
   limit: 25,
 }, false);

--- a/src/components/RecentJobLogs/RecentJobLogs.js
+++ b/src/components/RecentJobLogs/RecentJobLogs.js
@@ -10,11 +10,6 @@ import { stripesConnect } from '@folio/stripes/core';
 import { DataFetcherContext } from '../DataFetcher';
 import { JobLogsContainer } from '../JobLogsContainer';
 
-import {
-  OCLC_CREATE_INSTANCE_JOB_ID,
-  OCLC_UPDATE_INSTANCE_JOB_ID,
-} from '../../utils';
-
 const sortColumns = {
   ...DEFAULT_JOB_LOGS_SORT_COLUMNS,
   fileName: {
@@ -33,19 +28,13 @@ const RecentJobLogsComponent = () => {
     hasLoaded,
   } = useContext(DataFetcherContext);
 
-  const filteredFromOCLCLogs = logs?.filter(log => {
-    const { jobProfileInfo: { id: jobProfileId } } = log;
-
-    return jobProfileId !== OCLC_CREATE_INSTANCE_JOB_ID && jobProfileId !== OCLC_UPDATE_INSTANCE_JOB_ID;
-  });
-
   return (
     <JobLogsContainer>
       {({ listProps }) => (
         <JobLogs
           sortColumns={sortColumns}
           hasLoaded={hasLoaded}
-          contentData={filteredFromOCLCLogs}
+          contentData={logs}
           formatter={listProps.resultsFormatter}
           {...listProps}
         />


### PR DESCRIPTION
## Purpose
To ensure that the most recent 25 Imports show on the Data Import landing page

As a staff person working with imported files
I want to see the most recent 25 imports on the Data Import landing page (excluding the Inventory Single Record Imports)
So that I can maintain an understanding of the most recent imports

## Approach
- request to the job list has been updated to exclude OCLC records 
- filtering for job list has been removed from UI;

## Refs
https://issues.folio.org/browse/UIDATIMP-950

## Screenshots
![viewAll](https://user-images.githubusercontent.com/63101175/125673099-46f78b4e-3393-48c7-9933-d7cc4e7ca17d.png)
![landing](https://user-images.githubusercontent.com/63101175/125673201-1431ac00-73df-446d-b518-581369a928db.png)

