### PR TITLE
UIDATIMP-942: Prefer @folio/stripes exports to private paths when importing Calendar component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * When user have Can view only permission, don't show Actions and +New buttons (UIDATIMP-1174)
 * Change Import log hotlinks to textLink: Log details screen (UIDATIMP-1171)
 * Change associated hotlinks in Match, Action, Field mapping profiles to textLink, in Settings/Data import (UIDATIMP-1181)
+* Prefer @folio/stripes exports to private paths when importing Calendar component (UIDATIMP-942)
 
 ### Bugs fixed:
 * Data Import landing page log shows in old format instead of current format (UIDATIMP-1139)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Change Import log hotlinks to textLink: Landing page (UIDATIMP-1169)
 * When user have Can view only permission, don't show Actions and +New buttons (UIDATIMP-1174)
 * Change Import log hotlinks to textLink: Log details screen (UIDATIMP-1171)
+* Change associated hotlinks in Match, Action, Field mapping profiles to textLink, in Settings/Data import (UIDATIMP-1181)
 
 ### Bugs fixed:
 * Data Import landing page log shows in old format instead of current format (UIDATIMP-1139)

--- a/src/components/ProfileAssociator/associatedProfilesColumns.js
+++ b/src/components/ProfileAssociator/associatedProfilesColumns.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import {
   Button,
   Icon,
+  TextLink,
 } from '@folio/stripes/components';
 
 import { stringToWords } from '../../utils';
@@ -60,15 +61,12 @@ export const associatedProfilesColumns = ({
   return {
     ...formatter,
     name: record => (
-      <Button
+      <TextLink
         data-test-profile-link
-        buttonStyle="link"
-        marginBottom0
         to={`/settings/data-import/${entityName}/view/${record.id}`}
-        buttonClass={sharedCss.cellLink}
       >
         {formatter.name(record)}
-      </Button>
+      </TextLink>
     ),
   };
 };

--- a/src/components/TextDate/TextDate.css
+++ b/src/components/TextDate/TextDate.css
@@ -1,0 +1,4 @@
+.container {
+  position: relative;
+  width: 100%;
+}

--- a/src/components/TextDate/TextDate.js
+++ b/src/components/TextDate/TextDate.js
@@ -15,14 +15,16 @@ import {
 } from 'lodash';
 
 import {
+  Calendar,
   IconButton,
   Popper,
   RootCloseWrapper,
   TextField,
 } from '@folio/stripes/components';
-import Calendar from '@folio/stripes-components/lib/Datepicker/Calendar';
-import css from '@folio/stripes-components/lib/Datepicker/Calendar.css';
+
 import { AVAILABLE_PLACEMENTS } from '../../utils';
+
+import css from './TextDate.css';
 
 const pickDataProps = props => pick(props, (v, key) => key.indexOf('data-test') !== -1);
 


### PR DESCRIPTION
## Purpose
- prefer @folio/stripes exports to private paths when importing Calendar component

## Refs
- https://issues.folio.org/browse/UIDATIMP-942