### PR TITLE
UIDATAIMP-1044: Add an Authority toggle and show response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Cover `<UploadingJobsDisplay>` component with tests (UIDATIMP-730)
 * Cover `FileExtensions` components with tests (UIDATIMP-973)
 * Cover `<JobProfiles` component with tests (UIDATIMP-974)
+* Add an Authority toggle and show response (UIDATIMP-1044)
 
 ## [5.0.2](https://github.com/folio-org/ui-data-import/tree/v5.0.2) (2021-11-12)
 

--- a/src/components/LogViewer/LogViewer.js
+++ b/src/components/LogViewer/LogViewer.js
@@ -43,6 +43,9 @@ const filterOptions = [
     id: OPTIONS.ITEM,
     caption: 'ui-data-import.logViewer.filter.item',
   }, {
+    id: OPTIONS.AUTHORITY,
+    caption: 'ui-data-import.logViewer.filter.authority',
+  }, {
     id: OPTIONS.ORDER,
     caption: 'ui-data-import.logViewer.filter.order',
     disabled: true,

--- a/src/components/LogViewer/LogViewer.test.js
+++ b/src/components/LogViewer/LogViewer.test.js
@@ -38,11 +38,19 @@ const logViewerLogsProps = {
       }],
       errorBlockId: 'item-error',
     }],
-    4: [{}],
-    5: [{
+    4: [{
+      label: 'authority label',
+      logs: [{
+        id: '4',
+        name: 'test',
+      }],
+      errorBlockId: 'authority-error',
+    }],
+    5: [{}],
+    6: [{
       label: 'invoice label',
       logs: [{
-        id: '5',
+        id: '6',
         name: 'test',
       }],
       errorBlockId: 'invoice-error',

--- a/src/routes/ViewJobLog.js
+++ b/src/routes/ViewJobLog.js
@@ -66,6 +66,12 @@ export class ViewJobLog extends Component {
       throwErrors: false,
       accumulate: true,
     },
+    authorities: {
+      type: 'okapi',
+      path: 'authority-storage/authorities',
+      throwErrors: false,
+      accumulate: true,
+    },
   });
 
   static propTypes = {
@@ -98,6 +104,10 @@ export class ViewJobLog extends Component {
         hasLoaded: PropTypes.bool.isRequired,
         records: PropTypes.arrayOf(PropTypes.object.isRequired).isRequired,
       }),
+      authorities: PropTypes.shape({
+        hasLoaded: PropTypes.bool.isRequired,
+        records: PropTypes.arrayOf(PropTypes.object.isRequired).isRequired,
+      }),
     }).isRequired,
     mutator: PropTypes.shape({
       instances: PropTypes.shape({ GET: PropTypes.func.isRequired }).isRequired,
@@ -105,6 +115,7 @@ export class ViewJobLog extends Component {
       items: PropTypes.shape({ GET: PropTypes.func.isRequired }).isRequired,
       invoice: PropTypes.shape({ GET: PropTypes.func.isRequired }).isRequired,
       invoiceLine: PropTypes.shape({ GET: PropTypes.func.isRequired }).isRequired,
+      authorities: PropTypes.shape({ GET: PropTypes.func.isRequired }).isRequired,
     }).isRequired,
   };
 
@@ -123,6 +134,7 @@ export class ViewJobLog extends Component {
       this.fetchItemsData();
       this.fetchInvoiceData();
       this.fetchInvoiceLineData();
+      this.fetchAuthorityData();
     }
   }
 
@@ -166,6 +178,14 @@ export class ViewJobLog extends Component {
     if (invoiceLineId) {
       this.props.mutator.invoiceLine.GET({ path: `invoice-storage/invoice-lines/${invoiceLineId}` });
     }
+  }
+
+  fetchAuthorityData() {
+    const authorityIds = this.props.resources.jobLog.records[0]?.relatedAuthorityInfo?.idList || [];
+
+    authorityIds.forEach(authorityId => {
+      this.props.mutator.authorities.GET({ path: `authority-storage/authorities/${authorityId}` });
+    });
   }
 
   get jobLogData() {
@@ -231,6 +251,18 @@ export class ViewJobLog extends Component {
     };
   }
 
