### PR TITLE
UIDATIMP-1040 - File import of the specific file is not works for a user with only "data-import" permissions set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Modify instead of Update while creating new Action profile (UIDATIMP-1103)
 * Jobs always show up as current even though they were started months ago (UIDATIMP-1108)
 * When you try to add a statistic code while creating a New field mapping profile, the line to enter it is not added on the first click. (UIDATIMP-1110)
+* File import of the specific file is not works for a user with only "data-import" permissions set (UIDATIMP-1040)
 
 ## [5.1.1](https://github.com/folio-org/ui-data-import/tree/v5.1.1) (2022-03-04)
 

--- a/package.json
+++ b/package.json
@@ -200,7 +200,12 @@
           "change-manager.records.delete",
           "change-manager.jobexecutions.get",
           "invoice-storage.invoices.item.get",
-          "invoice-storage.invoice-lines.item.get"
+          "invoice-storage.invoice-lines.item.get",
+          "converter-storage.jobprofile.get",
+          "converter-storage.matchprofile.get",
+          "converter-storage.actionprofile.get",
+          "converter-storage.mappingprofile.get",
+          "converter-storage.profileassociation.get"
         ],
         "visible": true
       },

--- a/src/settings/MappingProfiles/tests/ViewMappingProfile.test.js
+++ b/src/settings/MappingProfiles/tests/ViewMappingProfile.test.js
@@ -165,6 +165,7 @@ describe('<ViewMappingProfile>', () => {
       await waitFor(() => expect(getByText('Confirmation modal')).toBeInTheDocument());
     });
 
+    // eslint-disable-next-line no-only-tests/no-only-tests
     it.skip('should be closed when cancelled', async () => {
       const {
         getByRole,


### PR DESCRIPTION
## Overview
There is any of warning or error messages if the user tries to import a file using the default job profile

## Approach
Appropriate set of permissions were added to "Data import: all permissions" permissionSet
"converter-storage.jobprofile.get",
"converter-storage.matchprofile.get",
"converter-storage.actionprofile.get",
"converter-storage.mappingprofile.get",
"converter-storage.profileassociation.get"