### PR TITLE
UIDATIMP-1021 - Add AUTHORITY type into folioRecordTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Cover `<EditKeyShortcutsWrapper` component with tests (UIDATIMP-957)
 * Cover `<ViewAllLogs>` component with tests (UIDATIMP-969)
 * Cover `<ReturnToAssignJobs>` component with tests (UIDATIMP-960)
+* Cover `<MatchingFieldsManager>` component with tests (UIDATIMP-712)
+* Cover `<FieldOrganization>` component with tests (UIDATIMP-958)
+* Add AUTHORITY type into folioRecordTypes (UIDATIMP-1021)
 
 ## [5.0.0](https://github.com/folio-org/ui-data-import/tree/v5.0.0) (2021-10-08)
 
@@ -46,8 +49,6 @@
 * Cover `<DetailsKeyShortcutsWrapper>` component with tests (UIDATIMP-956)
 * Get rid of outdated componentWillReceiveProps method in SearchAndSort component (UIDATIMP-1001)
 * refactor psets away from backend ".all" permissions (UIDATIMP-1017)
-* Cover `<MatchingFieldsManager>` component with tests (UIDATIMP-712)
-* Cover `<FieldOrganization>` component with tests (UIDATIMP-958)
 
 ### Bugs fixed:
 * Auxiliary "repeatableFieldAction" property disappear while removing "vendor reference number" field mapping (UIDATIMP-987)

--- a/src/components/ListTemplate/folioRecordTypes.js
+++ b/src/components/ListTemplate/folioRecordTypes.js
@@ -39,4 +39,9 @@ export const FOLIO_RECORD_TYPES = {
     captionId: 'ui-data-import.recordTypes.marc-auth',
     iconKey: 'marcAuthorities',
   },
+  AUTHORITY: {
+    type: 'AUTHORITY',
+    captionId: 'ui-data-import.recordTypes.authority',
+    iconKey: 'marcAuthorities',
+  },
 };

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -478,6 +478,7 @@
   "recordTypes.marc-auth": "MARC Authority",
   "recordTypes.marc-hold": "MARC Holdings",
   "recordTypes.srsMarc": "SRS MARC",
+  "recordTypes.authority": "Authority",
   "actionProfilesForm.recordTypes.marc-bib": "MARC Bibliographic",
   "actionProfilesForm.recordTypes.marc-auth": "MARC Authority",
   "actionProfilesForm.recordTypes.marc-hold": "MARC Holdings",


### PR DESCRIPTION
## Overview:
In connection with creation new separate AUHTORITY entity in the inventory, we should extend folioRecord by adding new type - AUHTORITY

## Refs
https://issues.folio.org/browse/UIDATIMP-1021