### PR TITLE
UIDATIMP-1145-FIX: Rename permissionName for Can view only permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
         "visible": true
       },
       {
-        "permissionName": "settings.data-import.view",
+        "permissionName": "settings.data-import.enabled",
         "displayName": "Settings (Data import): Can view only",
         "subPermissions": [
           "settings.enabled",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
- After UIDATIMP-1145, `Can view only` permission wasn't working as expected
-  `permissionName` property of permission object should be `settings.data-import.enabled` for settings to be visible.
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Rename `permissionName`
<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->