### PR TITLE
UIDATIMP-1004 - Illegal character in query for mod-source-record-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Cover `<FieldOrganization>` component with tests (UIDATIMP-958)
 * Add AUTHORITY type into folioRecordTypes (UIDATIMP-1021)
 
+### Bugs fixed:
+* Illegal character in query for mod-source-record-manager (UIDATIMP-1004)
+
 ## [5.0.0](https://github.com/folio-org/ui-data-import/tree/v5.0.0) (2021-10-08)
 
 ### Features added:

--- a/src/components/DataFetcher/DataFetcher.js
+++ b/src/components/DataFetcher/DataFetcher.js
@@ -42,7 +42,7 @@ const logsUrl = createUrl('metadata-provider/jobExecutions', {
   AND (jobProfileInfo="\\“id\\“==" NOT jobProfileInfo="\\“id\\“=="${OCLC_UPDATE_INSTANCE_JOB_ID}") 
   sortBy completedDate/sort.descending`,
   limit: 25,
-}, false);
+}, true);
 
 @stripesConnect
 export class DataFetcher extends Component {


### PR DESCRIPTION
## Description
There is an error log from mod-source-record-manager while using endpoint "/metadata-provider/jobExecutions":

## Approach
- third parameter 'encode' for createUrl function for correspond request has been changed to true

## Refs
https://issues.folio.org/browse/UIDATIMP-1004