### PR TITLE
UIDATIMP-1006 - Dropdown component not working properly after updating to React v17. Fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Invoice field mapping profile only displays first 10 acq unit values (UIDATIMP-1008)
 * Imported Invoice JSON log screen does not display (UIDATIMP-1010)
 * Error getting metadata for record (UIDATIMP-1018)
+* Dropdown component not working properly after updating to React v17 (UIDATIMP-1006)
 
 ## [4.1.5](https://github.com/folio-org/ui-data-import/tree/v4.1.5) (2021-10-01)
 

--- a/src/components/ProfileTree/ProfileLinker/ProfileLinker.js
+++ b/src/components/ProfileTree/ProfileLinker/ProfileLinker.js
@@ -4,7 +4,6 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { noop } from 'lodash';
 
 import classNames from 'classnames';
 
@@ -111,7 +110,7 @@ export const ProfileLinker = ({
           id={`type-selector-dropdown-${id}`}
           className={classNames(css['linker-button'], className)}
           open={typeSelectorOpen}
-          onToggle={noop}
+          onToggle={() => setTypeSelectorOpen(!typeSelectorOpen)}
           renderTrigger={trigger}
           renderMenu={menu}
           usePortal={false}


### PR DESCRIPTION
## Overview
Dropdown component not working properly after updating to React v17. Fixed

## Approach
workaround for Dropdown component has been reverted

## Refs
https://issues.folio.org/browse/UIDATIMP-1006