### PR TITLE
UIDATIMP-1027 - Adjust the FOLIO record type in the field mapping profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Cover `<MatchingFieldsManager>` component with tests (UIDATIMP-712)
 * Cover `<FieldOrganization>` component with tests (UIDATIMP-958)
 * Add AUTHORITY type into folioRecordTypes (UIDATIMP-1021)
+* Adjust the FOLIO record type in the field mapping profile (UIDATIMP-1027)
+* Adjust the FOLIO record type in the action profile (UIDATIMP-1028)
 
 ## [5.0.1](https://github.com/folio-org/ui-data-import/tree/v5.0.1) (2021-10-19)
 

--- a/src/components/ListTemplate/folioRecordTypes.js
+++ b/src/components/ListTemplate/folioRecordTypes.js
@@ -14,6 +14,11 @@ export const FOLIO_RECORD_TYPES = {
     captionId: 'ui-data-import.recordTypes.item',
     iconKey: 'items',
   },
+  AUTHORITY: {
+    type: 'AUTHORITY',
+    captionId: 'ui-data-import.recordTypes.authority',
+    iconKey: 'marcAuthorities',
+  },
   ORDER: {
     type: 'ORDER',
     captionId: 'ui-data-import.recordTypes.order',
@@ -37,11 +42,6 @@ export const FOLIO_RECORD_TYPES = {
   MARC_AUTHORITY: {
     type: 'MARC_AUTHORITY',
     captionId: 'ui-data-import.recordTypes.marc-auth',
-    iconKey: 'marcAuthorities',
-  },
-  AUTHORITY: {
-    type: 'AUTHORITY',
-    captionId: 'ui-data-import.recordTypes.authority',
     iconKey: 'marcAuthorities',
   },
 };


### PR DESCRIPTION
UIDATIMP-1028 - Adjust the FOLIO record type in the field action profile

## Purpose
To make the Authority record type visible, but not selectable in the Field mapping profiles

## Approach
- order of folioRecordTypes has been changed

## Refs
https://issues.folio.org/browse/UIDATIMP-1027
https://issues.folio.org/browse/UIDATIMP-1028

