### PR TITLE
UIDATIMP-718: Cover <ProfileTree> component with unit tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Cover `<MatchCriterion>` component with unit tests (UIDATIMP-711)
 * Use `<PersistedPaneset>` smart component for Data Import landing page (UIDATIMP-884)
 * Cover `<LogViewer>` component with unit tests (UIDATIMP-710)
+* Cover `<ProfileTree>` component with unit tests (UIDATIMP-718)
 
 ## [4.1.2](https://github.com/folio-org/ui-data-import/tree/v4.1.2) (2021-07-31)
 

--- a/src/components/ProfileTree/ProfileBranch.test.js
+++ b/src/components/ProfileTree/ProfileBranch.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 import '../../../test/jest/__mock__';
 import { translationsProperties } from '../../../test/jest/helpers';
 
 import { ProfileBranch } from './ProfileBranch';
-import { fireEvent } from '@testing-library/react';
 
 window.ResizeObserver = jest.fn(() => ({
   observe() {},
@@ -31,22 +31,22 @@ const profileBranchProps = {
     contentType: 'matchProfile',
     content: {
       id: 'testId',
-      name: 'testName'
+      name: 'testName',
     },
-    childSnapshotWrappers: [{ 
+    childSnapshotWrappers: [{
       reactTo: 'MATCH',
       contentType: 'matchProfile',
       content: {
         id: 'testId',
-        name: 'testName'
+        name: 'testName',
       },
       childSnapshotWrappers: [],
-    }, { 
+    }, {
       reactTo: 'NON_MATCH',
       contentType: 'matchProfile',
       content: {
         id: 'testId',
-        name: 'testName'
+        name: 'testName',
       },
       childSnapshotWrappers: [],
     }],
@@ -55,7 +55,7 @@ const profileBranchProps = {
     contentType: 'matchProfile',
     content: {
       id: 'testId',
-      name: 'testName'
+      name: 'testName',
     },
     childSnapshotWrappers: [{ reactTo: 'MATCH' }, { reactTo: 'NON_MATCH' }],
   },
@@ -80,7 +80,7 @@ const profileBranchProps = {
         },
         description: 'testDescription',
       }],
-    }
+    },
   },
 };
 
