### PR TITLE
UIDATIMP-1003 Expand module permissions with permissions for retrieving invoice and invoice lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Cover `<TreeView>` component with tests (UIDATIMP-728)
 * Cover `<RecordTypesSelect>` component with unit tests (UIDATIMP-721)
 * Field mappings: Item - update reference dropdown list for Item status to include new statuses (UIDATIMP-641)
+* Expand module permissions with permissions for retrieving invoice and invoice lines (UIDATIMP-1003)
 
 ### Bugs fixed:
 * Auxiliary "repeatableFieldAction" property disappear while removing "vendor reference number" field mapping (UIDATIMP-987)

--- a/package.json
+++ b/package.json
@@ -204,7 +204,9 @@
           "inventory-storage.preceding-succeeding-titles.item.get",
           "inventory-storage.preceding-succeeding-titles.item.post",
           "inventory-storage.preceding-succeeding-titles.item.put",
-          "inventory-storage.preceding-succeeding-titles.item.delete"
+          "inventory-storage.preceding-succeeding-titles.item.delete",
+          "invoice-storage.invoices.item.get",
+          "invoice-storage.invoice-lines.item.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Description
It is necessary to add the following "invoice-storage.invoices.item.get", "invoice-storage.invoice-lines.item.get" module permissions to obtain invoice and invoice lines for the JSON screen.

## Approach
Correspond permissions has been added