### PR TITLE
UIDATIMP-1186: The "select all items" button does not select all logs after deleting multiple logs from the landing logs page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,13 +44,13 @@
 * Create a new Data import UI permission for only viewing app and logs (UIDATIMP-1187)
 * Update the "Data Import: All permissions" permission (UIDATIMP-1143)
 * Check for accessibility issues on updated match screens (UIDATIMP-1052)
-* The "select all items" button does not select all logs after deleting multiple logs from the landing logs page (UIDATIMP-1186)
 
 ### Bugs fixed:
 * Data Import landing page log shows in old format instead of current format (UIDATIMP-1139)
 * Some issues with log searching in Juniper Bugfest/Smoke testing (UIDATIMP-1125)
 * QuotaExceededError: Failed to execute 'setItem' on 'Storage': Setting the value of 'profileTreeData' exceeded the quota (UIDATIMP-1166)
 * Action button is missing on the data-import/job-summary page when select a job profiles (UIDATIMP-1183)
+* The "select all items" button does not select all logs after deleting multiple logs from the landing logs page (UIDATIMP-1186)
 
 ## [5.1.3](https://github.com/folio-org/ui-data-import/tree/v5.1.3) (2022-05-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Connect summary table of import job's log to BE (UIDATIMP-1163)
 * View all logs: Job profile filter contains only profiles displayed on a specific page (UIDATIMP-1177)
 * Update the "Data Import: All permissions" permission (UIDATIMP-1143)
