### PR TITLE
UIDATIMP-1180: Change Job profile tree hotlinks to textLink, in Settings/Data import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Change Import log hotlinks to textLink: Landing page (UIDATIMP-1169)
 * When user have Can view only permission, don't show Actions and +New buttons (UIDATIMP-1174)
 * Change Import log hotlinks to textLink: Log details screen (UIDATIMP-1171)
+* Change Job profile tree hotlinks to textLink, in Settings/Data import (UIDATIMP-1180)
 
 ### Bugs fixed:
 * Data Import landing page log shows in old format instead of current format (UIDATIMP-1139)

--- a/src/components/ListTemplate/ColumnTemplates/DefaultColumn.js
+++ b/src/components/ListTemplate/ColumnTemplates/DefaultColumn.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import {
   NoValue,
-  Button,
+  TextLink,
 } from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes/core';
 
@@ -54,20 +54,17 @@ export const DefaultColumn = memo(({
     </AppIcon>
   );
 
-  const hotlink = (
-    <Button
+  const textLink = (
+    <TextLink
       data-test-profile-link={entityName}
-      buttonStyle="link"
-      marginBottom0
       to={`/settings/data-import/${entityName}/view/${recordId}`}
-      buttonClass={sharedCss.cellLink}
     >
       {appIcon}
-    </Button>
+    </TextLink>
   );
 
   return showLabelsAsHotLink
-    ? hotlink
+    ? textLink
     : appIcon;
 });
 


### PR DESCRIPTION
## Purpose
Change Job profile tree hotlinks to textLink, in Settings/Data import

## Refs
https://issues.folio.org/browse/UIDATIMP-1180

## Screenshots
![textlinkSettings](https://user-images.githubusercontent.com/100832608/170548515-fc8eb09d-3764-4947-b95b-771f38752d14.png)

