### PR TITLE
UIDATIMP-1189: Instance Field mapping profile: Admin note does not check for MARC or text validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * Some issues with log searching in Juniper Bugfest/Smoke testing (UIDATIMP-1125)
 * QuotaExceededError: Failed to execute 'setItem' on 'Storage': Setting the value of 'profileTreeData' exceeded the quota (UIDATIMP-1166)
 * Action button is missing on the data-import/job-summary page when select a job profiles (UIDATIMP-1183)
+* Instance Field mapping profile: Admin note does not check for MARC or text validation (UIDATIMP-1189)
 
 ## [5.1.3](https://github.com/folio-org/ui-data-import/tree/v5.1.3) (2022-05-24)
 

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/AdministrativeData.js
@@ -216,11 +216,16 @@ export const AdministrativeData = ({
                       data-test-admisitrative-note
                       xs={12}
                     >
-                      <Field
-                        component={TextField}
-                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.administrativeNote`} />}
-                        name={getSubfieldName(5, 0, index)}
-                      />
+                      <WithValidation>
+                        {validation => (
+                          <Field
+                            component={TextField}
+                            label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.administrativeNote`} />}
+                            name={getSubfieldName(5, 0, index)}
+                            validate={[validation]}
+                          />
+                        )}
+                      </WithValidation>
                     </Col>
                   </Row>
                 )}

--- a/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/AdministrativeData.js
@@ -16,6 +16,7 @@ import {
   DatePickerDecorator,
   AcceptedValuesField,
   RepeatableActionsField,
+  WithValidation,
 } from '../../../../../components';
 
 import {
@@ -236,11 +237,16 @@ export const AdministrativeData = ({
                       data-test-admisitrative-note
                       xs={12}
                     >
-                      <Field
-                        component={TextField}
-                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.administrativeNote`} />}
-                        name={getSubfieldName(9, 0, index)}
-                      />
+                      <WithValidation>
+                        {validation => (
+                          <Field
+                            component={TextField}
+                            label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.administrativeNote`} />}
+                            name={getSubfieldName(9, 0, index)}
+                            validate={[validation]}
+                          />
+                        )}
+                      </WithValidation>
                     </Col>
                   </Row>
                 )}

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/AdministrativeData.js
@@ -238,11 +238,16 @@ export const AdministrativeData = ({
                       data-test-admisitrative-note
                       xs={12}
                     >
-                      <Field
-                        component={TextField}
-                        label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.administrativeNote`} />}
-                        name={getSubfieldName(7, 0, index)}
-                      />
+                      <WithValidation>
+                        {validation => (
+                          <Field
+                            component={TextField}
+                            label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.administrativeNote`} />}
+                            name={getSubfieldName(7, 0, index)}
+                            validate={[validation]}
+                          />
+                        )}
+                      </WithValidation>
                     </Col>
                   </Row>
                 )}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Most of the fields in the MARC field mapping profiles check that a MARC value or a text string value has correct structure. If not, an error shows, and the profile cannot be saved. That was not put in place for the new Administrative note fields when they were added to the Instance, Holdings, and Item field mapping profiles.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add validation to Admin note fields

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1189

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
