### PR TITLE
UIDATIMP-1183: Actions button is missing when importing new data import job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Change associated hotlinks in Match, Action, Field mapping profiles to textLink, in Settings/Data import (UIDATIMP-1181)
 * Prefer @folio/stripes exports to private paths when importing Calendar component (UIDATIMP-942)
 * Accessibility check: Individual job log screen (UIDATIMP-1154)
+* Action button is missing on the data-import/job-summary page when select a job profiles (UIDATIMP-1183)
 
 ### Bugs fixed:
 * Data Import landing page log shows in old format instead of current format (UIDATIMP-1139)

--- a/src/settings/JobProfiles/ViewJobProfile.js
+++ b/src/settings/JobProfiles/ViewJobProfile.js
@@ -58,7 +58,8 @@ import {
   compose,
   createUrlFromArray,
   FILE_STATUSES,
-  showActionMenu, permissions,
+  showActionMenu,
+  permissions,
 } from '../../utils';
 
 import sharedCss from '../../shared.css';
@@ -308,14 +309,14 @@ const ViewJobProfileComponent = props => {
               </KeyValue>
             </Accordion>
             {(tagsEnabled && isSettingsEnabled) && (
-            <div data-test-tags-accordion>
-              <TagsAccordion
-                link={tagsEntityLink}
-                getEntity={getEntity}
-                getEntityTags={getEntityTags}
-                entityTagsPath="profile.tags"
-              />
-            </div>
+              <div data-test-tags-accordion>
+                <TagsAccordion
+                  link={tagsEntityLink}
+                  getEntity={getEntity}
+                  getEntityTags={getEntityTags}
+                  entityTagsPath="profile.tags"
+                />
+              </div>
             )}
             {isSettingsEnabled && (
               <div data-test-job-profile-overview-details>

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -1,3 +1,5 @@
 export const permissions = {
   SETTINGS_MANAGE: 'ui-data-import.settings.manage',
+  SETTINGS_VIEW_ONLY: 'ui-data-import.settings.readOnly',
+  DATA_IMPORT_MANAGE: 'ui-data-import.manage',
 };

--- a/src/utils/showActionMenu.js
+++ b/src/utils/showActionMenu.js
@@ -3,10 +3,10 @@ import { permissions } from './permissions';
 /**
  * Displays Action menu if user has appropriate permission(s).
  *
- * @param {{renderer: Function | null, stripes: Object}} options
-*/
-export function showActionMenu({ renderer, stripes }) {
-  const hasPerm = stripes.hasPerm(permissions.SETTINGS_MANAGE);
+ * @param {{renderer: Function | null, stripes: Object, perm?: string}} options
+ */
+export function showActionMenu({ renderer, stripes, perm = permissions.SETTINGS_MANAGE }) {
+  const hasPerm = stripes.hasPerm(perm);
 
   return hasPerm ? renderer : null;
 }

--- a/src/utils/tests/showActionMenu.test.js
+++ b/src/utils/tests/showActionMenu.test.js
@@ -3,20 +3,21 @@ import { permissions } from '../permissions';
 
 describe('showActionMenu function', () => {
   const renderer = jest.fn();
+  const perm = permissions.SETTINGS_MANAGE;
 
   it('should render action menu when user has correct permission', () => {
     const stripes = {
-      hasPerm: perm => perm === permissions.SETTINGS_MANAGE
+      hasPerm: permission => permission === permissions.SETTINGS_MANAGE
     };
 
-    expect(showActionMenu({ renderer, stripes })).toEqual(renderer);
+    expect(showActionMenu({ renderer, stripes, perm })).toEqual(renderer);
   });
 
   it('should return null when user does not have correct permission', () => {
     const stripes = {
-      hasPerm: perm => perm === 'test.permission'
+      hasPerm: permission => permission === 'test.permission'
     };
 
-    expect(showActionMenu({ renderer, stripes })).toBeNull();
+    expect(showActionMenu({ renderer, stripes, perm })).toBeNull();
   });
 });


### PR DESCRIPTION
## Purpose
- Action button is missing on the data-import/job-summary page when select a job profiles

## Approach
- Data import upload and settings job profiles pages use the same `<Jobprofiles />` component. Add conditional logic to check for appropriate `permission` to show Actions button depending on the which page user is on.
- Also, hide `Job profiles tree Overview` and `Tags` accordions if user doesn't have `settings enabled` permissions

## Refs
- https://issues.folio.org/browse/UIDATIMP-1183