### PR TITLE
UIDATIMP-1162: Fix Accessibility problems on /data-import view all lo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Create a new Data import UI permission for only viewing app and logs (UIDATIMP-1187)
 * Update the "Data Import: All permissions" permission (UIDATIMP-1143)
 * Check for accessibility issues on updated match screens (UIDATIMP-1052)
+* Fix Accessibility problems on /data-import view all logs page. (UIDATIMP-1162)
 
 ### Bugs fixed:
 * Data Import landing page log shows in old format instead of current format (UIDATIMP-1139)

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@folio/stripes-acq-components": "~3.0.0",
-    "@folio/stripes-data-transfer-components": "^5.0.0",
+    "@folio/stripes-data-transfer-components": "^5.1.0",
     "classnames": "^2.2.5",
     "dom-helpers": "^5.2.0",
     "faker": "^4.1.0",

--- a/src/components/ActionMenu/menuTemplate.js
+++ b/src/components/ActionMenu/menuTemplate.js
@@ -196,9 +196,11 @@ export const menuTemplate = ({
       };
 
       return (
-        <IfPermission perm={permissions.DELETE_LOGS}>
+        <IfPermission
+          perm={permissions.DELETE_LOGS}
+          key={key}
+        >
           <Default
-            key={key}
             caption="ui-data-import.deleteSelectedLogs"
             icon="trash"
             isDisabled={entity.isDeleteAllLogsDisabled()}

--- a/src/components/RecentJobLogs/RecentJobLogs.js
+++ b/src/components/RecentJobLogs/RecentJobLogs.js
@@ -36,6 +36,7 @@ export const RecentJobLogs = ({
           hasLoaded={haveLogsLoaded}
           contentData={logs}
           formatter={listProps.resultsFormatter}
+          mclProps={{ nonInteractiveHeaders: ['selected'] }}
           {...listProps}
         />
       )}

--- a/src/routes/ViewAllLogs/ViewAllLogs.js
+++ b/src/routes/ViewAllLogs/ViewAllLogs.js
@@ -18,6 +18,7 @@ import { SearchAndSort } from '@folio/stripes/smart-components';
 import {
   TextLink,
   ConfirmationModal,
+  DefaultMCLRowFormatter,
 } from '@folio/stripes/components';
 import {
   changeSearchIndex,
@@ -329,6 +330,7 @@ class ViewAllLogs extends Component {
           }
           columnMapping={columnMapping}
           resultsFormatter={resultsFormatter}
+          resultRowFormatter={DefaultMCLRowFormatter}
           columnWidths={DEFAULT_JOB_LOG_COLUMNS_WIDTHS}
           actionMenu={showActionMenu({
             renderer: this.renderActionMenu,


### PR DESCRIPTION
## Purpose
   Fix Accessibility problems on /data-import view all logs page.
     **Problems:**   
       -  Certain aria roles must contain particular children
       -  Certain aria roles must be contained by particular parents 
       -         
## Approach
   Use DefaultMCLRowFormatter from stripes components
## Refs
[UIDATIMP-1162](https://issues.folio.org/browse/UIDATIMP-1162)

### PREVIOUS
![prevLogs](https://user-images.githubusercontent.com/100832608/172842447-ed495bef-e232-45fe-86cf-6ba39379a6e0.png)

### AFTER
![afterLogs](https://user-images.githubusercontent.com/100832608/172842688-a17a1781-0398-457a-8308-420b26ed9a1a.png)

