### PR TITLE
UIDATIMP-1053: Display Authority information on Data import log page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add Admin note field to the Instance field mapping profile: View (UIDATIMP-1121)
 * Add Admin note field to the Item field mapping profile: Create/Edit (UIDATIMP-1120)
 * Add Admin note field to the Holdings field mapping profile: View (UIDATIMP-1122)
+* Display Authority information on Data import log page: View (UIDATIMP-1053)
 
 ## [5.1.2](https://github.com/folio-org/ui-data-import/tree/v5.1.2) (2022-03-24)
 

--- a/src/routes/JobSummary/JobSummary.js
+++ b/src/routes/JobSummary/JobSummary.js
@@ -40,6 +40,7 @@ const sortMap = {
   instanceStatus: 'instance_action_status',
   holdingsStatus: 'holdings_action_status',
   itemStatus: 'item_action_status',
+  authorityStatus: 'authority_action_status',
   orderStatus: 'order_action_status',
   invoiceStatus: 'invoice_action_status',
   error: 'error',
@@ -101,6 +102,7 @@ const JobSummaryComponent = ({
     'instanceStatus',
     'holdingsStatus',
     'itemStatus',
+    'authorityStatus',
     'orderStatus',
     'invoiceStatus',
     'error',
@@ -112,6 +114,7 @@ const JobSummaryComponent = ({
     instanceStatus: <FormattedMessage id="ui-data-import.recordTypes.instance" />,
     holdingsStatus: <FormattedMessage id="ui-data-import.recordTypes.holdings" />,
     itemStatus: <FormattedMessage id="ui-data-import.recordTypes.item" />,
+    authorityStatus: <FormattedMessage id="ui-data-import.recordTypes.authority" />,
     orderStatus: <FormattedMessage id="ui-data-import.recordTypes.order" />,
     invoiceStatus: <FormattedMessage id="ui-data-import.recordTypes.invoice" />,
     error: <FormattedMessage id="ui-data-import.error" />,
@@ -202,6 +205,21 @@ const JobSummaryComponent = ({
         || itemActionStatus === RECORD_ACTION_STATUS.UPDATED);
 
       return getHotlinkCellFormatter(isHotlink, entityLabel, path, 'item');
+    },
+    authorityStatus: ({
+      authorityActionStatus,
+      sourceRecordId,
+    }) => {
+      const entityLabel = getRecordActionStatusLabel(authorityActionStatus);
+      const sourceRecord = jobLogRecords.find(item => item.sourceRecordId === sourceRecordId);
+      const authorityId = sourceRecord?.relatedAuthorityInfo.idList[0];
+      const path = `/marc-authorities/authorities/${authorityId}`;
+
+      const isPathCorrect = !!authorityId;
+      const isHotlink = isPathCorrect && (authorityActionStatus === RECORD_ACTION_STATUS.CREATED
+        || authorityActionStatus === RECORD_ACTION_STATUS.UPDATED);
+
+      return getHotlinkCellFormatter(isHotlink, entityLabel, path, 'authority');
     },
     orderStatus: ({ orderActionStatus }) => getRecordActionStatusLabel(orderActionStatus),
     invoiceStatus: ({

--- a/src/routes/JobSummary/JobSummary.test.js
+++ b/src/routes/JobSummary/JobSummary.test.js
@@ -27,6 +27,7 @@ const sourceRecordsIds = [
   faker.random.uuid(),
 ];
 const instanceId = faker.random.uuid();
+const authorityId = faker.random.uuid();
 
 const getJobExecutionsResources = dataType => buildResources({
   resourceName: 'jobExecutions',
@@ -42,12 +43,14 @@ const jobLogEntriesResources = buildResources({
     sourceRecordActionStatus: 'CREATED',
     sourceRecordType: 'MARC_BIBLIOGRAPHIC',
     instanceActionStatus: 'CREATED',
+    authorityActionStatus: 'CREATED',
     jobExecutionId: firstRecordJobExecutionId,
     sourceRecordId: sourceRecordsIds[0],
     sourceRecordOrder: '0',
     sourceRecordTitle: 'Test item 1',
   }, {
     instanceActionStatus: 'UPDATED',
+    authorityActionStatus: 'UPDATED',
     sourceRecordType: 'MARC_BIBLIOGRAPHIC',
     jobExecutionId: faker.random.uuid(),
     sourceRecordId: sourceRecordsIds[1],
@@ -106,6 +109,10 @@ const jobLogResources = buildResources({
       actionStatus: 'CREATED',
       idList: [faker.random.uuid()],
     },
+    relatedAuthorityInfo: {
+      actionStatus: 'CREATED',
+      idList: [authorityId],
+    },
   }, {
     sourceRecordId: sourceRecordsIds[1],
     sourceRecordOrder: '1',
@@ -121,6 +128,10 @@ const jobLogResources = buildResources({
     relatedItemInfo: {
       actionStatus: 'UPDATED',
       idList: [faker.random.uuid()],
+    },
+    relatedAuthorityInfo: {
+      actionStatus: 'UPDATED',
+      idList: [authorityId],
     },
   }, {
     sourceRecordId: sourceRecordsIds[2],
@@ -138,6 +149,10 @@ const jobLogResources = buildResources({
       actionStatus: 'MULTIPLE',
       idList: [faker.random.uuid()],
     },
+    relatedAuthorityInfo: {
+      actionStatus: 'MULTIPLE',
+      idList: [faker.random.uuid()],
+    },
   }, {
     sourceRecordId: sourceRecordsIds[3],
     sourceRecordOrder: '3',
@@ -151,6 +166,10 @@ const jobLogResources = buildResources({
       idList: [faker.random.uuid()],
     },
     relatedItemInfo: {
+      actionStatus: 'DISCARDED',
+      idList: [faker.random.uuid()],
+    },
+    relatedAuthorityInfo: {
       actionStatus: 'DISCARDED',
       idList: [faker.random.uuid()],
     },
@@ -210,6 +229,7 @@ describe('Job summary page', () => {
       expect(getByText('Instance')).toBeDefined();
       expect(holdingsColumn.innerHTML).toEqual('Holdings');
       expect(getByText('Item')).toBeDefined();
+      expect(getByText('Authority')).toBeDefined();
       expect(getByText('Order')).toBeDefined();
       expect(getByText('Invoice')).toBeDefined();
       expect(errorColumn.innerHTML).toEqual('Error');
@@ -249,22 +269,38 @@ describe('Job summary page', () => {
   });
 
   describe('when action status is CREATED', () => {
-    it('the value should be a hotlink', () => {
+    it('the instance value should be a hotlink', () => {
       const { container } = renderJobSummary();
 
       fireEvent.click(container.querySelector('[data-row-index="row-0"] [data-test-entity-name="instance"]'));
 
       expect(window.location.href).toContain(`/inventory/view/${instanceId}`);
     });
+
+    it('the authority value should be a hotlink', () => {
+      const { container } = renderJobSummary();
+
+      fireEvent.click(container.querySelector('[data-row-index="row-0"] [data-test-entity-name="authority"]'));
+
+      expect(window.location.href).toContain(`/marc-authorities/authorities/${authorityId}`);
+    });
   });
 
   describe('when action status is UPDATED', () => {
-    it('the value should be a hotlink', () => {
+    it('the instance value should be a hotlink', () => {
       const { container } = renderJobSummary();
 
       fireEvent.click(container.querySelector('[data-row-index="row-1"] [data-test-entity-name="instance"]'));
 
       expect(window.location.href).toContain(`/inventory/view/${instanceId}`);
+    });
+
+    it('the authority value should be a hotlink', () => {
+      const { container } = renderJobSummary();
+
+      fireEvent.click(container.querySelector('[data-row-index="row-1"] [data-test-entity-name="authority"]'));
+
+      expect(window.location.href).toContain(`/marc-authorities/authorities/${authorityId}`);
     });
   });
 


### PR DESCRIPTION
## Description
Display Authority information on Data import log page

## Issues
[UIDATIMP-1053](https://issues.folio.org/browse/UIDATIMP-1053)

## Screenshots



https://user-images.githubusercontent.com/96055497/163401748-4f611cc9-d267-48d7-8242-49fd6b726e4d.mp4


