### PR TITLE
UIDATIMP-1102: Match Profile - Duplicate action does not display existing record information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 ### Bugs fixed:
 * Need to be able to use the same match profile in the same job profile, with different actions (UIDATIMP-1067)
 * The log hotlinks for Instance, Holdings, and/or Item record are not populated (UIDATIMP-1101)
+* Match Profile - Duplicate action does not display Existing record information (UIDATIMP-1102)
 
 ## [5.0.4](https://github.com/folio-org/ui-data-import/tree/v5.0.4) (2022-02-09)
 ### Bugs fixed:

--- a/src/components/MatchCriterion/view/IncomingSectionStatic/IncomingSectionStatic.test.js
+++ b/src/components/MatchCriterion/view/IncomingSectionStatic/IncomingSectionStatic.test.js
@@ -83,15 +83,15 @@ describe('IncomingSectionStatic view', () => {
       it('should be rendered TEXT static value type', () => {
         const { getByText } = renderIncomingSectionStatic(incomingSectionStaticWithText);
 
-        expect(getByText('test text')).toBeDefined();
+        expect(getByText('test text')).toBeInTheDocument();
       });
     });
 
     describe('and the text field is not filled', () => {
       it('should be rendered with empty TEXT static value type', () => {
-        const { getByLabelText } = renderIncomingSectionStatic(incomingSectionStaticWithoutText);
+        const { getByText } = renderIncomingSectionStatic(incomingSectionStaticWithoutText);
 
-        expect(getByLabelText('No value set')).toBeDefined();
+        expect(getByText('No value set')).toBeInTheDocument();
       });
     });
   });
@@ -101,15 +101,15 @@ describe('IncomingSectionStatic view', () => {
       it('should be rendered NUMBER static value type', () => {
         const { getByText } = renderIncomingSectionStatic(incomingSectionStaticWithNumber);
 
-        expect(getByText('test text')).toBeDefined();
+        expect(getByText('test text')).toBeInTheDocument();
       });
     });
 
     describe('and the number field is not filled', () => {
       it('should be rendered with empty NUMBER static value type', () => {
-        const { getByLabelText } = renderIncomingSectionStatic(incomingSectionStaticWithoutNumber);
+        const { getByText } = renderIncomingSectionStatic(incomingSectionStaticWithoutNumber);
 
-        expect(getByLabelText('No value set')).toBeDefined();
+        expect(getByText('No value set')).toBeInTheDocument();
       });
     });
   });
@@ -119,15 +119,15 @@ describe('IncomingSectionStatic view', () => {
       it('should be rendered EXACT_DATE static value type', () => {
         const { queryByText } = renderIncomingSectionStatic(incomingSectionStaticWithDate);
 
-        expect(queryByText('12/30/2010')).toBeDefined();
+        expect(queryByText('12/30/2010')).toBeInTheDocument();
       });
     });
 
     describe('and the date field is not filled', () => {
       it('should be rendered with empty EXACT_DATE static value type', () => {
-        const { getByLabelText } = renderIncomingSectionStatic(incomingSectionStaticWithoutDate);
+        const { getByText } = renderIncomingSectionStatic(incomingSectionStaticWithoutDate);
 
-        expect(getByLabelText('No value set')).toBeDefined();
+        expect(getByText('No value set')).toBeInTheDocument();
       });
     });
   });
@@ -144,9 +144,9 @@ describe('IncomingSectionStatic view', () => {
 
     describe('and the date range field is not filled', () => {
       it('should be rendered with empty DATE_RANGE static value type', () => {
-        const { getAllByLabelText } = renderIncomingSectionStatic(incomingSectionStaticWithoutDateRange);
+        const { getAllByText } = renderIncomingSectionStatic(incomingSectionStaticWithoutDateRange);
 
-        expect(getAllByLabelText('No value set')).toBeDefined();
+        expect(getAllByText('No value set').length).toBe(2);
       });
     });
   });

--- a/src/components/MatchCriterion/view/IncomingSectionStatic/IncomingSectionStatic.test.js
+++ b/src/components/MatchCriterion/view/IncomingSectionStatic/IncomingSectionStatic.test.js
@@ -119,7 +119,7 @@ describe('IncomingSectionStatic view', () => {
       it('should be rendered EXACT_DATE static value type', () => {
         const { queryByText } = renderIncomingSectionStatic(incomingSectionStaticWithDate);
 
-        expect(queryByText('12/30/2010')).toBeInTheDocument();
+        expect(queryByText('12/30/2010')).toBeDefined();
       });
     });
 

