### PR TITLE
UIDATIMP-1110 - Fix for RepeatableFieldComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed:
 * Modify instead of Update while creating new Action profile (UIDATIMP-1103)
 * Jobs always show up as current even though they were started months ago (UIDATIMP-1108)
+* When you try to add a statistic code while creating a New field mapping profile, the line to enter it is not added on the first click. (UIDATIMP-1110)
 
 ## [5.1.1](https://github.com/folio-org/ui-data-import/tree/v5.1.1) (2022-03-04)
 

--- a/src/components/RepeatableActionsField/RepeatableActionsField.js
+++ b/src/components/RepeatableActionsField/RepeatableActionsField.js
@@ -57,6 +57,8 @@ export const RepeatableActionsField = memo(({
   );
 
   const handleRepeatableActionChange = e => {
+    e.target.blur();
+
     if (e.target.value === actionToClearFields) {
       onRepeatableActionChange(subfieldsToClearPath || `profile.mappingDetails.mappingFields[${repeatableFieldIndex}].subfields`, []);
     }


### PR DESCRIPTION
## Overview
When you try to add a statistic code while creating a New field mapping profile, the line to enter it is not added on the first click, but the message "One or more values must be added before the profile can be saved." is displayed. To add a line for input, you must press a second time.

## Approach
- added blur event trigger after option from dropdown has been chosen