### PR TITLE
UIDATIMP-1171: Change Import log hotlinks to textLink: Log details screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Create a new Data import UI permission for deleting import logs (UIDATIMP-1144)
 * When new data import log summary is opened, old UI from previous log summary is displayed (UIDATIMP-1164)
 * Change Import log hotlinks to textLink: Landing page (UIDATIMP-1169)
+* Change Import log hotlinks to textLink: Log details screen (UIDATIMP-1169)
 
 ### Bugs fixed:
 * Data Import landing page log shows in old format instead of current format (UIDATIMP-1139)

--- a/src/routes/JobSummary/components/RecordsTable.js
+++ b/src/routes/JobSummary/components/RecordsTable.js
@@ -15,9 +15,9 @@ import {
   mapNsKeys,
 } from '@folio/stripes/smart-components';
 import {
-  Button,
   NoValue,
   MCLPagingTypes,
+  TextLink,
 } from '@folio/stripes/components';
 
 import { FOLIO_RECORD_TYPES } from '../../../components';
@@ -26,8 +26,6 @@ import {
   RECORD_ACTION_STATUS,
   RECORD_ACTION_STATUS_LABEL_IDS,
 } from '../../../utils';
-
-import sharedCss from '../../../shared.css';
 
 const getRecordActionStatusLabel = recordType => {
   if (!recordType) return <NoValue />;
@@ -59,15 +57,12 @@ export const RecordsTable = ({
   const getHotlinkCellFormatter = (isHotlink, entityLabel, path, entity) => {
     if (isHotlink) {
       return (
-        <Button
+        <TextLink
           data-test-entity-name={entity}
-          buttonStyle="link"
           to={path}
-          marginBottom0
-          buttonClass={sharedCss.cellLink}
         >
           {entityLabel}
-        </Button>
+        </TextLink>
       );
     }
 
@@ -150,15 +145,13 @@ export const RecordsTable = ({
         : sourceRecordTitle;
 
       return (
-        <Button
-          buttonStyle="link"
+        <TextLink
           target="_blank"
-          marginBottom0
+          rel="noopener noreferrer"
           to={path}
-          buttonClass={sharedCss.cellLink}
         >
           {title}
-        </Button>
+        </TextLink>
       );
     },
     srsMarcStatus: ({ sourceRecordActionStatus }) => getRecordActionStatusLabel(sourceRecordActionStatus),


### PR DESCRIPTION
## Purpose
- Change Import log hotlinks to textLink: Log details screen

## Approach
- use `<TextLink />` instead of `<Button />`

## Refs
- https://issues.folio.org/browse/UIDATIMP-1171

## Screenshots
<img src="https://user-images.githubusercontent.com/89512426/170266256-5881e436-a35b-41f8-8cc9-f2e231ef425b.png" width="450" />

