### PR TITLE
UIDATIMP-1081 Job profiles are showing incorrect info for "Jobs using this profile" accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Enable Action profile action for incoming MARC Authorities: Update MARC Authority records (UIDATIMP-1055)
 * Enable Matching profile for incoming MARC Authorities (UIDATIMP-1054)
 * Enable Field Mapping profile action for updating MARC Authorities records (UIDATIMP-1056)
+* Job profiles are showing incorrect info for "Jobs using this profile" accordion (UIDATIMP-1081)
 
 ### Bugs fixed:
 * Need to be able to use the same match profile in the same job profile, with different actions (UIDATIMP-1067)

--- a/src/settings/JobProfiles/ViewJobProfile.js
+++ b/src/settings/JobProfiles/ViewJobProfile.js
@@ -56,6 +56,7 @@ import {
   getEntity,
   getEntityTags,
   compose,
+  createUrlFromArray,
 } from '../../utils';
 
 import sharedCss from '../../shared.css';
@@ -416,10 +417,11 @@ ViewJobProfileComponent.manifest = Object.freeze({
   },
   jobsUsingThisProfile: {
     type: 'okapi',
-    path: createUrl('metadata-provider/jobExecutions', {
-      query: '(jobProfileInfo.id==":{id}") sortBy completedDate/sort.descending',
-      limit: 25,
-    }, false),
+    path: createUrlFromArray('metadata-provider/jobExecutions', [
+      'profileIdAny=:{id}',
+      'limit=25',
+      'sortBy=completed_date,desc',
+    ]),
     throwErrors: false,
   },
 });

--- a/src/settings/JobProfiles/ViewJobProfile.js
+++ b/src/settings/JobProfiles/ViewJobProfile.js
@@ -56,7 +56,6 @@ import {
   getEntity,
   getEntityTags,
   compose,
-  createUrlFromArray,
 } from '../../utils';
 
 import sharedCss from '../../shared.css';
@@ -417,11 +416,11 @@ ViewJobProfileComponent.manifest = Object.freeze({
   },
   jobsUsingThisProfile: {
     type: 'okapi',
-    path: createUrlFromArray('metadata-provider/jobExecutions', [
-      'profileIdAny=:{id}',
-      'limit=25',
-      'sortBy=completed_date,desc',
-    ]),
+    path: createUrl('metadata-provider/jobExecutions', {
+      profileIdAny: ':{id}',
+      limit: 25,
+      sortBy: 'completed_date,desc',
+    }, false),
     throwErrors: false,
   },
 });


### PR DESCRIPTION
## Overview
When a job profile creates or updates an Instance, the log hotlinks for Instance, Holdings, and/or Item record are populated. When a job profile creates or updates a Holdings or Item, without updating an Instance, the Holdings and/or Item log hotlinks are not populated

## Approach
Request payload now filling with separated parameters instead inside 'query' parameter


## Refs
https://issues.folio.org/browse/UIDATIMP-1081

## Screenshots
### Before
![old](https://user-images.githubusercontent.com/63101175/151183835-76f020d8-73eb-43ea-bd11-eccd1c9dbc0b.png)
### After
![new](https://user-images.githubusercontent.com/63101175/151183670-da9fc3bc-62fd-4b31-bd71-20b8ee5a29d7.png)
