### PR TITLE
UIDATIMP-969: Cover <ViewAllLogs> component with tests

### DIFF
--- a/src/routes/ViewAllLogs/ViewAllLogs.test.js
+++ b/src/routes/ViewAllLogs/ViewAllLogs.test.js
@@ -1,0 +1,84 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import { BrowserRouter as Router } from 'react-router-dom';
+
+import { noop } from 'lodash';
+
+import {
+  buildResources,
+  buildMutator,
+  Harness,
+} from '@folio/stripes-data-transfer-components/test/helpers';
+
+import '../../../test/jest/__mock__';
+
+import { translationsProperties } from '../../../test/jest/helpers';
+
+import ViewAllLogs from './ViewAllLogs';
+
+const mutator = buildMutator({
+  initializedFilterConfig: {
+    update: jest.fn(),
+    replace: jest.fn(),
+  },
+  query: {
+    replace: jest.fn(),
+    update: jest.fn(),
+  },
+  records: {
+    DELETE: jest.fn(),
+    POST: jest.fn(),
+    PUT: jest.fn(),
+    cancel: jest.fn(),
+  },
+  resultCount: {
+    replace: jest.fn(),
+    update: jest.fn(),
+  },
+});
+
+const resources = buildResources({
+  query: {
+    query: '',
+    filters: '',
+    sort: '-completedDate',
+  },
+  resultCount: 100,
+  records: {
+    failed: false,
+    records: [],
+  },
+});
+
+const renderViewAllLogs = () => {
+  const component = () => (
+    <Harness translations={translationsProperties}>
+      <Router>
+        <ViewAllLogs
+          mutator={mutator}
+          resources={resources}
+          disableRecordCreation={false}
+          history={{ push: noop }}
+          intl={{ formatMessage: jest.fn() }}
+          stripes={{
+            hasPerm: jest.fn(),
+            connect: jest.fn(),
+            logger: { log: jest.fn() },
+          }}
+        />
+      </Router>
+    </Harness>
+  );
+
+  return render(component());
+};
+
+describe('ViewAllLogs component', () => {
+  it('should render search component correctly', () => {
+    const { getByText } = renderViewAllLogs();
+
+    expect(getByText('Search & filter')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Cover `<ViewAllLogs>` component with tests using RTL + Jest
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
When rendered `<ViewAllLogs>` inside test block, I am getting UI like (2-image) instead of actual UI like (1-image). Please, see the images below: 
1. Actual rendered component
2. Component rendered inside test suit
<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-969
## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![Screenshot (39)](https://user-images.githubusercontent.com/89512426/136818149-3d23d73c-d683-47c2-8fd9-5015d1b71814.png)
![Screenshot (40)](https://user-images.githubusercontent.com/89512426/136818312-dc455959-f55f-4e79-b3eb-3fa56547e9d6.png)
