### PR TITLE
UIDATIMP-1187: Create a new Data import UI permission for only viewing app and logs and fix delete logs permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * View all logs: User filter contains only users displayed on a specific page (UIDATIMP-1178)
 * Connect summary table of import job's log to BE (UIDATIMP-1163)
 * View all logs: Job profile filter contains only profiles displayed on a specific page (UIDATIMP-1177)
+* Create a new Data import UI permission for only viewing app and logs (UIDATIMP-1187)
 
 ### Bugs fixed:
 * Data Import landing page log shows in old format instead of current format (UIDATIMP-1139)

--- a/package.json
+++ b/package.json
@@ -222,10 +222,23 @@
         "visible": true
       },
       {
+        "permissionName": "ui-data-import.view",
+        "displayName": "Data import: Can view only",
+        "subPermissions": [
+          "module.data-import.enabled",
+          "data-import.uploaddefinitions.get",
+          "metadata-provider.logs.get",
+          "metadata-provider.jobexecutions.get",
+          "source-storage.records.get",
+          "change-manager.jobexecutions.get"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-data-import.logs.delete",
         "displayName": "Data import: Can delete import logs",
         "subPermissions": [
-          "ui-data-import.manage",
+          "ui-data-import.view",
           "change-manager.jobexecutions.delete"
         ],
         "visible": true

--- a/src/components/ImportJobs/ImportJobs.js
+++ b/src/components/ImportJobs/ImportJobs.js
@@ -269,7 +269,7 @@ export class ImportJobs extends Component {
   };
 
   renderImportJobs() {
-    const { match: { path } } = this.props;
+    const { match: { path }, stripes } = this.props;
     const { filesExtensionsModalType } = this.state;
     const { uploadDefinition } = this.context;
 
@@ -325,7 +325,7 @@ export class ImportJobs extends Component {
         onDragEnter={this.onDragEnter}
         onDragLeave={this.onDragLeave}
         onDrop={this.onDrop}
-        disabled={!this.props.stripes.hasPerm(permissions.DATA_IMPORT_MANAGE)}
+        disabled={!stripes.hasPerm(permissions.DATA_IMPORT_MANAGE)}
       >
         {openDialogWindow => (
           <ConfirmationModal

--- a/src/components/ImportJobs/ImportJobs.js
+++ b/src/components/ImportJobs/ImportJobs.js
@@ -37,6 +37,7 @@ import {
   getErrorModalMeta,
   ERROR_MODAL_META_TYPES,
 } from './components/getErrorModalMeta';
+import { permissions } from '../../utils';
 
 import sharedCss from '../../shared.css';
 
@@ -324,6 +325,7 @@ export class ImportJobs extends Component {
         onDragEnter={this.onDragEnter}
         onDragLeave={this.onDragLeave}
         onDrop={this.onDrop}
+        disabled={!this.props.stripes.hasPerm(permissions.DATA_IMPORT_MANAGE)}
       >
         {openDialogWindow => (
           <ConfirmationModal

--- a/src/components/ImportJobs/ImportJobs.js
+++ b/src/components/ImportJobs/ImportJobs.js
@@ -269,7 +269,10 @@ export class ImportJobs extends Component {
   };
 
   renderImportJobs() {
-    const { match: { path }, stripes } = this.props;
+    const {
+      match: { path },
+      stripes,
+    } = this.props;
     const { filesExtensionsModalType } = this.state;
     const { uploadDefinition } = this.context;
 

--- a/src/components/Jobs/components/Job/Job.js
+++ b/src/components/Jobs/components/Job/Job.js
@@ -12,7 +12,8 @@ import classNames from 'classnames';
 
 import {
   withStripes,
-  stripesShape, IfPermission,
+  stripesShape,
+  IfPermission,
 } from '@folio/stripes/core';
 
 import {
@@ -27,7 +28,10 @@ import {
   createOkapiHeaders,
   createUrl,
 } from '@folio/stripes-data-transfer-components';
-import { permissions, DEFAULT_TIMEOUT_BEFORE_JOB_DELETION } from '../../../../utils';
+import {
+  permissions,
+  DEFAULT_TIMEOUT_BEFORE_JOB_DELETION,
+} from '../../../../utils';
 
 import { jobMetaTypes } from './jobMetaTypes';
 import { jobExecutionPropTypes } from './jobExecutionPropTypes';

--- a/src/components/Jobs/components/Job/Job.js
+++ b/src/components/Jobs/components/Job/Job.js
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 
 import {
   withStripes,
-  stripesShape,
+  stripesShape, IfPermission,
 } from '@folio/stripes/core';
 
 import {
@@ -27,11 +27,10 @@ import {
   createOkapiHeaders,
   createUrl,
 } from '@folio/stripes-data-transfer-components';
+import { permissions, DEFAULT_TIMEOUT_BEFORE_JOB_DELETION } from '../../../../utils';
 
 import { jobMetaTypes } from './jobMetaTypes';
 import { jobExecutionPropTypes } from './jobExecutionPropTypes';
-
-import { DEFAULT_TIMEOUT_BEFORE_JOB_DELETION } from '../../../../utils';
 
 import * as API from '../../../../utils/upload';
 
@@ -174,18 +173,20 @@ export class Job extends Component {
             )}
           </span>
         </div>
-        <FormattedMessage id="ui-data-import.delete">
-          {label => (
-            <IconButton
-              data-test-delete-button
-              icon="trash"
-              size="small"
-              ariaLabel={label}
-              className={classNames(css.icon, css.deleteIcon)}
-              onClick={this.handleDeleteJob}
-            />
-          )}
-        </FormattedMessage>
+        <IfPermission perm={permissions.DATA_IMPORT_MANAGE}>
+          <FormattedMessage id="ui-data-import.delete">
+            {label => (
+              <IconButton
+                data-test-delete-button
+                icon="trash"
+                size="small"
+                ariaLabel={label}
+                className={classNames(css.icon, css.deleteIcon)}
+                onClick={this.handleDeleteJob}
+              />
+            )}
+          </FormattedMessage>
+        </IfPermission>
         <button
           data-test-undo-button
           type="button"


### PR DESCRIPTION
## Purpose
     Create a new Data import UI permission for only viewing app and logs and also fix delete logs permission.
## Approach
Create a new UI permission on package.json for view only and fix the delete logs permission.

## Refs
[UIDATIMP-1187](https://issues.folio.org/browse/UIDATIMP-1187)
[UIDATIMP-1144](https://issues.folio.org/browse/UIDATIMP-1144)

## Screenshots
![fixDeletelogs](https://user-images.githubusercontent.com/100832608/171869258-f9f3743c-01ed-4539-a21e-737f8b40496f.png)

