### PR TITLE
UIDATIMP-1037 use correct css-loader syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Adjust the FOLIO record type in the action profile (UIDATIMP-1028)
 * Cover `<ViewContainer>` component with tests (UIDATIMP-731)
 * Cover `<ActionProfiles>` settings with tests (UIDATIMP-971)
+* Use correct `css-loader` syntax (UIDATIMP-1037)
 
 ## [5.0.1](https://github.com/folio-org/ui-data-import/tree/v5.0.1) (2021-10-19)
 

--- a/src/components/DatePickerDecorator/DatePickerDecorator.css
+++ b/src/components/DatePickerDecorator/DatePickerDecorator.css
@@ -1,11 +1,11 @@
 .decoratorWrapper {
-  composes: decoratorWrapper from "@folio/data-import/src/components/withReferenceValues/withReferenceValues.css";
+  composes: decoratorWrapper from "~@folio/data-import/src/components/withReferenceValues/withReferenceValues.css";
 }
 
 .decorator {
-  composes: decorator from "@folio/data-import/src/components/withReferenceValues/withReferenceValues.css";
+  composes: decorator from "~@folio/data-import/src/components/withReferenceValues/withReferenceValues.css";
 }
 
 .options-dropdown {
-  composes: options-dropdown from "@folio/data-import/src/components/withReferenceValues/withReferenceValues.css";
+  composes: options-dropdown from "~@folio/data-import/src/components/withReferenceValues/withReferenceValues.css";
 }

--- a/src/components/MatchCriterion/edit/MatchCriterions.css
+++ b/src/components/MatchCriterion/edit/MatchCriterions.css
@@ -1,39 +1,39 @@
 @import "@folio/stripes-components/lib/variables.css";
 
 .matchCriterion {
-  composes: matchCriterion from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: matchCriterion from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .inputContainer {
-  composes: inputContainer from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: inputContainer from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .staticSection {
-  composes: staticSection from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: staticSection from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .dateRangeLabel {
-  composes: dateRangeLabel from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: dateRangeLabel from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .incoming {
-  composes: incoming from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: incoming from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .criterionSection {
-  composes: criterionSection from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: criterionSection from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .existing {
-  composes: existing from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: existing from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .field {
-  composes: field from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: field from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .matchCriteria {
-  composes: matchCriteria from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: matchCriteria from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
   margin-top: -14px;
   margin-bottom: -14px;
 }

--- a/src/components/MatchCriterion/view/ViewMatchCriterion.css
+++ b/src/components/MatchCriterion/view/ViewMatchCriterion.css
@@ -1,41 +1,41 @@
 @import "@folio/stripes-components/lib/variables.css";
 
 .matchCriteria {
-  composes: matchCriteria from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: matchCriteria from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .matchCriterion {
-  composes: matchCriterion from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: matchCriterion from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .inputContainer {
-  composes: inputContainer from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: inputContainer from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .dateRangeLabel {
-  composes: dateRangeLabel from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: dateRangeLabel from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .criterionSection {
-  composes: criterionSection from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: criterionSection from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .incoming {
-  composes: incoming from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: incoming from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .existing {
-  composes: existing from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: existing from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .field,
 .qualifier,
 .part {
-  composes: field from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: field from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
 }
 
 .staticSection {
-  composes: staticSection from "@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
+  composes: staticSection from "~@folio/data-import/src/components/MatchCriterion/CommonMatchCriterion.css";
   & > div:first-child {
     color: var(--color-text);
 

--- a/src/components/RecordTypesSelect/RecordTypesSelect.css
+++ b/src/components/RecordTypesSelect/RecordTypesSelect.css
@@ -62,7 +62,7 @@
 }
 
 .headingCell {
-  composes: display-flex centerContent from "@folio/stripes-components/lib/Layout/Layout.css";
+  composes: display-flex centerContent from "~@folio/stripes-components/lib/Layout/Layout.css";
   border-bottom: 1px solid var(--color-border);
   padding: .5rem;
 }
@@ -98,7 +98,7 @@
 }
 
 .selectedLine {
-  composes: display-flex justify-end from "@folio/stripes-components/lib/Layout/Layout.css";
+  composes: display-flex justify-end from "~@folio/stripes-components/lib/Layout/Layout.css";
   position: absolute;
   left: var(--selected-line-margin);
   right: var(--selected-line-margin);
@@ -110,7 +110,7 @@
 }
 
 .hint {
-  composes: display-flex flex-align-items-center centerContent textCentered from "@folio/stripes-components/lib/Layout/Layout.css";
+  composes: display-flex flex-align-items-center centerContent textCentered from "~@folio/stripes-components/lib/Layout/Layout.css";
   pointer-events: all !important;
 }
 
@@ -126,7 +126,7 @@
 }
 
 .incomingRecord {
-  composes: display-flex flex-align-items-center from "@folio/stripes-components/lib/Layout/Layout.css";
+  composes: display-flex flex-align-items-center from "~@folio/stripes-components/lib/Layout/Layout.css";
   width: 100%;
   line-height: .9;
   white-space: normal;
@@ -142,7 +142,7 @@
 }
 
 .compare {
-  composes: display-flex flex-align-items-center from "@folio/stripes-components/lib/Layout/Layout.css";
+  composes: display-flex flex-align-items-center from "~@folio/stripes-components/lib/Layout/Layout.css";
   position: absolute;
   top: 9px;
   transform: translate(50%);


### PR DESCRIPTION
Use the correct syntax when linking to styles in other packages.

Refs [UIDATIMP-1037](https://issues.folio.org/browse/UIDATIMP01037), [STRIPES-770](https://issues.folio.org/browse/STRIPES-770)