### PR TITLE
UIDATIMP-1008 - Invoice field mapping profile only displays first 10 acq unit values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Auxiliary "repeatableFieldAction" property disappear while removing "vendor reference number" field mapping (UIDATIMP-987)
 * Cannot add matches or actions to a job profile (UIDATIMP-1002)
 * EDIFACT invoices fail to import properly due to invalid "value" retrieving for vendor's accountingCode - Juniper env (UIDATIMP-1005)
+* Invoice field mapping profile only displays first 10 acq unit values (UIDATIMP-1008)
 
 ## [4.1.4](https://github.com/folio-org/ui-data-import/tree/v4.1.4) (2021-08-23)
 

--- a/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceInformation.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceInformation.js
@@ -106,7 +106,7 @@ export const InvoiceInformation = ({
             optionLabel="name"
             wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
             wrapperSources={[{
-              wrapperSourceLink: '/acquisitions-units/units',
+              wrapperSourceLink: '/acquisitions-units/units?limit=1000',
               wrapperSourcePath: 'acquisitionsUnits',
             }]}
             isRemoveValueAllowed


### PR DESCRIPTION
## Overview
If there are more than 10 acquisitions units for a tenant, the invoice field mapping profile only shows the first 10 in the dropdown list

## Approach
- limit parameter has been added to correspond request

## Refs
https://issues.folio.org/browse/UIDATIMP-1008

## Screenshots
![new](https://user-images.githubusercontent.com/63101175/135086462-ce86a3aa-6b3f-4818-86d4-8aa5d3a5ee62.png)