+  get authorityData() {
+    const { resources } = this.props;
+
+    const authorities = resources.authorities || {};
+    const [record] = authorities.records || [];
+
+    return {
+      hasLoaded: authorities.hasLoaded,
+      record,
+    };
+  }
+
   get invoiceData() {
     const { resources } = this.props;
 
@@ -268,6 +300,7 @@ export class ViewJobLog extends Component {
       relatedInstanceInfo,
       relatedHoldingsInfo,
       relatedItemInfo,
+      relatedAuthorityInfo,
       relatedOrderInfo,
       relatedInvoiceInfo,
       relatedInvoiceLineInfo,
@@ -278,6 +311,7 @@ export class ViewJobLog extends Component {
       [OPTIONS.INSTANCE]: relatedInstanceInfo.error || '',
       [OPTIONS.HOLDINGS]: relatedHoldingsInfo.error || '',
       [OPTIONS.ITEM]: relatedItemInfo.error || '',
+      [OPTIONS.AUTHORITY]: relatedAuthorityInfo?.error || '',
       [OPTIONS.ORDER]: relatedOrderInfo.error || '',
       [OPTIONS.INVOICE]: {
         invoiceInfo: relatedInvoiceInfo.error || '',
@@ -353,6 +387,12 @@ export class ViewJobLog extends Component {
         logs: this.itemData.record,
         error: this.getErrorMessage(OPTIONS.ITEM),
         errorBlockId: 'item-error',
+      }],
+      [OPTIONS.AUTHORITY]: [{
+        label: '',
+        logs: this.authorityData.record,
+        error: this.getErrorMessage(OPTIONS.AUTHORITY),
+        errorBlockId: 'authority-error',
       }],
       [OPTIONS.ORDER]: [{}],
       [OPTIONS.INVOICE]: [{

--- a/src/routes/ViewJobLog.js
+++ b/src/routes/ViewJobLog.js
@@ -311,7 +311,7 @@ export class ViewJobLog extends Component {
       [OPTIONS.INSTANCE]: relatedInstanceInfo.error || '',
       [OPTIONS.HOLDINGS]: relatedHoldingsInfo.error || '',
       [OPTIONS.ITEM]: relatedItemInfo.error || '',
-      [OPTIONS.AUTHORITY]: relatedAuthorityInfo?.error || '',
+      [OPTIONS.AUTHORITY]: relatedAuthorityInfo.error || '',
       [OPTIONS.ORDER]: relatedOrderInfo.error || '',
       [OPTIONS.INVOICE]: {
         invoiceInfo: relatedInvoiceInfo.error || '',

--- a/src/routes/tests/ViewJobLog.test.js
+++ b/src/routes/tests/ViewJobLog.test.js
@@ -289,7 +289,7 @@ describe('View job log page', () => {
         });
       });
 
-      describe('and Item tag is active', () => {
+      describe('and Authority tag is active', () => {
         it('should display Authority JSON details on the screen', () => {
           const {
             container,

--- a/src/routes/tests/ViewJobLog.test.js
+++ b/src/routes/tests/ViewJobLog.test.js
@@ -46,6 +46,10 @@ const invoiceLineJSONData = {
   id: faker.random.uuid(),
   title: 'Test invoice line title',
 };
+const authorityJSONData = {
+  id: faker.random.uuid(),
+  title: 'Test authority title',
+};
 
 const jobLogResources = hasLoaded => buildResources({
   resourceName: 'jobLog',
@@ -62,6 +66,7 @@ const jobLogResources = hasLoaded => buildResources({
       id: faker.random.uuid(),
       fullInvoiceLineNumber: '1024200-1',
     },
+    relatedAuthorityInfo: { idList: [faker.random.uuid()] },
     sourceRecordOrder: 0,
     sourceRecordTitle: 'Test record title',
   }],
@@ -91,6 +96,10 @@ const invoiceLineResources = buildResources({
   resourceName: 'invoiceLine',
   records: [invoiceLineJSONData],
 });
+const authoritiesResources = buildResources({
+  resourceName: 'authorities',
+  records: [authorityJSONData],
+});
 
 const getResources = ({
   recordType,
@@ -103,6 +112,7 @@ const getResources = ({
   ...itemsResources,
   ...invoiceResources,
   ...invoiceLineResources,
+  ...authoritiesResources,
 });
 
 const mutator = buildMutator({
@@ -111,6 +121,7 @@ const mutator = buildMutator({
   items: { GET: jest.fn() },
   invoice: { GET: jest.fn() },
   invoiceLine: { GET: jest.fn() },
+  authorities: { GET: jest.fn() },
 });
 
 const getViewJobLogComponent = ({
@@ -160,6 +171,7 @@ describe('View job log page', () => {
       expect(mutator.items.GET).toHaveBeenCalled();
       expect(mutator.invoice.GET).toHaveBeenCalled();
       expect(mutator.invoiceLine.GET).toHaveBeenCalled();
+      expect(mutator.authorities.GET).toHaveBeenCalled();
     });
   });
 
@@ -208,10 +220,10 @@ describe('View job log page', () => {
       expect(getByText('Show:')).toBeDefined();
     });
 
-    it('should have 6 tabs', () => {
+    it('should have 7 tabs', () => {
       const { getAllByRole } = renderViewJobLog({ recordType: 'MARC' });
 
-      expect(getAllByRole('tab').length).toEqual(6);
+      expect(getAllByRole('tab').length).toEqual(7);
     });
   });
 
@@ -274,6 +286,20 @@ describe('View job log page', () => {
           const codeElement = container.querySelector('code.info');
 
           expect(JSON.parse(codeElement.textContent)).toEqual(itemsJSONData);
+        });
+      });
+
+      describe('and Item tag is active', () => {
+        it('should display Authority JSON details on the screen', () => {
+          const {
+            container,
+            getByText,
+          } = renderViewJobLog({ recordType: 'MARC' });
+
+          fireEvent.click(getByText('Authority'));
+          const codeElement = container.querySelector('code.info');
+
+          expect(JSON.parse(codeElement.textContent)).toEqual(authorityJSONData);
         });
       });
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -146,8 +146,9 @@ export const LOG_VIEWER = {
       INSTANCE: 1,
       HOLDINGS: 2,
       ITEM: 3,
-      ORDER: 4,
-      INVOICE: 5,
+      AUTHORITY: 4,
+      ORDER: 5,
+      INVOICE: 6,
     },
   },
 };

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -856,6 +856,7 @@
   "logViewer.filter.instance": "Instance",
   "logViewer.filter.holdings": "Holdings",
   "logViewer.filter.item": "Item",
+  "logViewer.filter.authority": "Authority",
   "logViewer.filter.order": "Order",
   "logViewer.filter.invoice": "Invoice",
   "logLight.actionStatus.created": "Created",


### PR DESCRIPTION
# UIDATIMP-1044: Data Import > Import Log for record page > Add an Authority toggle and show response

## Purpose
Functionality for new `Authority` toggle button same as for `Holdings` or `Instance`, but needs backend implementation for `metadata-provider/jobLogEntries/` endpoint. It should returns a `relatedAuthorityInfo` object in response.

## Refs
Issue: [UIDATIMP-1044](https://issues.folio.org/browse/UIDATIMP-1044)

## Screenshots
![image](https://user-images.githubusercontent.com/55701515/143023263-f0ccfb82-1136-44e0-bb08-2ebb29ab6d72.png)
