### PR TITLE
UIDATIMP-1145-FOLLOWUP: Move setting.data-import.enabled to new permSet

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
         "visible": false
       },
       {
-        "permissionName": "settings.data-import.manage",
+        "permissionName": "ui-data-import.settings.manage",
         "displayName": "Settings (Data import): Can view, create, edit, and remove",
         "subPermissions": [
           "settings.data-import.enabled",
@@ -284,7 +284,7 @@
         "visible": true
       },
       {
-        "permissionName": "settings.data-import.readOnly",
+        "permissionName": "ui-data-import.settings.readOnly",
         "displayName": "Settings (Data import): Can view only",
         "subPermissions": [
           "settings.data-import.enabled",

--- a/package.json
+++ b/package.json
@@ -214,9 +214,17 @@
       },
       {
         "permissionName": "settings.data-import.enabled",
+        "displayName": "Settings (Data import): Display list of settings pages for Data import",
+        "subPermissions": [
+          "settings.enabled"
+        ],
+        "visible": false
+      },
+      {
+        "permissionName": "settings.data-import.manage",
         "displayName": "Settings (Data import): Can view, create, edit, and remove",
         "subPermissions": [
-          "settings.enabled",
+          "settings.data-import.enabled",
           "data-import.fileExtensions.get",
           "data-import.fileExtensions.post",
           "data-import.fileExtensions.put",
@@ -276,10 +284,10 @@
         "visible": true
       },
       {
-        "permissionName": "settings.data-import.enabled",
+        "permissionName": "settings.data-import.readOnly",
         "displayName": "Settings (Data import): Can view only",
         "subPermissions": [
-          "settings.enabled",
+          "settings.data-import.enabled",
           "data-import.fileExtensions.get",
           "converter-storage.field-protection-settings.get",
           "converter-storage.jobprofilesnapshots.get",


### PR DESCRIPTION
## Purpose
- Per conversation with Zak Burke, an app will have a (mostly empty) `permSet` like `settings.thenameoftheapp.enabled` that includes `settings.enabled` as the only subPermissions value. That allows the app to show up in the left-hand pane of settings. Additionally, for the list-items `foo` and `bar` in the second pane of settings an app will have `ui-thenameoftheapp.settings.foo` and `ui-thenameoftheapp.settings.bar` that include `settings.thenameoftheapp.enabled` plus additional foo-specific or bar-specific permissions.