### PR TITLE
UIDATIMP-1169: Change Import log hotlinks to textLink: Landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Remove additional validation in the "Currency" field (UIDATIMP-1167)
 * Create a new Data import UI permission for deleting import logs (UIDATIMP-1144)
 * When new data import log summary is opened, old UI from previous log summary is displayed (UIDATIMP-1164)
+* Change Import log hotlinks to textLink: Landing page (UIDATIMP-1169)
 
 ### Bugs fixed:
 * Data Import landing page log shows in old format instead of current format (UIDATIMP-1139)

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
-import { Button } from '@folio/stripes/components';
+import { Button, TextLink } from '@folio/stripes/components';
 import { useJobLogsProperties } from '@folio/stripes-data-transfer-components';
 
 import { listTemplate } from '../ListTemplate';
@@ -32,15 +32,11 @@ export const JobLogsContainer = props => {
   const { formatMessage } = useIntl();
 
   const fileNameCellFormatter = record => (
-    <Button
-      buttonStyle="link"
-      marginBottom0
+    <TextLink
       to={`/data-import/job-summary/${record.id}`}
-      buttonClass={sharedCss.cellLink}
-      onClick={e => e.stopPropagation()}
     >
       {record.fileName || formatMessage({ id: 'ui-data-import.noFileName' }) }
-    </Button>
+    </TextLink>
   );
 
   const customProperties = {

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
-import { Button, TextLink } from '@folio/stripes/components';
+import { TextLink } from '@folio/stripes/components';
 import { useJobLogsProperties } from '@folio/stripes-data-transfer-components';
 
 import { listTemplate } from '../ListTemplate';
@@ -14,8 +14,6 @@ import {
   getJobLogsListColumnMapping,
   statusCellFormatter,
 } from '../../utils';
-
-import sharedCss from '../../shared.css';
 
 export const JobLogsContainer = props => {
   const {


### PR DESCRIPTION
## Purpose
-  Change Import log hotlinks to textLink: Landing page

## Approach
- Use `TextLink` instead of `Button`

## Refs
- https://issues.folio.org/browse/UIDATIMP-1169

## Screenshots
- 
![Screenshot (285)](https://user-images.githubusercontent.com/89512426/170047305-35f7fa1c-4a3b-4a78-abf0-fa933de89743.png)
