### PR TITLE
UIDATIMP-951: After editing the match profile the data does not change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bugs fixed:
 * When closing the log summary, user sometimes goes to unexpected place (UIDATIMP-949)
+* After editing the match profile the data does not change (UIDATIMP-951)
 
 ## [4.1.1](https://github.com/folio-org/ui-data-import/tree/v4.1.1) (2021-06-25)
 

--- a/src/components/MatchCriterion/edit/IncomingSectionStatic/StaticValueDateRange.js
+++ b/src/components/MatchCriterion/edit/IncomingSectionStatic/StaticValueDateRange.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'react-final-form';
+import moment from 'moment';
 
 import {
   Layout,
@@ -9,9 +10,20 @@ import {
   Headline,
 } from '@folio/stripes/components';
 
+import { isFieldPristine } from '../../../../utils';
+
 import css from '../MatchCriterions.css';
 
+const DATE_FORMAT = 'YYYY-MM-DD';
+
 export const StaticValueDateRange = ({ repeatableIndex }) => {
+  const getDatesEqualState = (initialDate, newDate) => {
+    const initialFormattedDate = moment.utc(initialDate, DATE_FORMAT).format();
+    const newFormattedDate = moment.utc(newDate, DATE_FORMAT).format();
+
+    return isFieldPristine(initialFormattedDate, newFormattedDate);
+  };
+
   return (
     <Layout
       data-test-static-date-range-field
@@ -28,9 +40,15 @@ export const StaticValueDateRange = ({ repeatableIndex }) => {
         {([ariaLabel]) => (
           <Field
             name={`profile.matchDetails[${repeatableIndex}].incomingMatchExpression.staticValueDetails.fromDate`}
-            component={Datepicker}
-            dateFormat="YYYY-MM-DD"
-            aria-label={ariaLabel}
+            isEqual={getDatesEqualState}
+            render={fieldProps => (
+              <Datepicker
+                {...fieldProps}
+                aria-label={ariaLabel}
+                dateFormat={DATE_FORMAT}
+                dirty={fieldProps.meta.dirty}
+              />
+            )}
           />
         )}
       </FormattedMessage>
@@ -46,9 +64,15 @@ export const StaticValueDateRange = ({ repeatableIndex }) => {
         {([ariaLabel]) => (
           <Field
             name={`profile.matchDetails[${repeatableIndex}].incomingMatchExpression.staticValueDetails.toDate`}
-            component={Datepicker}
-            dateFormat="YYYY-MM-DD"
-            aria-label={ariaLabel}
+            isEqual={getDatesEqualState}
+            render={fieldProps => (
+              <Datepicker
+                {...fieldProps}
+                aria-label={ariaLabel}
+                dateFormat={DATE_FORMAT}
+                dirty={fieldProps.meta.dirty}
+              />
+            )}
           />
         )}
       </FormattedMessage>

--- a/src/utils/formUtils.js
+++ b/src/utils/formUtils.js
@@ -157,6 +157,16 @@ export const isFieldPristine = (initialValue, currentValue) => {
   return isEqual(initialValue, currentValue);
 };
 
+/**
+ * Handles profile form saving
+ *
+ * @param {function} handleSubmit react-final-form render prop. Handles a form submit.
+ * @param {function} resetForm react-final-form prop. Resets the values back to the initial values
+ * the form was initialized with.
+ * @param {function} transitionToParams Builds URL with passed params.
+ * @param {string} path URL basic path.
+ * @returns {(function(*=): Promise<void>)|*}
+ */
 export const handleProfileSave = (handleSubmit, resetForm, transitionToParams, path) => async event => {
   const record = await handleSubmit(event);
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
After editing the match profile the data does not change.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add check on date range fields pristine.
- Fix dirty state of date inputs.

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-951

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![Whr5Q9VAPM](https://user-images.githubusercontent.com/55138456/126639862-8ebaf779-3f70-4e7a-a9a1-0777ab4635b6.gif)