--- a/src/components/ProfileAssociator/tests/ProfileAssociator.test.js
+++ b/src/components/ProfileAssociator/tests/ProfileAssociator.test.js
@@ -239,7 +239,7 @@ describe('<ProfileAssociator>', () => {
   describe('when "unlink" button is clicked', () => {
     it('Confirmation modal should appear', async () => {
       const {
-        getAllByRole,
+        getAllByTitle,
         findByText,
       } = renderProfileAssociator({
         isMultiSelect: false,
@@ -249,7 +249,9 @@ describe('<ProfileAssociator>', () => {
         detailType: PROFILE_TYPES.JOB_PROFILE,
       });
 
-      fireEvent.click(getAllByRole('button', { name: /unlink this profile/i })[0]);
+      const unlinkButton = getAllByTitle(/unlink this profile/i)[0];
+
+      fireEvent.click(unlinkButton);
 
       expect(await findByText('Confirmation modal')).toBeInTheDocument();
     });
@@ -257,7 +259,7 @@ describe('<ProfileAssociator>', () => {
     describe('when cancel button is clicked', () => {
       it('Confirmation modal should be closed', async () => {
         const {
-          getAllByRole,
+          getAllByTitle,
           findByText,
           queryByText,
         } = renderProfileAssociator({
@@ -265,7 +267,9 @@ describe('<ProfileAssociator>', () => {
           useSearch: false,
         });
 
-        fireEvent.click(getAllByRole('button', { name: /unlink this profile/i })[0]);
+        const unlinkButton = getAllByTitle(/unlink this profile/i)[0];
+
+        fireEvent.click(unlinkButton);
 
         const cancelButton = await findByText('Cancel');
 
@@ -278,7 +282,7 @@ describe('<ProfileAssociator>', () => {
     describe('when confirm button is clicked', () => {
       it('Confirmation modal should be closed', async () => {
         const {
-          getAllByRole,
+          getAllByTitle,
           findByText,
           queryByText,
         } = renderProfileAssociator({
@@ -286,7 +290,9 @@ describe('<ProfileAssociator>', () => {
           useSearch: false,
         });
 
-        fireEvent.click(getAllByRole('button', { name: /unlink this profile/i })[0]);
+        const unlinkButton = getAllByTitle(/unlink this profile/i)[0];
+
+        fireEvent.click(unlinkButton);
 
         const confirmButton = await findByText('Confirm');
 

--- a/src/settings/MatchProfiles/MatchProfilesForm.js
+++ b/src/settings/MatchProfiles/MatchProfilesForm.js
@@ -156,12 +156,13 @@ export const MatchProfilesFormComponent = memo(({
   const { layer } = queryString.parse(search);
 
   const isEditMode = layer === LAYER_TYPES.EDIT;
+  const isDuplicateMode = layer === LAYER_TYPES.DUPLICATE;
   const staticValueTypes = FORMS_SETTINGS[ENTITY_KEYS.MATCH_PROFILES].MATCHING.STATIC_VALUE_TYPES;
 
   const currentStaticValueType = get(form.getState(), ['values', 'profile', 'matchDetails', '0', 'incomingMatchExpression', 'staticValueDetails', 'staticValueType'], null);
 
   const [incomingRecord, setIncomingRecord] = useState(MATCH_INCOMING_RECORD_TYPES[incomingRecordType]);
-  const [existingRecord, setExistingRecord] = useState(isEditMode ? existingRecordType : '');
+  const [existingRecord, setExistingRecord] = useState(existingRecordType || '');
   const [existingRecordFields, setExistingRecordFields] = useState([]);
   const [staticValueType, setStaticValueType] = useState(currentStaticValueType);
   const [isConfirmEditModalOpen, setConfirmModalOpen] = useState(false);
@@ -180,7 +181,7 @@ export const MatchProfilesFormComponent = memo(({
   const editWithModal = isEditMode && associatedJobProfilesAmount;
 
   const getInitialFields = (matchFields, getDropdownOptions) => {
-    if (isEditMode) {
+    if (isEditMode || isDuplicateMode) {
       const matches = matchFields(jsonSchemas[existingRecordType], existingRecordType);
 
       return getDropdownOptions(matches);
@@ -188,6 +189,7 @@ export const MatchProfilesFormComponent = memo(({
 
     return [];
   };
+
   const onSubmit = async event => {
     if (editWithModal) {
       event.preventDefault();

--- a/src/settings/MatchProfiles/MatchProfilesForm.test.js
+++ b/src/settings/MatchProfiles/MatchProfilesForm.test.js
@@ -276,9 +276,9 @@ describe('MatchProfilesForm', () => {
       it('should be closed after double click', () => {
         const {
           queryByText,
-          getByText,
+          getAllByText,
         } = renderMatchProfilesForm(matchProfilesFormProps());
-        const qualifier = getByText('Use a qualifier');
+        const qualifier = getAllByText('Use a qualifier')[0];
 
         fireEvent.click(qualifier);
         fireEvent.click(qualifier);


### PR DESCRIPTION
## Purpose
- Match Profile - Duplicate action does not display Existing record information

## Approach
- Current code only displays existing record fields when record is being edited. Because `existingRecord` state is assigned intial `existingRecordType` value only in `editing` mode. Also, `existing record field` selection list is populated only in editing mode.
- I added `isDuplicate` to check in `getInitialFields()` function to populate  `existing record field` selection list in `duplicate` mode

## Refs
- https://issues.folio.org/browse/UIDATIMP-1102