### PR TITLE
UIDATIMP-1017 - refactor psets away from backend ".all" permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Change MARC SRS bib column header and toggle (UIDATIMP-1011)
 * Add hotlinks to the Import log summary for EDIFACT imports (UIDATIMP-989)
 * Cover `<DetailsKeyShortcutsWrapper>` component with tests (UIDATIMP-956)
+* refactor psets away from backend ".all" permissions (UIDATIMP-1017)
 
 ### Bugs fixed:
 * Auxiliary "repeatableFieldAction" property disappear while removing "vendor reference number" field mapping (UIDATIMP-987)

--- a/package.json
+++ b/package.json
@@ -200,11 +200,6 @@
           "data-import.uploaddefinitions.files.post",
           "change-manager.records.delete",
           "change-manager.jobexecutions.get",
-          "inventory-storage.preceding-succeeding-titles.collection.get",
-          "inventory-storage.preceding-succeeding-titles.item.get",
-          "inventory-storage.preceding-succeeding-titles.item.post",
-          "inventory-storage.preceding-succeeding-titles.item.put",
-          "inventory-storage.preceding-succeeding-titles.item.delete",
           "invoice-storage.invoices.item.get",
           "invoice-storage.invoice-lines.item.get"
         ],


### PR DESCRIPTION
## Summary
Refactor psets to avoid .all permissions from backend modules.

## Approach
actually we don't have such dependencies in our permissions presets, but we have find few permissions that were added on UI as workaround and currently could be removed

## Refs
https://issues.folio.org/browse/UIDATIMP-1017