### PR TITLE
UIDATIMP-1178: View all logs: User filter contains only users displayed on a specific page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Change associated hotlinks in Match, Action, Field mapping profiles to textLink, in Settings/Data import (UIDATIMP-1181)
 * Prefer @folio/stripes exports to private paths when importing Calendar component (UIDATIMP-942)
 * Accessibility check: Individual job log screen (UIDATIMP-1154)
+* View all logs: User filter contains only users displayed on a specific page (UIDATIMP-1178)
 
 ### Bugs fixed:
 * Data Import landing page log shows in old format instead of current format (UIDATIMP-1139)

--- a/src/routes/ViewAllLogs/ViewAllLogs.js
+++ b/src/routes/ViewAllLogs/ViewAllLogs.js
@@ -55,7 +55,7 @@ const {
 } = FILE_STATUSES;
 
 const INITIAL_RESULT_COUNT = 100;
-const RESULT_COUNT_INCREMENT = 100;
+const RESULT_COUNT_INCREMENT = 10;
 
 const entityKey = 'jobLogs';
 
@@ -101,6 +101,10 @@ export const ViewAllLogsManifest = Object.freeze({
     },
     perRequest: RESULT_COUNT_INCREMENT,
     throwErrors: false,
+  },
+  users: {
+    type: 'okapi',
+    path: 'metadata-provider/jobExecutions/users',
   },
 });
 
@@ -181,13 +185,16 @@ class ViewAllLogs extends Component {
       .map(item => item.jobProfileInfo)
       .sort((jobProfileA, jobProfileB) => jobProfileA.name.localeCompare(jobProfileB.name));
 
-    const users = get(resources, ['records', 'records'], [])
-      .map(item => ({
-        userId: item.userId,
-        firstName: item.runBy.firstName,
-        lastName: item.runBy.lastName,
-      }))
-      .sort((userA, userB) => {
+    const users = get(resources, ['users', 'records', 0, 'jobExecutionUsersInfo'], [])
+      .map(item => {
+        return {
+          userId: item.userId,
+          firstName:
+          item?.jobUserFirstName,
+          lastName:
+          item?.jobUserLastName,
+        };
+      }).sort((userA, userB) => {
         const nameA = userA.firstName || userA.lastName;
         const nameB = userB.firstName || userB.lastName;
 

--- a/src/routes/ViewAllLogs/ViewAllLogs.js
+++ b/src/routes/ViewAllLogs/ViewAllLogs.js
@@ -55,7 +55,7 @@ const {
 } = FILE_STATUSES;
 
 const INITIAL_RESULT_COUNT = 100;
-const RESULT_COUNT_INCREMENT = 10;
+const RESULT_COUNT_INCREMENT = 100;
 
 const entityKey = 'jobLogs';
 
@@ -104,7 +104,9 @@ export const ViewAllLogsManifest = Object.freeze({
   },
   users: {
     type: 'okapi',
+    records: 'jobExecutionUsersInfo',
     path: 'metadata-provider/jobExecutions/users',
+    throwErrors: false,
   },
 });
 
@@ -179,20 +181,18 @@ class ViewAllLogs extends Component {
   }
 
   renderFilters = onChange => {
-    const { resources } = this.props;
+    const { resources: { users: { records: jobExecutionUsers = [] }, records: { records: jobExecutionProfiles = [] }, query } } = this.props;
 
-    const jobProfiles = get(resources, ['records', 'records'], [])
+    const jobProfiles = jobExecutionProfiles
       .map(item => item.jobProfileInfo)
       .sort((jobProfileA, jobProfileB) => jobProfileA.name.localeCompare(jobProfileB.name));
 
-    const users = get(resources, ['users', 'records', 0, 'jobExecutionUsersInfo'], [])
+    const users = jobExecutionUsers
       .map(item => {
         return {
           userId: item.userId,
-          firstName:
-          item?.jobUserFirstName,
-          lastName:
-          item?.jobUserLastName,
+          firstName: item.jobUserFirstName,
+          lastName: item.jobUserLastName,
         };
       }).sort((userA, userB) => {
         const nameA = userA.firstName || userA.lastName;
@@ -205,7 +205,7 @@ class ViewAllLogs extends Component {
         return nameA.localeCompare(nameB);
       });
 
-    return resources.query
+    return query
       ? (
         <ViewAllLogsFilters
           activeFilters={this.getActiveFilters()}

--- a/src/routes/ViewAllLogs/ViewAllLogs.js
+++ b/src/routes/ViewAllLogs/ViewAllLogs.js
@@ -181,13 +181,13 @@ class ViewAllLogs extends Component {
   }
 
   renderFilters = onChange => {
-    const { resources: { users: { records: jobExecutionUsers = [] }, records: { records: jobExecutionProfiles = [] }, query } } = this.props;
+    const { resources } = this.props;
 
-    const jobProfiles = jobExecutionProfiles
+    const jobProfiles = get(resources, ['records', 'records'], [])
       .map(item => item.jobProfileInfo)
       .sort((jobProfileA, jobProfileB) => jobProfileA.name.localeCompare(jobProfileB.name));
 
-    const users = jobExecutionUsers
+    const users = get(resources, ['users', 'records'], [])
       .map(item => {
         return {
           userId: item.userId,
@@ -205,7 +205,7 @@ class ViewAllLogs extends Component {
         return nameA.localeCompare(nameB);
       });
 
-    return query
+    return resources.query
       ? (
         <ViewAllLogsFilters
           activeFilters={this.getActiveFilters()}


### PR DESCRIPTION

## Purpose
View all logs: User filter contains only users displayed on a specific page

## Approach
Use new API
 
## Refs
[UIDATIMP-1178](https://issues.folio.org/browse/UIDATIMP-1178)

## Screenshots

https://user-images.githubusercontent.com/100832608/171158272-6d25a00c-0b44-41ab-9c63-13408a21b346.mp4