@@ -93,7 +93,7 @@ const renderProfileBranch = ({
   setParentSectionData,
   resources,
   okapi,
-  record
+  record,
 }) => {
   const component = (
     <ProfileBranch
@@ -116,7 +116,7 @@ describe('ProfileBranch', () => {
   afterAll(() => {
     delete window.ResizeObserver;
   });
-  
+
   it('should be rendered', () => {
     const { getAllByText } = renderProfileBranch(profileBranchProps);
 
@@ -136,13 +136,12 @@ describe('ProfileBranch', () => {
       fireEvent.click(button);
 
       expect(expandedBlock).not.toHaveClass('expanded');
-
     });
   });
 
   describe('when clicking on For non matches button', () => {
     it('content block should be expanded', () => {
-      const { container, getByText, debug } = renderProfileBranch(profileBranchProps);
+      const { container } = renderProfileBranch(profileBranchProps);
       const button = container.querySelector('[aria-controls="accordion32"]');
       const expandedBlock = container.querySelector('#accordion32');
 

--- a/src/components/ProfileTree/ProfileBranch.test.js
+++ b/src/components/ProfileTree/ProfileBranch.test.js
@@ -1,0 +1,156 @@
+import React from 'react';
+
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+import '../../../test/jest/__mock__';
+import { translationsProperties } from '../../../test/jest/helpers';
+
+import { ProfileBranch } from './ProfileBranch';
+import { fireEvent } from '@testing-library/react';
+
+window.ResizeObserver = jest.fn(() => ({
+  observe() {},
+  unobserve() {},
+}));
+const profileBranchProps = {
+  linkingRules: {
+    profilesAllowed: ['matchProfiles', 'actionProfiles'],
+    childrenAllowed: ['actionProfiles', 'matchProfiles'],
+    siblingsProhibited: { actionProfiles: ['matchProfile'] },
+    columnsAllowed: {
+      matchProfiles: [
+        'name',
+        'match',
+      ],
+      actionProfiles: [
+        'name',
+        'action',
+      ],
+    },
+  },
+  recordData: {
+    contentType: 'matchProfile',
+    content: {
+      id: 'testId',
+      name: 'testName'
+    },
+    childSnapshotWrappers: [{ 
+      reactTo: 'MATCH',
+      contentType: 'matchProfile',
+      content: {
+        id: 'testId',
+        name: 'testName'
+      },
+      childSnapshotWrappers: [],
+    }, { 
+      reactTo: 'NON_MATCH',
+      contentType: 'matchProfile',
+      content: {
+        id: 'testId',
+        name: 'testName'
+      },
+      childSnapshotWrappers: [],
+    }],
+  },
+  parentRecordData: {
+    contentType: 'matchProfile',
+    content: {
+      id: 'testId',
+      name: 'testName'
+    },
+    childSnapshotWrappers: [{ reactTo: 'MATCH' }, { reactTo: 'NON_MATCH' }],
+  },
+  parentSectionKey: 'jobProfiles.current.testId.data.match',
+  record: null,
+  parentSectionData: [{ reactTo: 'MATCH' }],
+  setParentSectionData: jest.fn(),
+  okapi: {
+    tenant: 'test-tenant',
+    token: 'test-token',
+    url: 'test-url',
+  },
+  resources: {
+    jobProfile: {
+      hasLoaded: true,
+      records: [{
+        name: 'testName',
+        dataType: 'EDIFACT',
+        metadata: {
+          createdByUserId: 'testUserId',
+          updateByUserId: 'testUserId',
+        },
+        description: 'testDescription',
+      }],
+    }
+  },
+};
+
+const renderProfileBranch = ({
+  linkingRules,
+  recordData,
+  parentRecordData,
+  parentSectionKey,
+  parentSectionData,
+  setParentSectionData,
+  resources,
+  okapi,
+  record
+}) => {
+  const component = (
+    <ProfileBranch
+      linkingRules={linkingRules}
+      recordData={recordData}
+      parentRecordData={parentRecordData}
+      parentSectionKey={parentSectionKey}
+      parentSectionData={parentSectionData}
+      setParentSectionData={setParentSectionData}
+      resources={resources}
+      okapi={okapi}
+      record={record}
+    />
+  );
+
+  return renderWithIntl(component, translationsProperties);
+};
+
+describe('ProfileBranch', () => {
+  afterAll(() => {
+    delete window.ResizeObserver;
+  });
+  
+  it('should be rendered', () => {
+    const { getAllByText } = renderProfileBranch(profileBranchProps);
+
+    expect(getAllByText('Match profile: "testName"')).toBeDefined();
+    expect(getAllByText('For matches')).toBeDefined();
+    expect(getAllByText('For non-matches')).toBeDefined();
+  });
+
+  describe('when clicking on For matches button', () => {
+    it('content block should be collapsed', () => {
+      const { container } = renderProfileBranch(profileBranchProps);
+      const button = container.querySelector('.defaultCollapseButton');
+      const expandedBlock = container.querySelector('.content-wrap.expanded');
+
+      expect(expandedBlock).toHaveClass('expanded');
+
+      fireEvent.click(button);
+
+      expect(expandedBlock).not.toHaveClass('expanded');
+
+    });
+  });
+
+  describe('when clicking on For non matches button', () => {
+    it('content block should be expanded', () => {
+      const { container, getByText, debug } = renderProfileBranch(profileBranchProps);
+      const button = container.querySelector('[aria-controls="accordion32"]');
+      const expandedBlock = container.querySelector('#accordion32');
+
+      expect(expandedBlock).toHaveClass('expanded');
+
+      fireEvent.click(button);
+
+      expect(expandedBlock).not.toHaveClass('expanded');
+    });
+  });
+});

--- a/src/components/ProfileTree/ProfileLabel.test.js
+++ b/src/components/ProfileTree/ProfileLabel.test.js
@@ -1,0 +1,215 @@
+import React from 'react';
+
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+import '../../../test/jest/__mock__';
+import { translationsProperties } from '../../../test/jest/helpers';
+
+import { ProfileLabel } from './ProfileLabel';
+import { fireEvent } from '@testing-library/react';
+
+jest.mock('@folio/stripes/components', () => ({
+  ...jest.requireActual('@folio/stripes/components'),
+  ConfirmationModal: jest.fn(({
+    open,
+    onCancel,
+    onConfirm,
+  }) => (open ? (
+    <div>
+      <span>Confirmation modal</span>
+      <button
+        type="button"
+        onClick={onCancel}
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        id="confirmButton"
+        onClick={onConfirm}
+      >
+        Confirm
+      </button>
+    </div>
+  ) : null)),
+}));
+
+const profileLabelProps = ({ allowUnlink, allowDelete, record }) => {
+  return {
+    linkingRules: {
+      columnsAllowed: {
+        matchProfiles: ['name', 'match'],
+        actionProfiles: ['name', 'action'],
+      },
+      allowUnlink,
+      allowDelete,
+    },
+    recordData: {
+      contentType: 'matchProfile',
+      content: {
+        id: 'testId',
+        name: 'testName'
+      },
+      childSnapshotWrappers: [{ contentType: 'mapping-profiles' }],
+    },
+    parentRecordData: {
+      contentType: 'INVOICE',
+      profileId: '448ae575-daec-49c1-8041-d64c8ed8e5b1',
+    },
+    parentSectionKey: 'jobProfiles.current',
+    parentSectionData: [{}],
+    setParentSectionData: jest.fn(),
+    resources: {},
+    label: 'test label',
+    currentProfilesRelationTypes: 'ROOT',
+    record,
+  };
+};
+
+const renderProfileLabel = ({
+  linkingRules,
+  recordData,
+  parentRecordData,
+  parentSectionKey,
+  parentSectionData,
+  setParentSectionData,
+  resources,
+  label,
+  record,
+}) => {
+  const component = (
+    <ProfileLabel
+      linkingRules={linkingRules}
+      recordData={recordData}
+      parentRecordData={parentRecordData}
+      parentSectionKey={parentSectionKey}
+      parentSectionData={parentSectionData}
+      setParentSectionData={setParentSectionData}
+      resources={resources}
+      label={label}
+      record={record}
+    />
+  );
+
+  return renderWithIntl(component, translationsProperties);
+};
+
+describe('ProfileLabel', () => {
+  describe('when unlink is allowed', () => {
+    it('should be rendered unlink button', () => {
+      const { container } = renderProfileLabel(profileLabelProps({
+        allowUnlink: true,
+        allowDelete: false,
+        record: null,
+      }));
+      const unlinkButton = container.querySelector('[data-test-profile-unlink="true"]');
+
+      expect(unlinkButton).toBeDefined();
+    });
+  });
+
+  describe('when clicking on unlink icon', () => {
+    it('unlink modal window should be rendered', () => {
+      const { container, getByText } = renderProfileLabel(profileLabelProps({
+        allowUnlink: true,
+        allowDelete: false,
+        record: null,
+      }));
+      const unlinkButton = container.querySelector('[data-test-profile-unlink="true"]');
+  
+      fireEvent.click(unlinkButton);
+  
+      expect(getByText('Confirmation modal')).toBeDefined();
+    });
+
+    describe('when clicking on Cancel button', () => {
+      it('unlink modal window should be closed', () => {
+        const { container, getByText, queryByText, debug } = renderProfileLabel(profileLabelProps({
+          allowUnlink: true,
+          allowDelete: false,
+          record: null,
+        }));
+        const unlinkButton = container.querySelector('[data-test-profile-unlink="true"]');
+  
+        fireEvent.click(unlinkButton);
+
+        const cancel = getByText('Cancel');
+
+        fireEvent.click(cancel);
+
+        expect(queryByText('Confirmation modal')).toBeNull();
+      });
+    }); 
+
+    describe('when clicking on Confirm button', () => {
+      it('unlink modal window should be closed', () => {
+        const { container, getByText, queryByText, debug } = renderProfileLabel(profileLabelProps({
+          allowUnlink: true,
+          allowDelete: false,
+          record: null,
+        }));
+        const unlinkButton = container.querySelector('[data-test-profile-unlink="true"]');
+  
+        fireEvent.click(unlinkButton);
+
+        const unlink = container.querySelector('#confirmButton');
+debug();
+        fireEvent.click(unlink);
+
+        expect(queryByText('Confirmation modal')).toBeNull();
+      });
+    }); 
+  });
+
+  describe('when clicking on Delete icon', () => {
+    it('unlink modal window should be rendered', () => {
+      const { container, getByText, debug } = renderProfileLabel(profileLabelProps({
+        allowUnlink: false,
+        allowDelete: true,
+        record: null,
+      }));
+      const deleteButton = container.querySelector('[data-test-profile-delete="true"]');
+
+      fireEvent.click(deleteButton);
+
+      expect(getByText('Confirmation modal')).toBeDefined();
+    });
+
+    describe('when clicking on Cancel button', () => {
+      it('unlink modal window should be closed', () => {
+        const { container, getByText, queryByText } = renderProfileLabel(profileLabelProps({
+          allowUnlink: false,
+          allowDelete: true,
+          record: null,
+        }));
+        const deleteButton = container.querySelector('[data-test-profile-delete="true"]');
+  
+        fireEvent.click(deleteButton);
+
+        const cancel = getByText('Cancel');
+
+        fireEvent.click(cancel);
+
+        expect(queryByText('Confirmation modal')).toBeNull();
+      });
+    }); 
+
+    describe('when clicking on Confirm button', () => {
+      it('unlink modal window should be closed', () => {
+        const { container, getByText, queryByText, debug } = renderProfileLabel(profileLabelProps({
+          allowUnlink: false,
+          allowDelete: true,
+          record: null,
+        }));
+        const deleteButton = container.querySelector('[data-test-profile-delete="true"]');
+  
+        fireEvent.click(deleteButton);
+
+        const deleteModalButton = container.querySelector('#confirmButton');
+
+        fireEvent.click(deleteModalButton);
+
+        expect(queryByText('Confirmation modal')).toBeNull();
+      });
+    }); 
+  })
+});

--- a/src/components/ProfileTree/ProfileLabel.test.js
+++ b/src/components/ProfileTree/ProfileLabel.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 import '../../../test/jest/__mock__';
 import { translationsProperties } from '../../../test/jest/helpers';
 
 import { ProfileLabel } from './ProfileLabel';
-import { fireEvent } from '@testing-library/react';
 
 jest.mock('@folio/stripes/components', () => ({
   ...jest.requireActual('@folio/stripes/components'),
@@ -33,7 +33,11 @@ jest.mock('@folio/stripes/components', () => ({
   ) : null)),
 }));
 
-const profileLabelProps = ({ allowUnlink, allowDelete, record }) => {
+const profileLabelProps = ({
+  allowUnlink,
+  allowDelete,
+  record,
+}) => {
   return {
     linkingRules: {
       columnsAllowed: {
@@ -47,7 +51,7 @@ const profileLabelProps = ({ allowUnlink, allowDelete, record }) => {
       contentType: 'matchProfile',
       content: {
         id: 'testId',
-        name: 'testName'
+        name: 'testName',
       },
       childSnapshotWrappers: [{ contentType: 'mapping-profiles' }],
     },
@@ -109,27 +113,34 @@ describe('ProfileLabel', () => {
 
   describe('when clicking on unlink icon', () => {
     it('unlink modal window should be rendered', () => {
-      const { container, getByText } = renderProfileLabel(profileLabelProps({
+      const {
+        container,
+        getByText,
+      } = renderProfileLabel(profileLabelProps({
         allowUnlink: true,
         allowDelete: false,
         record: null,
       }));
       const unlinkButton = container.querySelector('[data-test-profile-unlink="true"]');
-  
+
       fireEvent.click(unlinkButton);
-  
+
       expect(getByText('Confirmation modal')).toBeDefined();
     });
 
     describe('when clicking on Cancel button', () => {
       it('unlink modal window should be closed', () => {
-        const { container, getByText, queryByText, debug } = renderProfileLabel(profileLabelProps({
+        const {
+          container,
+          getByText,
+          queryByText,
+        } = renderProfileLabel(profileLabelProps({
           allowUnlink: true,
           allowDelete: false,
           record: null,
         }));
         const unlinkButton = container.querySelector('[data-test-profile-unlink="true"]');
-  
+
         fireEvent.click(unlinkButton);
 
         const cancel = getByText('Cancel');
@@ -138,31 +149,37 @@ describe('ProfileLabel', () => {
 
         expect(queryByText('Confirmation modal')).toBeNull();
       });
-    }); 
+    });
 
     describe('when clicking on Confirm button', () => {
       it('unlink modal window should be closed', () => {
-        const { container, getByText, queryByText, debug } = renderProfileLabel(profileLabelProps({
+        const {
+          container,
+          queryByText,
+        } = renderProfileLabel(profileLabelProps({
           allowUnlink: true,
           allowDelete: false,
           record: null,
         }));
         const unlinkButton = container.querySelector('[data-test-profile-unlink="true"]');
-  
+
         fireEvent.click(unlinkButton);
 
         const unlink = container.querySelector('#confirmButton');
-debug();
+
         fireEvent.click(unlink);
 
         expect(queryByText('Confirmation modal')).toBeNull();
       });
-    }); 
+    });
   });
 
   describe('when clicking on Delete icon', () => {
     it('unlink modal window should be rendered', () => {
-      const { container, getByText, debug } = renderProfileLabel(profileLabelProps({
+      const {
+        container,
+        getByText,
+      } = renderProfileLabel(profileLabelProps({
         allowUnlink: false,
         allowDelete: true,
         record: null,
@@ -176,13 +193,17 @@ debug();
 
     describe('when clicking on Cancel button', () => {
       it('unlink modal window should be closed', () => {
-        const { container, getByText, queryByText } = renderProfileLabel(profileLabelProps({
+        const {
+          container,
+          getByText,
+          queryByText,
+        } = renderProfileLabel(profileLabelProps({
           allowUnlink: false,
           allowDelete: true,
           record: null,
         }));
         const deleteButton = container.querySelector('[data-test-profile-delete="true"]');
-  
+
         fireEvent.click(deleteButton);
 
         const cancel = getByText('Cancel');
@@ -191,17 +212,20 @@ debug();
 
         expect(queryByText('Confirmation modal')).toBeNull();
       });
-    }); 
+    });
 
     describe('when clicking on Confirm button', () => {
       it('unlink modal window should be closed', () => {
-        const { container, getByText, queryByText, debug } = renderProfileLabel(profileLabelProps({
+        const {
+          container,
+          queryByText,
+        } = renderProfileLabel(profileLabelProps({
           allowUnlink: false,
           allowDelete: true,
           record: null,
         }));
         const deleteButton = container.querySelector('[data-test-profile-delete="true"]');
-  
+
         fireEvent.click(deleteButton);
 
         const deleteModalButton = container.querySelector('#confirmButton');
@@ -210,6 +234,6 @@ debug();
 
         expect(queryByText('Confirmation modal')).toBeNull();
       });
-    }); 
-  })
+    });
+  });
 });

--- a/src/components/ProfileTree/ProfileLinker/LinkerButton.test.js
+++ b/src/components/ProfileTree/ProfileLinker/LinkerButton.test.js
@@ -1,0 +1,95 @@
+import React from 'react';
+
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+import '../../../../test/jest/__mock__';
+import { translationsProperties } from '../../../../test/jest/helpers';
+
+import { LinkerButton } from './LinkerButton';
+import { fireEvent } from '@testing-library/react';
+
+const onClick = jest.fn();
+const linkerButtonProps = {
+  id: 'testId',
+  entityKey: 'jobProfiles',
+};
+
+const renderLinkerButton = ({
+  id,
+  entityKey,
+  searchLabel,
+  className,
+  isButtonDisabled,
+  dataAttributes,
+}) => {
+  const component = (
+    <LinkerButton
+      id={id}
+      entityKey={entityKey}
+      onClick={onClick}
+      searchLabel={searchLabel}
+      className={className}
+      isButtonDisabled={isButtonDisabled}
+      dataAttributes={dataAttributes}
+    />
+  );
+
+  return renderWithIntl(component, translationsProperties);
+};
+
+describe('LinkerButton', () => {
+  afterEach(() => {
+    onClick.mockClear();
+  });
+
+  it('should be rendered with FormattedMessage title', () => {
+    const { getByText } = renderLinkerButton(linkerButtonProps);
+    
+    expect(getByText('Job')).toBeDefined();
+  });
+  
+  it('should be rendered with text type title', () => {
+    const { getByText } = renderLinkerButton({
+      ...linkerButtonProps,
+      searchLabel: 'test label',
+    });
+
+    expect(getByText('test label')).toBeDefined();
+  });
+
+  it('should be rendered with node type title', () => {
+    const { getByText } = renderLinkerButton({
+      ...linkerButtonProps,
+      searchLabel: <span>test label</span>,
+    });
+
+    expect(getByText('test label')).toBeDefined();
+  });
+
+  describe('when clicking on button', () => {
+    describe('when button is disabled', () => {
+      it('should not be called onClick function', () => {
+        const { getByText } = renderLinkerButton({
+          ...linkerButtonProps,
+          searchLabel: <span>test label</span>,
+          isButtonDisabled: true,
+        });
+        
+        fireEvent.click(getByText('test label'));
+  
+        expect(onClick).toHaveBeenCalledTimes(0);
+      });
+    });
+    describe('when button is not disabled', () => {
+      it('should be called onClick function', () => {
+        const { getByText } = renderLinkerButton({
+          ...linkerButtonProps,
+          searchLabel: <span>test label</span>,
+        });
+        
+        fireEvent.click(getByText('test label'));
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/src/components/ProfileTree/ProfileLinker/LinkerButton.test.js
+++ b/src/components/ProfileTree/ProfileLinker/LinkerButton.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 import '../../../../test/jest/__mock__';
 import { translationsProperties } from '../../../../test/jest/helpers';
 
 import { LinkerButton } from './LinkerButton';
-import { fireEvent } from '@testing-library/react';
 
 const onClick = jest.fn();
 const linkerButtonProps = {
@@ -43,10 +43,10 @@ describe('LinkerButton', () => {
 
   it('should be rendered with FormattedMessage title', () => {
     const { getByText } = renderLinkerButton(linkerButtonProps);
-    
+
     expect(getByText('Job')).toBeDefined();
   });
-  
+
   it('should be rendered with text type title', () => {
     const { getByText } = renderLinkerButton({
       ...linkerButtonProps,
@@ -73,9 +73,9 @@ describe('LinkerButton', () => {
           searchLabel: <span>test label</span>,
           isButtonDisabled: true,
         });
-        
+
         fireEvent.click(getByText('test label'));
-  
+
         expect(onClick).toHaveBeenCalledTimes(0);
       });
     });
@@ -85,7 +85,7 @@ describe('LinkerButton', () => {
           ...linkerButtonProps,
           searchLabel: <span>test label</span>,
         });
-        
+
         fireEvent.click(getByText('test label'));
 
         expect(onClick).toHaveBeenCalledTimes(1);

--- a/src/components/ProfileTree/ProfileLinker/LinkerMenu.test.js
+++ b/src/components/ProfileTree/ProfileLinker/LinkerMenu.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+import '../../../../test/jest/__mock__';
+import { translationsProperties } from '../../../../test/jest/helpers';
+
+import { LinkerMenu } from './LinkerMenu';
+
+const onClick = jest.fn();
+const onToggle = jest.fn();
+
+const linkerMenuProps = {
+  id: 'testId',
+  open: false,
+  entityKeys: [
+    'matchProfiles',
+    'actionProfiles',
+  ],
+  disabledOptions: ['matchProfiles'],
+  keyHandler: jest.fn(),
+};
+
+const renderLinkerMenu = ({
+  id,
+  open,
+  entityKeys,
+  disabledOptions,
+  keyHandler,
+}) => {
+  const component = (
+    <LinkerMenu
+      id={id}
+      open={open}
+      entityKeys={entityKeys}
+      onClick={onClick}
+      onToggle={onToggle}
+      disabledOptions={disabledOptions}
+      keyHandler={keyHandler}
+    />
+  );
+
+  return renderWithIntl(component, translationsProperties);
+};
+
+describe('LinkerMenu', () => {
+  afterEach(() => {
+    onClick.mockClear();
+  });
+  it('should be rendered with label', () => {
+    const { getByText } = renderLinkerMenu(linkerMenuProps);
+
+    expect(getByText('Add')).toBeDefined();
+  });
+
+  it('should be rendered with dropdown buttons', () => {
+    const { getByText, debug } = renderLinkerMenu(linkerMenuProps);
+    debug();
+    expect(getByText('Match')).toBeDefined();
+    expect(getByText('Action')).toBeDefined();
+  });
+});

--- a/src/components/ProfileTree/ProfileLinker/LinkerMenu.test.js
+++ b/src/components/ProfileTree/ProfileLinker/LinkerMenu.test.js
@@ -53,8 +53,8 @@ describe('LinkerMenu', () => {
   });
 
   it('should be rendered with dropdown buttons', () => {
-    const { getByText, debug } = renderLinkerMenu(linkerMenuProps);
-    debug();
+    const { getByText } = renderLinkerMenu(linkerMenuProps);
+
     expect(getByText('Match')).toBeDefined();
     expect(getByText('Action')).toBeDefined();
   });

--- a/src/components/ProfileTree/ProfileLinker/LinkerTrigger.test.js
+++ b/src/components/ProfileTree/ProfileLinker/LinkerTrigger.test.js
@@ -47,9 +47,7 @@ describe('LinkerTrigger', () => {
   });
 
   it('should be rendered with FormattedMessage type title', () => {
-    const { getByText } = renderLinkerTrigger({
-      ...linkerTriggerProps,
-    });
+    const { getByText } = renderLinkerTrigger({ ...linkerTriggerProps });
 
     expect(getByText('Click here to get started')).toBeDefined();
   });

--- a/src/components/ProfileTree/ProfileLinker/LinkerTrigger.test.js
+++ b/src/components/ProfileTree/ProfileLinker/LinkerTrigger.test.js
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+import '../../../../test/jest/__mock__';
+import { translationsProperties } from '../../../../test/jest/helpers';
+
+import { LinkerTrigger } from './LinkerTrigger';
+
+const onClick = jest.fn();
+
+const linkerTriggerProps = {
+  triggerRef: {},
+  ariaProps: {},
+  keyHandler: jest.fn(),
+  id: 'testId',
+};
+
+const renderLinkerTrigger = ({
+  title,
+  triggerRef,
+  ariaProps,
+  keyHandler,
+  id,
+}) => {
+  const component = (
+    <LinkerTrigger
+      title={title}
+      triggerRef={triggerRef}
+      ariaProps={ariaProps}
+      keyHandler={keyHandler}
+      id={id}
+      onClick={onClick}
+    />
+  );
+
+  return renderWithIntl(component, translationsProperties);
+};
+
+describe('LinkerTrigger', () => {
+  it('should be rendered with node type title', () => {
+    const { getByText } = renderLinkerTrigger({
+      ...linkerTriggerProps,
+      title: <span>test node title</span>,
+    });
+
+    expect(getByText('test node title')).toBeDefined();
+  });
+
+  it('should be rendered with FormattedMessage type title', () => {
+    const { getByText } = renderLinkerTrigger({
+      ...linkerTriggerProps,
+    });
+
+    expect(getByText('Click here to get started')).toBeDefined();
+  });
+});

--- a/src/components/ProfileTree/ProfileLinker/ProfileLinker.test.js
+++ b/src/components/ProfileTree/ProfileLinker/ProfileLinker.test.js
@@ -3,25 +3,16 @@ import { fireEvent } from '@testing-library/react';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 import '../../../../test/jest/__mock__';
+import { Pluggable } from '@folio/stripes/core';
 import { translationsProperties } from '../../../../test/jest/helpers';
 
 import { ProfileLinker } from './ProfileLinker';
 
-jest.mock('@folio/stripes/core', () => ({
-  ...jest.requireActual('@folio/stripes/core'),
-  Pluggable: jest.fn(({ onLink, renderTrigger }) =>
-    <span
-      onLink={onLink}
-      renderTrigger={renderTrigger}
-    >
-      test
-    </span>),
-}));
+const onLink = jest.fn();
 
 const profileLinkerProps = {
   id: 'testId',
-  parentType: 'jobProfiles',
-  onLink: jest.fn(),
+  parentType: 'matchProfiles',
   linkingRules: { profilesAllowed: ['matchProfiles', 'actionProfiles'] },
   dataKey: 'testDataKey',
   initialData: [{}],
@@ -31,12 +22,12 @@ const profileLinkerProps = {
     token: 'test-token',
     url: 'test-url',
   },
+  title: <span>test title</span>,
 };
 
 const renderProfileLinker = ({
   id,
   parentType,
-  onLink,
   linkingRules,
   dataKey,
   initialData,
@@ -60,9 +51,12 @@ const renderProfileLinker = ({
 };
 
 describe('ProfileLinker', () => {
-  it('should be rendered', () => {
-    const { getByText, debug } = renderProfileLinker(profileLinkerProps);
+  afterEach(() => {
+    Pluggable.mockClear();
+  });
 
+  it('should be rendered', () => {
+    const { getByText } = renderProfileLinker(profileLinkerProps);
 
     expect(getByText('Click here to get started')).toBeDefined();
   });
@@ -86,19 +80,14 @@ describe('ProfileLinker', () => {
       expect(getByText('Match')).not.toBeVisible();
       expect(getByText('Action')).not.toBeVisible();
     });
+  });
 
-    describe('when clicking on Match option', () => {
-      it('modal window should appear', () => {
-        const { container, getByText, debug } = renderProfileLinker(profileLinkerProps);
+  it('plugin info should be rendered', async () => {
+    const { getAllByText } = renderProfileLinker(profileLinkerProps);
 
-        fireEvent.click(getByText('Icon'));
+    await Pluggable.mock.calls[0][0].renderTrigger({ buttonRefs: 'asd' });
+    await Pluggable.mock.calls[0][0].onLink([{ id: 'testId' }]);
 
-        expect(getByText('Match')).toBeDefined();
-        fireEvent.click(container.querySelector('[data-test-no-plugin-available="true"]'));
-        console.log(container.querySelector('[data-test-no-plugin-available="true"]'));
-
-        fireEvent.click(getByText('Match'));
-      });
-    });
+    expect(getAllByText('Find Import Profile Plugin is not available now')).toBeDefined();
   });
 });

--- a/src/components/ProfileTree/ProfileLinker/ProfileLinker.test.js
+++ b/src/components/ProfileTree/ProfileLinker/ProfileLinker.test.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+import '../../../../test/jest/__mock__';
+import { translationsProperties } from '../../../../test/jest/helpers';
+
+import { ProfileLinker } from './ProfileLinker';
+
+const profileLinkerProps = {
+  id: 'testId',
+  parentType: 'jobProfiles',
+  onLink: jest.fn(),
+  linkingRules: {
+    profilesAllowed: [
+      'matchProfiles',
+      'actionProfiles',
+    ]
+  },
+  dataKey: 'testDataKey',
+  initialData: [{}],
+  setInitialData: jest.fn(),
+  okapi: {
+    tenant: 'test-tenant',
+    token: 'test-token',
+    url: 'test-url',
+  },
+};
+
+const renderProfileLinker = ({
+  id,
+  parentType,
+  onLink,
+  linkingRules,
+  dataKey,
+  initialData,
+  setInitialData,
+  okapi,
+}) => {
+  const component = (
+    <ProfileLinker
+      id={id}
+      parentType={parentType}
+      onLink={onLink}
+      linkingRules={linkingRules}
+      dataKey={dataKey}
+      initialData={initialData}
+      setInitialData={setInitialData}
+      okapi={okapi}
+    />
+  );
+
+  return renderWithIntl(component, translationsProperties);
+};
+
+describe('ProfileLinker', () => {
+  it('should be rendered', () => {
+    const { debug } = renderProfileLinker(profileLinkerProps);
+    debug();
+  });
+
+  describe('when clicking on plus icon', () => {
+   /*  it('should be changed the state', () => {
+      const { getByText, debug } = renderProfileLinker(profileLinkerProps);
+
+      fireEvent.click(getByText('Icon'));
+      debug();
+    }); */
+
+    describe('when click on dropdown', () => {
+      it('should click on item', () => {
+        const { container, getByText, debug } = renderProfileLinker(profileLinkerProps);
+        
+        fireEvent.click(getByText('Icon'));
+
+        expect(getByText('Action')).toBeVisible();
+debug();
+       // const elem = container.querySelector('#menu-link-match-type-selector-menu-testId-button-find-import-profile-matchProfiles');
+        fireEvent.click(getByText('Icon'));
+
+        const elem = container.querySelector('#menu-link-match-type-selector-menu-testId-button-find-import-profile-matchProfiles');
+        fireEvent.click(elem);
+       /*  debug();
+        fireEvent.click(getByText('Icon'));
+
+        expect(getByText('Action')).not.toBeVisible();
+        debug(); */
+      });
+    });
+  });
+});

--- a/src/components/ProfileTree/ProfileLinker/ProfileLinker.test.js
+++ b/src/components/ProfileTree/ProfileLinker/ProfileLinker.test.js
@@ -7,16 +7,22 @@ import { translationsProperties } from '../../../../test/jest/helpers';
 
 import { ProfileLinker } from './ProfileLinker';
 
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  Pluggable: jest.fn(({ onLink, renderTrigger }) =>
+    <span
+      onLink={onLink}
+      renderTrigger={renderTrigger}
+    >
+      test
+    </span>),
+}));
+
 const profileLinkerProps = {
   id: 'testId',
   parentType: 'jobProfiles',
   onLink: jest.fn(),
-  linkingRules: {
-    profilesAllowed: [
-      'matchProfiles',
-      'actionProfiles',
-    ]
-  },
+  linkingRules: { profilesAllowed: ['matchProfiles', 'actionProfiles'] },
   dataKey: 'testDataKey',
   initialData: [{}],
   setInitialData: jest.fn(),
@@ -55,36 +61,43 @@ const renderProfileLinker = ({
 
 describe('ProfileLinker', () => {
   it('should be rendered', () => {
-    const { debug } = renderProfileLinker(profileLinkerProps);
-    debug();
+    const { getByText, debug } = renderProfileLinker(profileLinkerProps);
+
+
+    expect(getByText('Click here to get started')).toBeDefined();
   });
 
-  describe('when clicking on plus icon', () => {
-   /*  it('should be changed the state', () => {
-      const { getByText, debug } = renderProfileLinker(profileLinkerProps);
+  describe('when clicking on linker button', () => {
+    it('dropdown should be expanded', () => {
+      const { getByText } = renderProfileLinker(profileLinkerProps);
 
       fireEvent.click(getByText('Icon'));
-      debug();
-    }); */
 
-    describe('when click on dropdown', () => {
-      it('should click on item', () => {
+      expect(getByText('Match')).toBeDefined();
+      expect(getByText('Action')).toBeDefined();
+    });
+
+    it('dropdown should be collapsed', () => {
+      const { getByText } = renderProfileLinker(profileLinkerProps);
+
+      fireEvent.click(getByText('Icon'));
+      fireEvent.click(getByText('Icon'));
+
+      expect(getByText('Match')).not.toBeVisible();
+      expect(getByText('Action')).not.toBeVisible();
+    });
+
+    describe('when clicking on Match option', () => {
+      it('modal window should appear', () => {
         const { container, getByText, debug } = renderProfileLinker(profileLinkerProps);
-        
+
         fireEvent.click(getByText('Icon'));
 
-        expect(getByText('Action')).toBeVisible();
-debug();
-       // const elem = container.querySelector('#menu-link-match-type-selector-menu-testId-button-find-import-profile-matchProfiles');
-        fireEvent.click(getByText('Icon'));
+        expect(getByText('Match')).toBeDefined();
+        fireEvent.click(container.querySelector('[data-test-no-plugin-available="true"]'));
+        console.log(container.querySelector('[data-test-no-plugin-available="true"]'));
 
-        const elem = container.querySelector('#menu-link-match-type-selector-menu-testId-button-find-import-profile-matchProfiles');
-        fireEvent.click(elem);
-       /*  debug();
-        fireEvent.click(getByText('Icon'));
-
-        expect(getByText('Action')).not.toBeVisible();
-        debug(); */
+        fireEvent.click(getByText('Match'));
       });
     });
   });

--- a/src/components/ProfileTree/ProfileTree.test.js
+++ b/src/components/ProfileTree/ProfileTree.test.js
@@ -1,0 +1,202 @@
+import React from 'react';
+
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+import '../../../test/jest/__mock__';
+import { translationsProperties } from '../../../test/jest/helpers';
+
+import { ProfileTree } from './ProfileTree';
+import { fireEvent } from '@testing-library/react';
+
+jest.mock('@folio/stripes/components', () => ({
+  ...jest.requireActual('@folio/stripes/components'),
+  ConfirmationModal: jest.fn(({
+    open,
+    onCancel,
+    onConfirm,
+  }) => (open ? (
+    <div>
+      <span>Confirmation modal</span>
+      <button
+        type="button"
+        onClick={onCancel}
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        id="confirmButton"
+        onClick={onConfirm}
+      >
+        Confirm
+      </button>
+    </div>
+  ) : null)),
+}));
+
+window.ResizeObserver = jest.fn(() => ({
+  observe() {},
+  unobserve() {},
+}));
+
+const onUnlink = jest.fn();
+const onDelete = jest.fn();
+
+const profileTreeProps = ({ allowUnlink, allowDelete, record }) => {
+  return {
+    linkingRules: { 
+      allowUnlink,
+      allowDelete,
+      profilesAllowed: ['matchProfiles', 'actionProfiles'],
+      childrenAllowed: ['actionProfiles', 'matchProfiles'],
+      siblingsProhibited: { actionProfiles: ['matchProfile'] },
+      columnsAllowed: {
+        matchProfiles: [
+          'name',
+          'match',
+        ],
+        actionProfiles: [
+          'name',
+          'action',
+        ],
+      },
+    },
+    contentData: [{
+      hasLoaded: true,
+      records: [{
+        id: 'testId',
+        profileId: 'testProfileId',
+          contentType: 'matchProfile',
+          content: {
+            id: 'testId',
+            name: 'testName',
+            description: 'testDescription1',
+            tags: { tagList: ['testTag'] },
+            match: 'testMatch',
+          },
+          description: 'testDescription2',
+      }],
+      contentType: 'matchProfile',
+      content: {
+        id: 'testId',
+        name: 'testName'
+      },
+      childSnapshotWrappers: [{ 
+        reactTo: 'MATCH',
+        contentType: 'matchProfile',
+        content: {
+          id: 'testId',
+          name: 'testName'
+        },
+        childSnapshotWrappers: [],
+      }, { 
+        reactTo: 'NON_MATCH',
+        contentType: 'matchProfile',
+        content: {
+          id: 'testId',
+          name: 'testName'
+        },
+        childSnapshotWrappers: [],
+      }],
+    }],
+    okapi: {
+      tenant: 'test-tenant',
+      token: 'test-token',
+      url: 'test-url',
+    },
+    resources: {
+      jobProfile: {
+        hasLoaded: true,
+        records: [{
+          name: 'testName',
+          dataType: 'EDIFACT',
+          metadata: {
+            createdByUserId: 'testUserId',
+            updateByUserId: 'testUserId',
+          },
+          description: 'testDescription',
+        }],
+      }
+    },
+    record,
+  };
+};
+
+const renderProfileTree = ({
+  linkingRules,
+  contentData,
+  okapi,
+  resources,
+  record,
+}) => {
+  const component = (
+    <ProfileTree
+      linkingRules={linkingRules}
+      contentData={contentData}
+      okapi={okapi}
+      onUnlink={onUnlink}
+      onDelete={onDelete}
+      resources={resources}
+      record={record}
+    />
+  );
+
+  return renderWithIntl(component, translationsProperties);
+};
+
+describe('ProfileTree', () => {
+  afterAll(() => {
+    delete window.ResizeObserver;
+    onUnlink.mockClear();
+    onDelete.mockClear();
+  });
+
+  it('should be rendered', () => {
+    const { container, getByText, getAllByText, debug } = renderProfileTree(profileTreeProps({
+      allowUnlink: true,
+      allowDelete: false,
+      record: null,
+    }));
+
+    expect(getAllByText('Match profile: "testName"')).toBeDefined();
+    expect(getAllByText('For matches')).toBeDefined();
+    expect(getAllByText('For non-matches')).toBeDefined();
+  });
+
+  describe('when clicking on delete button', () => {
+    it('should called deleting function', () => {
+      const { container, getByText, getAllByText, debug } = renderProfileTree(profileTreeProps({
+        allowUnlink: false,
+        allowDelete: true,
+        record: null,
+      }));
+      const onDeleteButton = container.querySelector('button[data-test-profile-delete="true"]');
+
+      fireEvent.click(onDeleteButton);
+
+      const deleteButtonModal = getByText('Confirm');
+
+      fireEvent.click(deleteButtonModal);
+
+      expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when clicking on unlink button', () => {
+    it('should called unlinking function', () => {
+      const { container, getByText, getAllByText, debug } = renderProfileTree(profileTreeProps({
+        allowUnlink: true,
+        allowDelete: false,
+        record: null,
+      }));
+      const unlinkButton = container.querySelector('button[data-test-profile-unlink="true"]');
+      debug(container, 300000);
+      fireEvent.click(unlinkButton);
+
+      const unlink = getByText('Confirm');
+
+      fireEvent.click(unlink);
+
+      expect(onUnlink).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/ProfileTree/ProfileTree.test.js
+++ b/src/components/ProfileTree/ProfileTree.test.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 import '../../../test/jest/__mock__';
+import { Pluggable } from '@folio/stripes/core';
 import { translationsProperties } from '../../../test/jest/helpers';
 
 import { ProfileTree } from './ProfileTree';
-import { fireEvent } from '@testing-library/react';
 
 jest.mock('@folio/stripes/components', () => ({
   ...jest.requireActual('@folio/stripes/components'),
@@ -38,12 +39,13 @@ window.ResizeObserver = jest.fn(() => ({
   unobserve() {},
 }));
 
-const onUnlink = jest.fn();
-const onDelete = jest.fn();
-
-const profileTreeProps = ({ allowUnlink, allowDelete, record }) => {
+const profileTreeProps = ({
+  allowUnlink,
+  allowDelete,
+  record,
+}) => {
   return {
-    linkingRules: { 
+    linkingRules: {
       allowUnlink,
       allowDelete,
       profilesAllowed: ['matchProfiles', 'actionProfiles'],
@@ -65,35 +67,35 @@ const profileTreeProps = ({ allowUnlink, allowDelete, record }) => {
       records: [{
         id: 'testId',
         profileId: 'testProfileId',
-          contentType: 'matchProfile',
-          content: {
-            id: 'testId',
-            name: 'testName',
-            description: 'testDescription1',
-            tags: { tagList: ['testTag'] },
-            match: 'testMatch',
-          },
-          description: 'testDescription2',
+        contentType: 'matchProfile',
+        content: {
+          id: 'testId',
+          name: 'testName',
+          description: 'testDescription1',
+          tags: { tagList: ['testTag'] },
+          match: 'testMatch',
+        },
+        description: 'testDescription2',
       }],
       contentType: 'matchProfile',
       content: {
         id: 'testId',
-        name: 'testName'
+        name: 'testName',
       },
-      childSnapshotWrappers: [{ 
+      childSnapshotWrappers: [{
         reactTo: 'MATCH',
         contentType: 'matchProfile',
         content: {
           id: 'testId',
-          name: 'testName'
+          name: 'testName',
         },
         childSnapshotWrappers: [],
-      }, { 
+      }, {
         reactTo: 'NON_MATCH',
         contentType: 'matchProfile',
         content: {
           id: 'testId',
-          name: 'testName'
+          name: 'testName',
         },
         childSnapshotWrappers: [],
       }],
@@ -115,7 +117,7 @@ const profileTreeProps = ({ allowUnlink, allowDelete, record }) => {
           },
           description: 'testDescription',
         }],
-      }
+      },
     },
     record,
   };
@@ -133,8 +135,6 @@ const renderProfileTree = ({
       linkingRules={linkingRules}
       contentData={contentData}
       okapi={okapi}
-      onUnlink={onUnlink}
-      onDelete={onDelete}
       resources={resources}
       record={record}
     />
@@ -144,27 +144,17 @@ const renderProfileTree = ({
 };
 
 describe('ProfileTree', () => {
-  afterAll(() => {
+  afterEach(() => {
     delete window.ResizeObserver;
-    onUnlink.mockClear();
-    onDelete.mockClear();
-  });
-
-  it('should be rendered', () => {
-    const { container, getByText, getAllByText, debug } = renderProfileTree(profileTreeProps({
-      allowUnlink: true,
-      allowDelete: false,
-      record: null,
-    }));
-
-    expect(getAllByText('Match profile: "testName"')).toBeDefined();
-    expect(getAllByText('For matches')).toBeDefined();
-    expect(getAllByText('For non-matches')).toBeDefined();
+    Pluggable.mockClear();
   });
 
   describe('when clicking on delete button', () => {
-    it('should called deleting function', () => {
-      const { container, getByText, getAllByText, debug } = renderProfileTree(profileTreeProps({
+    it('modal window shod be closed', () => {
+      const {
+        container,
+        getByText,
+      } = renderProfileTree(profileTreeProps({
         allowUnlink: false,
         allowDelete: true,
         record: null,
@@ -177,26 +167,19 @@ describe('ProfileTree', () => {
 
       fireEvent.click(deleteButtonModal);
 
-      expect(onDelete).toHaveBeenCalledTimes(1);
+      expect(deleteButtonModal).not.toBeVisible();
     });
   });
 
-  describe('when clicking on unlink button', () => {
-    it('should called unlinking function', () => {
-      const { container, getByText, getAllByText, debug } = renderProfileTree(profileTreeProps({
-        allowUnlink: true,
-        allowDelete: false,
-        record: null,
-      }));
-      const unlinkButton = container.querySelector('button[data-test-profile-unlink="true"]');
-      debug(container, 300000);
-      fireEvent.click(unlinkButton);
+  it('should be rendered', () => {
+    const { getByText } = renderProfileTree(profileTreeProps({
+      allowUnlink: true,
+      allowDelete: false,
+      record: null,
+    }));
 
-      const unlink = getByText('Confirm');
+    Pluggable.mock.calls[0][0].onLink([{ id: 'testId' }]);
 
-      fireEvent.click(unlink);
-
-      expect(onUnlink).toHaveBeenCalledTimes(1);
-    });
+    expect(getByText('This list contains no items')).toBeDefined();
   });
 });

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -13,5 +13,5 @@ jest.mock('@folio/stripes/core', () => ({
       {...props}
     />
   ),
-  Pluggable: props => <>{props.children}</>,
+  Pluggable: jest.fn(props => <>{props.children}</>),
 }), { virtual: true });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->Cover <ProfileTree> component with unit tests 

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->Covered <ProfileTree> component with unit tests using RTL + Jest

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->https://issues.folio.org/browse/UIDATIMP-718

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://user-images.githubusercontent.com/85172747/129488233-d5e27a32-c81c-44fb-b798-6ff44058328f.png)
![image](https://user-images.githubusercontent.com/85172747/129488237-3a6fef80-9fd5-418f-bc55-37586b395587.png)