+* The "select all items" button does not select all logs after deleting multiple logs from the landing logs page (UIDATIMP-1186)
 
 ### Bugs fixed:
 * Data Import landing page log shows in old format instead of current format (UIDATIMP-1139)

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -23,7 +23,7 @@ import {
 const JobLogsContainer = props => {
   const {
     children,
-    checkboxDisabled = false,
+    checkboxesDisabled = false,
     checkboxList: {
       isAllSelected,
       handleSelectAllCheckbox,
@@ -55,13 +55,13 @@ const JobLogsContainer = props => {
     columnMapping: getJobLogsListColumnMapping({
       isAllSelected,
       handleSelectAllCheckbox,
-      checkboxDisabled,
+      checkboxDisabled: checkboxesDisabled,
     }),
     resultsFormatter: {
       ...listTemplate({
         selectRecord,
         selectedRecords,
-        checkboxDisabled,
+        checkboxDisabled: checkboxesDisabled,
       }),
       fileName: fileNameCellFormatter,
       status: statusCellFormatter(formatMessage),
@@ -79,10 +79,10 @@ const JobLogsContainer = props => {
 };
 
 JobLogsContainer.propTypes = {
+  children: PropTypes.func.isRequired,
   checkboxList: checkboxListShape.isRequired,
   stripes: stripesShape.isRequired,
-  checkboxDisabled: PropTypes.bool,
-  children: PropTypes.func.isRequired,
+  checkboxesDisabled: PropTypes.bool,
 };
 
 export default withStripes(JobLogsContainer);

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -23,6 +23,7 @@ import {
 const JobLogsContainer = props => {
   const {
     children,
+    checkboxDisabled = false,
     checkboxList: {
       isAllSelected,
       handleSelectAllCheckbox,
@@ -30,7 +31,6 @@ const JobLogsContainer = props => {
       selectedRecords,
     },
     stripes,
-    checkboxDisabled = false,
     ...rest
   } = props;
 

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -30,6 +30,7 @@ const JobLogsContainer = props => {
       selectedRecords,
     },
     stripes,
+    checkboxDisabled = false,
     ...rest
   } = props;
 
@@ -51,11 +52,16 @@ const JobLogsContainer = props => {
 
   const listProps = {
     ...useJobLogsProperties(customProperties),
-    columnMapping: getJobLogsListColumnMapping({ isAllSelected, handleSelectAllCheckbox }),
+    columnMapping: getJobLogsListColumnMapping({
+      isAllSelected,
+      handleSelectAllCheckbox,
+      checkboxDisabled,
+    }),
     resultsFormatter: {
       ...listTemplate({
         selectRecord,
         selectedRecords,
+        checkboxDisabled,
       }),
       fileName: fileNameCellFormatter,
       status: statusCellFormatter(formatMessage),
@@ -73,9 +79,10 @@ const JobLogsContainer = props => {
 };
 
 JobLogsContainer.propTypes = {
-  children: PropTypes.func.isRequired,
   checkboxList: checkboxListShape.isRequired,
   stripes: stripesShape.isRequired,
+  checkboxDisabled: PropTypes.bool,
+  children: PropTypes.func.isRequired,
 };
 
 export default withStripes(JobLogsContainer);

--- a/src/components/ListTemplate/ColumnTemplates/CheckboxColumn.js
+++ b/src/components/ListTemplate/ColumnTemplates/CheckboxColumn.js
@@ -11,6 +11,7 @@ export const CheckboxColumn = memo(({
   value,
   checked = false,
   onChange = noop,
+  disabled = false,
 }) => (
   <div // eslint-disable-line jsx-a11y/click-events-have-key-events
     tabIndex="0"
@@ -26,6 +27,7 @@ export const CheckboxColumn = memo(({
           checked={checked}
           onChange={() => onChange(value)}
           aria-label={ariaLabel}
+          disabled={disabled}
         />
       )}
     </FormattedMessage>
@@ -36,4 +38,5 @@ CheckboxColumn.propTypes = {
   value: PropTypes.string.isRequired,
   checked: PropTypes.bool,
   onChange: PropTypes.func,
+  disabled: PropTypes.bool,
 };

--- a/src/components/ListTemplate/ColumnTemplates/CheckboxColumn.js
+++ b/src/components/ListTemplate/ColumnTemplates/CheckboxColumn.js
@@ -10,8 +10,8 @@ import sharedCss from '../../../shared.css';
 export const CheckboxColumn = memo(({
   value,
   checked = false,
-  onChange = noop,
   disabled = false,
+  onChange = noop,
 }) => (
   <div // eslint-disable-line jsx-a11y/click-events-have-key-events
     tabIndex="0"
@@ -37,6 +37,6 @@ export const CheckboxColumn = memo(({
 CheckboxColumn.propTypes = {
   value: PropTypes.string.isRequired,
   checked: PropTypes.bool,
-  onChange: PropTypes.func,
   disabled: PropTypes.bool,
+  onChange: PropTypes.func,
 };

--- a/src/components/ListTemplate/HeaderTemplates/CheckboxHeader.js
+++ b/src/components/ListTemplate/HeaderTemplates/CheckboxHeader.js
@@ -9,8 +9,8 @@ import sharedCss from '../../../shared.css';
 
 export const CheckboxHeader = memo(({
   checked = false,
-  onChange = noop,
   disabled = false,
+  onChange = noop,
 }) => (
   <div // eslint-disable-line jsx-a11y/click-events-have-key-events
     role="button"
@@ -35,6 +35,6 @@ export const CheckboxHeader = memo(({
 
 CheckboxHeader.propTypes = {
   checked: PropTypes.bool,
-  onChange: PropTypes.func,
   disabled: PropTypes.bool,
+  onChange: PropTypes.func,
 };

--- a/src/components/ListTemplate/HeaderTemplates/CheckboxHeader.js
+++ b/src/components/ListTemplate/HeaderTemplates/CheckboxHeader.js
@@ -10,6 +10,7 @@ import sharedCss from '../../../shared.css';
 export const CheckboxHeader = memo(({
   checked = false,
   onChange = noop,
+  disabled = false,
 }) => (
   <div // eslint-disable-line jsx-a11y/click-events-have-key-events
     role="button"
@@ -25,6 +26,7 @@ export const CheckboxHeader = memo(({
           checked={checked}
           onChange={onChange}
           aria-label={ariaLabel}
+          disabled={disabled}
         />
       )}
     </FormattedMessage>
@@ -34,4 +36,5 @@ export const CheckboxHeader = memo(({
 CheckboxHeader.propTypes = {
   checked: PropTypes.bool,
   onChange: PropTypes.func,
+  disabled: PropTypes.bool,
 };

--- a/src/components/ListTemplate/listTemplate.js
+++ b/src/components/ListTemplate/listTemplate.js
@@ -33,12 +33,14 @@ export const listTemplate = ({
   selectRecord,
   selectedRecords,
   showLabelsAsHotLink,
+  checkboxDisabled = false,
 }) => ({
   selected: record => (
     <CheckboxColumn
       value={record.id}
       checked={selectedRecords.has(record.id)}
       onChange={selectRecord}
+      disabled={checkboxDisabled}
     />
   ),
   name: record => (

--- a/src/components/ListTemplate/listTemplate.js
+++ b/src/components/ListTemplate/listTemplate.js
@@ -23,6 +23,7 @@ import { formatUserName } from '../../utils';
  *   selectRecord?: (id: string) => void,
  *   selectedRecords?: Set<string>,
  *   showLabelsAsHotLink?: boolean,
+ *   checkboxDisabled?: boolean,
  * }}
  * Note: check which params are required based on used columns
  */

--- a/src/components/RecentJobLogs/RecentJobLogs.js
+++ b/src/components/RecentJobLogs/RecentJobLogs.js
@@ -27,9 +27,13 @@ export const RecentJobLogs = ({
   logs,
   haveLogsLoaded,
   checkboxList,
+  checkboxDisabled = false,
 }) => {
   return (
-    <JobLogsContainer checkboxList={checkboxList}>
+    <JobLogsContainer
+      checkboxList={checkboxList}
+      checkboxDisabled={checkboxDisabled}
+    >
       {({ listProps }) => (
         <JobLogs
           sortColumns={sortColumns}
@@ -47,4 +51,5 @@ RecentJobLogs.propTypes = {
   checkboxList: checkboxListShape.isRequired,
   logs: PropTypes.arrayOf(PropTypes.object),
   haveLogsLoaded: PropTypes.bool,
+  checkboxDisabled: PropTypes.bool,
 };

--- a/src/components/RecentJobLogs/RecentJobLogs.js
+++ b/src/components/RecentJobLogs/RecentJobLogs.js
@@ -27,12 +27,12 @@ export const RecentJobLogs = ({
   logs,
   haveLogsLoaded,
   checkboxList,
-  checkboxDisabled = false,
+  checkboxesDisabled = false,
 }) => {
   return (
     <JobLogsContainer
       checkboxList={checkboxList}
-      checkboxDisabled={checkboxDisabled}
+      checkboxesDisabled={checkboxesDisabled}
     >
       {({ listProps }) => (
         <JobLogs
@@ -51,5 +51,5 @@ RecentJobLogs.propTypes = {
   checkboxList: checkboxListShape.isRequired,
   logs: PropTypes.arrayOf(PropTypes.object),
   haveLogsLoaded: PropTypes.bool,
-  checkboxDisabled: PropTypes.bool,
+  checkboxesDisabled: PropTypes.bool,
 };

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -4,6 +4,7 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { isEqual } from 'lodash';
 
 import {
   Button,
@@ -30,25 +31,6 @@ import {
   withCheckboxList,
   deleteJobExecutions,
 } from '../utils';
-
-/**
- * Compares previous and current job logs by their ids.
- * Returns false if the logs are the same, otherwise true
- *
- * @param {Array<Object>} prevLogs - previous job logs
- * @param {Array<Object>} currentLogs - current job logs
- * @returns {boolean}
- */
-export function isLogsChanged(prevLogs = [], currentLogs = []) {
-  if (prevLogs.length !== currentLogs.length) return true;
-
-  if (prevLogs.length === 0 && currentLogs.length === 0) return false;
-
-  const prevLogsIds = prevLogs.map(log => log.id);
-  const currentLogsIds = currentLogs.map(log => log.id);
-
-  return !prevLogsIds.every(id => currentLogsIds.includes(id));
-}
 
 @withStripes
 @withCheckboxList
@@ -90,7 +72,7 @@ export class Home extends Component {
   }
 
   componentDidUpdate(_prevProps, prevState) {
-    if (this.context.logs && isLogsChanged(prevState.logs, this.context.logs)) {
+    if (this.context.logs && !isEqual(prevState.logs, this.context.logs)) {
       this.setLogsList();
 
       // enable checkboxes after deletion completed if user has deleted logs

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -89,7 +89,7 @@ export class Home extends Component {
     };
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(_prevProps, prevState) {
     if (this.context.logs && isLogsChanged(prevState.logs, this.context.logs)) {
       this.setLogsList();
 

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -64,7 +64,7 @@ export class Home extends Component {
 
     this.calloutRef = createRef();
     this.state = {
-      isCheckboxesDisabled: false,
+      isLogsDeletionInProgress: false,
       logs: [],
       selectedLogsNumber: 0,
       showDeleteConfirmation: false,
@@ -76,8 +76,8 @@ export class Home extends Component {
       this.setLogsList();
 
       // enable checkboxes after deletion completed if user has deleted logs
-      if (this.state.isCheckboxesDisabled) {
-        this.setState({ isCheckboxesDisabled: false });
+      if (this.state.isLogsDeletionInProgress) {
+        this.setState({ isLogsDeletionInProgress: false });
       }
     }
   }
@@ -175,7 +175,7 @@ export class Home extends Component {
     };
 
     // disable all checkboxes while deletion in progress
-    this.setState({ isCheckboxesDisabled: true });
+    this.setState({ isLogsDeletionInProgress: true });
 
     deleteJobExecutions(selectedRecords, okapi)
       .then(onSuccess)
@@ -192,7 +192,7 @@ export class Home extends Component {
       hasLoaded,
     } = this.context;
     const { checkboxList } = this.props;
-    const { isCheckboxesDisabled } = this.state;
+    const { isLogsDeletionInProgress } = this.state;
 
     return (
       <PersistedPaneset
@@ -227,7 +227,7 @@ export class Home extends Component {
             logs={logs}
             haveLogsLoaded={hasLoaded}
             checkboxList={checkboxList}
-            checkboxDisabled={isCheckboxesDisabled}
+            checkboxesDisabled={isLogsDeletionInProgress}
           />
         </Pane>
         <ConfirmationModal

--- a/src/routes/tests/Home.test.js
+++ b/src/routes/tests/Home.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  fireEvent, screen,
+  fireEvent,
   waitFor,
 } from '@testing-library/react';
 import { BrowserRouter as Router } from 'react-router-dom';

--- a/src/routes/tests/Home.test.js
+++ b/src/routes/tests/Home.test.js
@@ -11,10 +11,7 @@ import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jes
 import { translationsProperties } from '../../../test/jest/helpers';
 
 import { DataFetcherContext } from '../../components';
-import {
-  Home,
-  isLogsChanged,
-} from '../Home';
+import { Home } from '../Home';
 import { jobsLogs } from '../../../test/bigtest/mocks';
 import * as utils from '../../utils/deleteJobExecutions';
 
@@ -198,37 +195,6 @@ describe('Home component', () => {
 
         expect(queryByText('Confirmation modal')).toBeNull();
       });
-    });
-  });
-
-  describe('isLogsChanged function', () => {
-    it('should return false if both previous and current logs are empty', () => {
-      const prevLogs = [];
-      const currentLogs = [];
-
-      expect(isLogsChanged(prevLogs, currentLogs)).toBeFalsy();
-    });
-
-    it('should return true if the lengths of two logs are different ', () => {
-      const prevLogs = [];
-      const currentLogs = [];
-
-      expect(isLogsChanged(prevLogs, [{ id: 'testId' }])).toBeTruthy();
-      expect(isLogsChanged([{ id: 'testId' }], currentLogs)).toBeTruthy();
-    });
-
-    it('should return false if two logs contain the same elements', () => {
-      const prevLogs = [{ id: 'testId' }];
-      const currentLogs = [{ id: 'testId' }];
-
-      expect(isLogsChanged(prevLogs, currentLogs)).toBeFalsy();
-    });
-
-    it('should return true if two logs contain different elements', () => {
-      const prevLogs = [{ id: 'testId1' }];
-      const currentLogs = [{ id: 'testId2' }];
-
-      expect(isLogsChanged(prevLogs, currentLogs)).toBeTruthy();
     });
   });
 });

--- a/src/routes/tests/Home.test.js
+++ b/src/routes/tests/Home.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  fireEvent,
+  fireEvent, screen,
   waitFor,
 } from '@testing-library/react';
 import { BrowserRouter as Router } from 'react-router-dom';
@@ -123,6 +123,27 @@ describe('Home component', () => {
         fireEvent.click(getByText('Confirm'));
 
         await waitFor(() => expect(queryByText('Confirmation modal')).not.toBeInTheDocument());
+      });
+
+      it('All checkboxes should be disabled', async () => {
+        deleteJobExecutionsSpy.mockResolvedValue({ jobExecutionDetails: [{}] });
+
+        const {
+          getAllByLabelText,
+          getAllByRole,
+          getByText,
+        } = renderHome();
+
+        fireEvent.click(getAllByLabelText('select item')[0]);
+        fireEvent.click(getByText('Actions'));
+        fireEvent.click(getByText('Delete selected logs'));
+        fireEvent.click(getByText('Confirm'));
+
+        const checkboxes = getAllByRole('checkbox');
+
+        checkboxes.forEach(checkbox => {
+          expect(checkbox).toBeDisabled();
+        });
       });
 
       it('and successful callout should be displayed', async () => {

--- a/src/routes/tests/Home.test.js
+++ b/src/routes/tests/Home.test.js
@@ -11,7 +11,10 @@ import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jes
 import { translationsProperties } from '../../../test/jest/helpers';
 
 import { DataFetcherContext } from '../../components';
-import { Home } from '../Home';
+import {
+  Home,
+  isLogsChanged,
+} from '../Home';
 import { jobsLogs } from '../../../test/bigtest/mocks';
 import * as utils from '../../utils/deleteJobExecutions';
 
@@ -174,6 +177,37 @@ describe('Home component', () => {
 
         expect(queryByText('Confirmation modal')).toBeNull();
       });
+    });
+  });
+
+  describe('isLogsChanged function', () => {
+    it('should return false if both previous and current logs are empty', () => {
+      const prevLogs = [];
+      const currentLogs = [];
+
+      expect(isLogsChanged(prevLogs, currentLogs)).toBeFalsy();
+    });
+
+    it('should return true if the lengths of two logs are different ', () => {
+      const prevLogs = [];
+      const currentLogs = [];
+
+      expect(isLogsChanged(prevLogs, [{ id: 'testId' }])).toBeTruthy();
+      expect(isLogsChanged([{ id: 'testId' }], currentLogs)).toBeTruthy();
+    });
+
+    it('should return false if two logs contain the same elements', () => {
+      const prevLogs = [{ id: 'testId' }];
+      const currentLogs = [{ id: 'testId' }];
+
+      expect(isLogsChanged(prevLogs, currentLogs)).toBeFalsy();
+    });
+
+    it('should return true if two logs contain different elements', () => {
+      const prevLogs = [{ id: 'testId1' }];
+      const currentLogs = [{ id: 'testId2' }];
+
+      expect(isLogsChanged(prevLogs, currentLogs)).toBeTruthy();
     });
   });
 });

--- a/src/utils/jobLogsListProperties.js
+++ b/src/utils/jobLogsListProperties.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { CheckboxHeader } from '../components';
+import { CheckboxHeader } from '../components/ListTemplate/HeaderTemplates';
 
 export const DEFAULT_JOB_LOG_COLUMNS = [
   'fileName',

--- a/src/utils/jobLogsListProperties.js
+++ b/src/utils/jobLogsListProperties.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { CheckboxHeader } from '../components/ListTemplate/HeaderTemplates';
+import { CheckboxHeader } from '../components';
 
 export const DEFAULT_JOB_LOG_COLUMNS = [
   'fileName',
@@ -19,12 +19,17 @@ export const DEFAULT_JOB_LOG_COLUMNS_WIDTHS = {
   totalRecords: '80px',
 };
 
-export const getJobLogsListColumnMapping = ({ isAllSelected, handleSelectAllCheckbox }) => {
+export const getJobLogsListColumnMapping = ({
+  isAllSelected,
+  handleSelectAllCheckbox,
+  checkboxDisabled = false,
+}) => {
   return {
     selected: (
       <CheckboxHeader
         checked={isAllSelected}
         onChange={handleSelectAllCheckbox}
+        disabled={checkboxDisabled}
       />
     ),
     fileName: <FormattedMessage id="ui-data-import.fileName" />,


### PR DESCRIPTION
## Purpose
- The "select all items" button does not select all logs after deleting multiple logs from the landing logs page
- Refs: https://issues.folio.org/browse/UIDATIMP-1186

## Approach
- The problem was after deleting some logs, the logs list `checkboxList` was using was stale because it didn't get updated in `componentDidUpdate()` correctly.
- Add logic to update `checkboxList` list when `job logs` change.
- Disable checkboxes while deletion in progress and until `ui` has been updated.

## Screenshots
#### Before

https://user-images.githubusercontent.com/89512426/172786648-fd26131b-c52f-4726-9ed2-269c9da60c6d.mp4

#### After

https://user-images.githubusercontent.com/89512426/172786711-8bf5829f-3d72-4228-b7dc-7575b7c7f47b.mp4

