### PR TITLE
UIDATIMP-1181: Change associated hotlinks in Match, Action, Field mapping profiles to textLink, in Settings/Data import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Change Import log hotlinks to textLink: View all page (UIDATIMP-1170)
 * Change Import log hotlinks to textLink: Landing page (UIDATIMP-1169)
 * When user have Can view only permission, don't show Actions and +New buttons (UIDATIMP-1174)
+* Change associated hotlinks in Match, Action, Field mapping profiles to textLink, in Settings/Data import (UIDATIMP-1181)
 
 ### Bugs fixed:
 * Data Import landing page log shows in old format instead of current format (UIDATIMP-1139)

--- a/src/components/ProfileAssociator/associatedProfilesColumns.js
+++ b/src/components/ProfileAssociator/associatedProfilesColumns.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import {
   Button,
   Icon,
+  TextLink,
 } from '@folio/stripes/components';
 
 import { stringToWords } from '../../utils';
@@ -60,15 +61,12 @@ export const associatedProfilesColumns = ({
   return {
     ...formatter,
     name: record => (
-      <Button
+      <TextLink
         data-test-profile-link
-        buttonStyle="link"
-        marginBottom0
         to={`/settings/data-import/${entityName}/view/${record.id}`}
-        buttonClass={sharedCss.cellLink}
       >
         {formatter.name(record)}
-      </Button>
+      </TextLink>
     ),
   };
 };


### PR DESCRIPTION
## Purpose
- Change associated hotlinks in Match, Action, Field mapping profiles to textLink, in Settings/Data import

## Approach
- Use `<TextLink/>` instead of `<Button/>`

## Refs
- https://issues.folio.org/browse/UIDATIMP-1181

## Screenshots
<img src="https://user-images.githubusercontent.com/89512426/170486146-f8aeab25-43bd-4620-8332-ff6257f8af39.png" width="375" /> <img src="https://user-images.githubusercontent.com/89512426/170486155-b039fb21-e5ff-434e-b2a8-fec089a1db89.png" width="375" />  <img src="https://user-images.githubusercontent.com/89512426/170486159-a87dc285-b414-4019-90e7-1439858668be.png" 
 width="300" />
