### PR TITLE
UIDATIMP-1002 Cannot add matches or actions to a job profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Bugs fixed:
 * Auxiliary "repeatableFieldAction" property disappear while removing "vendor reference number" field mapping (UIDATIMP-987)
+* Cannot add matches or actions to a job profile (UIDATIMP-1002)
 
 ## [4.1.4](https://github.com/folio-org/ui-data-import/tree/v4.1.4) (2021-08-23)
 

--- a/src/components/ProfileTree/ProfileLinker/ProfileLinker.js
+++ b/src/components/ProfileTree/ProfileLinker/ProfileLinker.js
@@ -4,6 +4,7 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { noop } from 'lodash';
 
 import classNames from 'classnames';
 
@@ -110,7 +111,7 @@ export const ProfileLinker = ({
           id={`type-selector-dropdown-${id}`}
           className={classNames(css['linker-button'], className)}
           open={typeSelectorOpen}
-          onToggle={() => setTypeSelectorOpen(!typeSelectorOpen)}
+          onToggle={noop}
           renderTrigger={trigger}
           renderMenu={menu}
           usePortal={false}


### PR DESCRIPTION
## Overview
Currently cannot add matches or actions to a MARC or EDIFACT job profile on folio-snapshot or folio-snapshot-load

## Approach
- workaround to fix UIDATIMP-1002. Removing callback for Dropdown component onToggle

## Refs
https://issues.folio.org/browse/UIDATIMP-1002