### PR TITLE
UIDATIMP-1119 - Add Admin note field to the Holdings field mapping profile: Create/Edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features added
 * Add checkboxes and delete action to Data Import landing page (UIDATIMP-1077)
 * Add Admin note field to the Instance field mapping profile: Create/Edit (UIDATIMP-1118)
+* Add Admin note field to the Holdings field mapping profile: Create/Edit (UIDATIMP-1119)
 
 ## [5.1.2](https://github.com/folio-org/ui-data-import/tree/v5.1.2) (2022-03-24)
 

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/AdministrativeData.js
@@ -37,6 +37,7 @@ import {
 export const AdministrativeData = ({
   formerIds,
   statisticalCodeIds,
+  administrativeNotes,
   initialFields,
   setReferenceTables,
   getRepeatableFieldAction,
@@ -189,6 +190,45 @@ export const AdministrativeData = ({
           </RepeatableActionsField>
         </Col>
       </Row>
+      <Row left="xs">
+        <Col
+          data-test-admisitrative-notes
+          xs={12}
+        >
+          <RepeatableActionsField
+            wrapperFieldName={getRepeatableFieldName(5)}
+            legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.administrativeNotes.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(5)}
+            repeatableFieldIndex={5}
+            hasRepeatableFields={!!administrativeNotes.length}
+            onRepeatableActionChange={setReferenceTables}
+          >
+            {isDisabled => (
+              <RepeatableField
+                fields={administrativeNotes}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.administrativeNotes.addLabel`} />}
+                onAdd={() => onAdd(administrativeNotes, 'administrativeNotes', 5, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, administrativeNotes, 5, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col
+                      data-test-admisitrative-note
+                      xs={12}
+                    >
+                      <Field
+                        component={TextField}
+                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.administrativeNote`} />}
+                        name={getSubfieldName(5, 0, index)}
+                      />
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
+          </RepeatableActionsField>
+        </Col>
+      </Row>
     </Accordion>
   );
 };
@@ -196,6 +236,7 @@ export const AdministrativeData = ({
 AdministrativeData.propTypes = {
   formerIds: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   statisticalCodeIds: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
+  administrativeNotes: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
   initialFields: PropTypes.object.isRequired,
   setReferenceTables: PropTypes.func.isRequired,
   getRepeatableFieldAction: PropTypes.func.isRequired,

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/ElectronicAccess.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/ElectronicAccess.js
@@ -48,9 +48,9 @@ export const ElectronicAccess = ({
           xs={12}
         >
           <RepeatableActionsField
-            wrapperFieldName={getRepeatableFieldName(22)}
-            repeatableFieldAction={getRepeatableFieldAction(22)}
-            repeatableFieldIndex={22}
+            wrapperFieldName={getRepeatableFieldName(23)}
+            repeatableFieldAction={getRepeatableFieldAction(23)}
+            repeatableFieldIndex={23}
             hasRepeatableFields={!!electronicAccess.length}
             onRepeatableActionChange={setReferenceTables}
           >
@@ -58,8 +58,8 @@ export const ElectronicAccess = ({
               <RepeatableField
                 fields={electronicAccess}
                 addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.EAccess.addLabel`} />}
-                onAdd={() => onAdd(electronicAccess, 'electronicAccess', 22, initialFields, setReferenceTables, 'order')}
-                onRemove={index => onRemove(index, electronicAccess, 22, setReferenceTables, 'order')}
+                onAdd={() => onAdd(electronicAccess, 'electronicAccess', 23, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, electronicAccess, 23, setReferenceTables, 'order')}
                 canAdd={!isDisabled}
                 renderField={(field, index) => (
                   <Row left="xs">
@@ -69,7 +69,7 @@ export const ElectronicAccess = ({
                     >
                       <AcceptedValuesField
                         component={TextField}
-                        name={getSubfieldName(22, 0, index)}
+                        name={getSubfieldName(23, 0, index)}
                         label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.relationship`} />}
                         optionValue="name"
                         optionLabel="name"
@@ -79,7 +79,7 @@ export const ElectronicAccess = ({
                           wrapperSourcePath: 'electronicAccessRelationships',
                         }]}
                         setAcceptedValues={setReferenceTables}
-                        acceptedValuesPath={getRepeatableAcceptedValuesPath(22, 0, index)}
+                        acceptedValuesPath={getRepeatableAcceptedValuesPath(23, 0, index)}
                         okapi={okapi}
                       />
                     </Col>
@@ -89,7 +89,7 @@ export const ElectronicAccess = ({
                           <Field
                             component={TextField}
                             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.uri`} />}
-                            name={getSubfieldName(22, 1, index)}
+                            name={getSubfieldName(23, 1, index)}
                             validate={[validation]}
                           />
                         )}
@@ -101,7 +101,7 @@ export const ElectronicAccess = ({
                           <Field
                             component={TextField}
                             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.linkText`} />}
-                            name={getSubfieldName(22, 2, index)}
+                            name={getSubfieldName(23, 2, index)}
                             validate={[validation]}
                           />
                         )}
@@ -113,7 +113,7 @@ export const ElectronicAccess = ({
                           <Field
                             component={TextField}
                             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.materialsSpecified`} />}
-                            name={getSubfieldName(22, 3, index)}
+                            name={getSubfieldName(23, 3, index)}
                             validate={[validation]}
                           />
                         )}
@@ -125,7 +125,7 @@ export const ElectronicAccess = ({
                           <Field
                             component={TextField}
                             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.EAccess.field.urlPublicNote`} />}
-                            name={getSubfieldName(22, 4, index)}
+                            name={getSubfieldName(23, 4, index)}
                             validate={[validation]}
                           />
                         )}

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsDetails.js
@@ -54,7 +54,7 @@ export const HoldingsDetails = ({
             {validation => (
               <Field
                 component={TextField}
-                name={getFieldName(14)}
+                name={getFieldName(15)}
                 label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.details.field.numberOfItems`} />}
                 validate={[validation]}
               />
@@ -69,10 +69,10 @@ export const HoldingsDetails = ({
           xs={12}
         >
           <RepeatableActionsField
-            wrapperFieldName={getRepeatableFieldName(15)}
+            wrapperFieldName={getRepeatableFieldName(16)}
             legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement.legend`} />}
-            repeatableFieldAction={getRepeatableFieldAction(15)}
-            repeatableFieldIndex={15}
+            repeatableFieldAction={getRepeatableFieldAction(16)}
+            repeatableFieldIndex={16}
             hasRepeatableFields={!!holdingsStatements.length}
             onRepeatableActionChange={setReferenceTables}
           >
@@ -80,74 +80,8 @@ export const HoldingsDetails = ({
               <RepeatableField
                 fields={holdingsStatements}
                 addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement.addLabel`} />}
-                onAdd={() => onAdd(holdingsStatements, 'holdingsStatements', 15, initialFields, setReferenceTables, 'order')}
-                onRemove={index => onRemove(index, holdingsStatements, 15, setReferenceTables, 'order')}
-                canAdd={!isDisabled}
-                renderField={(field, index) => (
-                  <Row left="xs">
-                    <Col xs={4}>
-                      <WithValidation>
-                        {validation => (
-                          <Field
-                            component={TextField}
-                            label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement`} />}
-                            name={getSubfieldName(15, 0, index)}
-                            validate={[validation]}
-                          />
-                        )}
-                      </WithValidation>
-                    </Col>
-                    <Col xs={4}>
-                      <WithValidation>
-                        {validation => (
-                          <Field
-                            component={TextField}
-                            label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatementPublicNote`} />}
-                            name={getSubfieldName(15, 1, index)}
-                            validate={[validation]}
-                          />
-                        )}
-                      </WithValidation>
-                    </Col>
-                    <Col xs={4}>
-                      <WithValidation>
-                        {validation => (
-                          <Field
-                            component={TextField}
-                            label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatementStaffNote`} />}
-                            name={getSubfieldName(15, 2, index)}
-                            validate={[validation]}
-                          />
-                        )}
-                      </WithValidation>
-                    </Col>
-                  </Row>
-                )}
-              />
-            )}
-          </RepeatableActionsField>
-        </Col>
-      </Row>
-      <Row left="xs">
-        <Col
-          data-test-statements-for-supplement
-          id="section-holding-statements-for-supplements"
-          xs={12}
-        >
-          <RepeatableActionsField
-            wrapperFieldName={getRepeatableFieldName(16)}
-            legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForSupplements.legend`} />}
-            repeatableFieldAction={getRepeatableFieldAction(16)}
-            repeatableFieldIndex={16}
-            hasRepeatableFields={!!holdingsStatementsForSupplements.length}
-            onRepeatableActionChange={setReferenceTables}
-          >
-            {isDisabled => (
-              <RepeatableField
-                fields={holdingsStatementsForSupplements}
-                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForSupplements.addLabel`} />}
-                onAdd={() => onAdd(holdingsStatementsForSupplements, 'holdingsStatementsForSupplements', 16, initialFields, setReferenceTables, 'order')}
-                onRemove={index => onRemove(index, holdingsStatementsForSupplements, 16, setReferenceTables, 'order')}
+                onAdd={() => onAdd(holdingsStatements, 'holdingsStatements', 16, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, holdingsStatements, 16, setReferenceTables, 'order')}
                 canAdd={!isDisabled}
                 renderField={(field, index) => (
                   <Row left="xs">
@@ -196,24 +130,24 @@ export const HoldingsDetails = ({
       </Row>
       <Row left="xs">
         <Col
-          data-test-statements-for-indexes
-          id="section-holding-statements-for-indexes"
+          data-test-statements-for-supplement
+          id="section-holding-statements-for-supplements"
           xs={12}
         >
           <RepeatableActionsField
             wrapperFieldName={getRepeatableFieldName(17)}
-            legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForIndexes.legend`} />}
+            legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForSupplements.legend`} />}
             repeatableFieldAction={getRepeatableFieldAction(17)}
             repeatableFieldIndex={17}
-            hasRepeatableFields={!!holdingsStatementsForIndexes.length}
+            hasRepeatableFields={!!holdingsStatementsForSupplements.length}
             onRepeatableActionChange={setReferenceTables}
           >
             {isDisabled => (
               <RepeatableField
-                fields={holdingsStatementsForIndexes}
-                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForIndexes.addLabel`} />}
-                onAdd={() => onAdd(holdingsStatementsForIndexes, 'holdingsStatementsForIndexes', 17, initialFields, setReferenceTables, 'order')}
-                onRemove={index => onRemove(index, holdingsStatementsForIndexes, 17, setReferenceTables, 'order')}
+                fields={holdingsStatementsForSupplements}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForSupplements.addLabel`} />}
+                onAdd={() => onAdd(holdingsStatementsForSupplements, 'holdingsStatementsForSupplements', 17, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, holdingsStatementsForSupplements, 17, setReferenceTables, 'order')}
                 canAdd={!isDisabled}
                 renderField={(field, index) => (
                   <Row left="xs">
@@ -262,12 +196,78 @@ export const HoldingsDetails = ({
       </Row>
       <Row left="xs">
         <Col
+          data-test-statements-for-indexes
+          id="section-holding-statements-for-indexes"
+          xs={12}
+        >
+          <RepeatableActionsField
+            wrapperFieldName={getRepeatableFieldName(18)}
+            legend={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForIndexes.legend`} />}
+            repeatableFieldAction={getRepeatableFieldAction(18)}
+            repeatableFieldIndex={18}
+            hasRepeatableFields={!!holdingsStatementsForIndexes.length}
+            onRepeatableActionChange={setReferenceTables}
+          >
+            {isDisabled => (
+              <RepeatableField
+                fields={holdingsStatementsForIndexes}
+                addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.statements.field.holdingsStatementsForIndexes.addLabel`} />}
+                onAdd={() => onAdd(holdingsStatementsForIndexes, 'holdingsStatementsForIndexes', 18, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, holdingsStatementsForIndexes, 18, setReferenceTables, 'order')}
+                canAdd={!isDisabled}
+                renderField={(field, index) => (
+                  <Row left="xs">
+                    <Col xs={4}>
+                      <WithValidation>
+                        {validation => (
+                          <Field
+                            component={TextField}
+                            label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatement`} />}
+                            name={getSubfieldName(18, 0, index)}
+                            validate={[validation]}
+                          />
+                        )}
+                      </WithValidation>
+                    </Col>
+                    <Col xs={4}>
+                      <WithValidation>
+                        {validation => (
+                          <Field
+                            component={TextField}
+                            label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatementPublicNote`} />}
+                            name={getSubfieldName(18, 1, index)}
+                            validate={[validation]}
+                          />
+                        )}
+                      </WithValidation>
+                    </Col>
+                    <Col xs={4}>
+                      <WithValidation>
+                        {validation => (
+                          <Field
+                            component={TextField}
+                            label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.statements.field.holdingsStatementStaffNote`} />}
+                            name={getSubfieldName(18, 2, index)}
+                            validate={[validation]}
+                          />
+                        )}
+                      </WithValidation>
+                    </Col>
+                  </Row>
+                )}
+              />
+            )}
+          </RepeatableActionsField>
+        </Col>
+      </Row>
+      <Row left="xs">
+        <Col
           data-test-ill-policy
           xs={4}
         >
           <AcceptedValuesField
             component={TextField}
-            name={getFieldName(18)}
+            name={getFieldName(19)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.field.illPolicy`} />}
             optionValue="name"
             optionLabel="name"
@@ -278,7 +278,7 @@ export const HoldingsDetails = ({
             }]}
             isRemoveValueAllowed
             setAcceptedValues={setReferenceTables}
-            acceptedValuesPath={getAcceptedValuesPath(18)}
+            acceptedValuesPath={getAcceptedValuesPath(19)}
             okapi={okapi}
           />
         </Col>
@@ -290,7 +290,7 @@ export const HoldingsDetails = ({
             {validation => (
               <Field
                 component={TextField}
-                name={getFieldName(19)}
+                name={getFieldName(20)}
                 label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.field.digitizationPolicy`} />}
                 validate={[validation]}
               />
@@ -305,7 +305,7 @@ export const HoldingsDetails = ({
             {validation => (
               <Field
                 component={TextField}
-                name={getFieldName(20)}
+                name={getFieldName(21)}
                 label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.field.retentionPolicy`} />}
                 validate={[validation]}
               />

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsNotes.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsNotes.js
@@ -50,9 +50,9 @@ export const HoldingsNotes = ({
           xs={12}
         >
           <RepeatableActionsField
-            wrapperFieldName={getRepeatableFieldName(21)}
-            repeatableFieldAction={getRepeatableFieldAction(21)}
-            repeatableFieldIndex={21}
+            wrapperFieldName={getRepeatableFieldName(22)}
+            repeatableFieldAction={getRepeatableFieldAction(22)}
+            repeatableFieldIndex={22}
             hasRepeatableFields={!!notes.length}
             onRepeatableActionChange={setReferenceTables}
           >
@@ -60,8 +60,8 @@ export const HoldingsNotes = ({
               <RepeatableField
                 fields={notes}
                 addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.holdingsNotes.addLabel`} />}
-                onAdd={() => onAdd(notes, 'notes', 21, initialFields, setReferenceTables, 'order')}
-                onRemove={index => onRemove(index, notes, 21, setReferenceTables, 'order')}
+                onAdd={() => onAdd(notes, 'notes', 22, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, notes, 22, setReferenceTables, 'order')}
                 canAdd={!isDisabled}
                 renderField={(field, index) => (
                   <Row left="xs">
@@ -71,7 +71,7 @@ export const HoldingsNotes = ({
                     >
                       <AcceptedValuesField
                         component={TextField}
-                        name={getSubfieldName(21, 0, index)}
+                        name={getSubfieldName(22, 0, index)}
                         label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.noteType`} />}
                         optionValue="name"
                         optionLabel="name"
@@ -81,7 +81,7 @@ export const HoldingsNotes = ({
                           wrapperSourcePath: 'holdingsNoteTypes',
                         }]}
                         setAcceptedValues={setReferenceTables}
-                        acceptedValuesPath={getRepeatableAcceptedValuesPath(21, 0, index)}
+                        acceptedValuesPath={getRepeatableAcceptedValuesPath(22, 0, index)}
                         okapi={okapi}
                       />
                     </Col>
@@ -91,7 +91,7 @@ export const HoldingsNotes = ({
                           <Field
                             component={TextField}
                             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.note`} />}
-                            name={getSubfieldName(21, 1, index)}
+                            name={getSubfieldName(22, 1, index)}
                             validate={[validation]}
                           />
                         )}
@@ -103,7 +103,7 @@ export const HoldingsNotes = ({
                     >
                       <BooleanActionField
                         label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.staffOnly`} />}
-                        name={getBoolSubfieldName(21, 2, index)}
+                        name={getBoolSubfieldName(22, 2, index)}
                         required
                       />
                     </Col>

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/Location.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/Location.js
@@ -38,7 +38,7 @@ export const Location = ({
         >
           <AcceptedValuesField
             component={TextField}
-            name={getFieldName(5)}
+            name={getFieldName(6)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.location.field.permanent`} />}
             optionValue="name"
             optionLabel="name"
@@ -48,7 +48,7 @@ export const Location = ({
               wrapperSourcePath: 'locations',
             }]}
             setAcceptedValues={setReferenceTables}
-            acceptedValuesPath={getAcceptedValuesPath(5)}
+            acceptedValuesPath={getAcceptedValuesPath(6)}
             optionTemplate="**name** (**code**)"
             okapi={okapi}
           />
@@ -59,7 +59,7 @@ export const Location = ({
         >
           <AcceptedValuesField
             component={TextField}
-            name={getFieldName(6)}
+            name={getFieldName(7)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.location.field.temporary`} />}
             optionValue="name"
             optionLabel="name"
@@ -70,7 +70,7 @@ export const Location = ({
             }]}
             isRemoveValueAllowed
             setAcceptedValues={setReferenceTables}
-            acceptedValuesPath={getAcceptedValuesPath(6)}
+            acceptedValuesPath={getAcceptedValuesPath(7)}
             optionTemplate="**name** (**code**)"
             okapi={okapi}
           />
@@ -83,7 +83,7 @@ export const Location = ({
         >
           <Field
             component={TextField}
-            name={getFieldName(7)}
+            name={getFieldName(8)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.location.field.shelvingOrder`} />}
             disabled
           />
@@ -96,7 +96,7 @@ export const Location = ({
             {validation => (
               <Field
                 component={TextField}
-                name={getFieldName(8)}
+                name={getFieldName(9)}
                 label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.holdings.location.field.shelvingTitle`} />}
                 validate={[validation]}
               />
@@ -113,7 +113,7 @@ export const Location = ({
             {validation => (
               <Field
                 component={TextField}
-                name={getFieldName(9)}
+                name={getFieldName(10)}
                 label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.copyNumber`} />}
                 validate={[validation]}
               />
@@ -128,7 +128,7 @@ export const Location = ({
         >
           <AcceptedValuesField
             component={TextField}
-            name={getFieldName(10)}
+            name={getFieldName(11)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.callNumberType`} />}
             optionValue="name"
             optionLabel="name"
@@ -139,7 +139,7 @@ export const Location = ({
             }]}
             isRemoveValueAllowed
             setAcceptedValues={setReferenceTables}
-            acceptedValuesPath={getAcceptedValuesPath(10)}
+            acceptedValuesPath={getAcceptedValuesPath(11)}
             okapi={okapi}
           />
         </Col>
@@ -151,7 +151,7 @@ export const Location = ({
             {validation => (
               <Field
                 component={TextField}
-                name={getFieldName(11)}
+                name={getFieldName(12)}
                 label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.callNumberPrefix`} />}
                 validate={[validation]}
               />
@@ -166,7 +166,7 @@ export const Location = ({
             {validation => (
               <Field
                 component={TextField}
-                name={getFieldName(12)}
+                name={getFieldName(13)}
                 label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.callNumber`} />}
                 validate={[validation]}
               />
@@ -182,7 +182,7 @@ export const Location = ({
             {validation => (
               <Field
                 component={TextField}
-                name={getFieldName(13)}
+                name={getFieldName(14)}
                 label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.callNumberSuffix`} />}
                 validate={[validation]}
               />

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/ReceivingHistory.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/ReceivingHistory.js
@@ -44,9 +44,9 @@ export const ReceivingHistory = ({
           xs={12}
         >
           <RepeatableActionsField
-            wrapperFieldName={getRepeatableFieldName(23)}
-            repeatableFieldAction={getRepeatableFieldAction(23)}
-            repeatableFieldIndex={23}
+            wrapperFieldName={getRepeatableFieldName(24)}
+            repeatableFieldAction={getRepeatableFieldAction(24)}
+            repeatableFieldIndex={24}
             hasRepeatableFields={!!receivingHistory.length}
             onRepeatableActionChange={setReferenceTables}
           >
@@ -54,8 +54,8 @@ export const ReceivingHistory = ({
               <RepeatableField
                 fields={receivingHistory}
                 addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.receivingHistory.addLabel`} />}
-                onAdd={() => onAdd(receivingHistory, 'receivingHistory.entries', 23, initialFields, setReferenceTables, 'order')}
-                onRemove={index => onRemove(index, receivingHistory, 23, setReferenceTables, 'order')}
+                onAdd={() => onAdd(receivingHistory, 'receivingHistory.entries', 24, initialFields, setReferenceTables, 'order')}
+                onRemove={index => onRemove(index, receivingHistory, 24, setReferenceTables, 'order')}
                 canAdd={!isDisabled}
                 renderField={(field, index) => (
                   <Row left="xs">
@@ -65,7 +65,7 @@ export const ReceivingHistory = ({
                     >
                       <BooleanActionField
                         label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.publicDisplay`} />}
-                        name={getBoolSubfieldName(23, 0, index)}
+                        name={getBoolSubfieldName(24, 0, index)}
                       />
                     </Col>
                     <Col xs={4}>
@@ -74,7 +74,7 @@ export const ReceivingHistory = ({
                           <Field
                             component={TextField}
                             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.enumeration`} />}
-                            name={getSubfieldName(23, 1, index)}
+                            name={getSubfieldName(24, 1, index)}
                             validate={[validation]}
                           />
                         )}
@@ -89,7 +89,7 @@ export const ReceivingHistory = ({
                           <Field
                             component={TextField}
                             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.chronology`} />}
-                            name={getSubfieldName(23, 2, index)}
+                            name={getSubfieldName(24, 2, index)}
                             validate={[validation]}
                           />
                         )}

--- a/src/settings/MappingProfiles/detailsSections/edit/MappingHoldingsDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/MappingHoldingsDetails.js
@@ -27,6 +27,7 @@ export const MappingHoldingsDetails = ({
 }) => {
   const formerIds = referenceTables?.formerIds || [];
   const statisticalCodeIds = referenceTables?.statisticalCodeIds || [];
+  const administrativeNotes = referenceTables?.administrativeNotes || [];
   const holdingsStatements = referenceTables?.holdingsStatements || [];
   const holdingsStatementsForSupplements = referenceTables?.holdingsStatementsForSupplements || [];
   const holdingsStatementsForIndexes = referenceTables?.holdingsStatementsForIndexes || [];
@@ -39,6 +40,7 @@ export const MappingHoldingsDetails = ({
       <AdministrativeData
         formerIds={formerIds}
         statisticalCodeIds={statisticalCodeIds}
+        administrativeNotes={administrativeNotes}
         getRepeatableFieldAction={getRepeatableFieldAction}
         initialFields={initialFields}
         setReferenceTables={setReferenceTables}

--- a/src/settings/MappingProfiles/detailsSections/edit/tests/MappingHoldingsDetails.test.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/tests/MappingHoldingsDetails.test.js
@@ -33,6 +33,7 @@ const initialFieldsProp = getInitialFields(FOLIO_RECORD_TYPES.HOLDINGS.type);
 const {
   formerIds,
   statisticalCodeIds,
+  administrativeNotes,
   holdingsStatements,
   holdingsStatementsForSupplements,
   holdingsStatementsForIndexes,
@@ -156,6 +157,34 @@ describe('<MappingHoldingsDetails>', () => {
 
       expect(onRemove).toHaveBeenCalledTimes(1);
       expect(onRemove.mock.calls[0][1]).toEqual(statisticalCodeIds);
+    });
+  });
+
+  describe('Administrative notes field', () => {
+    it('User can add administrative note info', async () => {
+      const {
+        findByRole,
+        getByText,
+      } = renderMappingHoldingsDetails({ referenceTables: { administrativeNotes } });
+
+      const button = await findByRole('button', { name: /add administrative note/i });
+
+      fireEvent.click(button);
+
+      expect(onAdd).toHaveBeenCalledTimes(1);
+      expect(onAdd.mock.calls[0][1]).toBe('administrativeNotes');
+      expect(getByText('Administrative note')).toBeInTheDocument();
+    });
+
+    it('User can delete administrative note info', async () => {
+      const { findByRole } = renderMappingHoldingsDetails({ referenceTables: { administrativeNotes } });
+
+      const deleteButton = await findByRole('button', { name: /delete this item/i });
+
+      fireEvent.click(deleteButton);
+
+      expect(onRemove).toHaveBeenCalledTimes(1);
+      expect(onRemove.mock.calls[0][1]).toEqual(administrativeNotes);
     });
   });
 

--- a/src/settings/MappingProfiles/initialDetails/HOLDINGS.js
+++ b/src/settings/MappingProfiles/initialDetails/HOLDINGS.js
@@ -52,6 +52,21 @@ const HOLDINGS = {
       }],
     }],
   }, {
+    name: 'administrativeNotes',
+    enabled: true,
+    path: 'holdings.administrativeNotes[]',
+    value: '',
+    subfields: [{
+      order: 0,
+      path: 'holdings.administrativeNotes[]',
+      fields: [{
+        name: 'administrativeNote',
+        enabled: true,
+        path: 'holdings.administrativeNotes[]',
+        value: '',
+      }],
+    }],
+  }, {
     name: 'permanentLocationId',
     enabled: true,
     path: 'holdings.permanentLocationId',


### PR DESCRIPTION
## Purpose
To add Data Import support for the Administrative note field that was added to the Inventory Holdings

## Approach
- 'Administrative note' RepeatableActionsField has been added 
- DTO for HOLDINGS has been updated

## Refs
https://issues.folio.org/browse/UIDATIMP-1119

## Screenshots
![after](https://user-images.githubusercontent.com/63101175/161529747-7437c2ff-b84e-4858-9dc5-0087faaf6cc8.png)
