### PR TITLE
UIDATIMP-1191: The enabled indicator for duplicated field mapping fields is set to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * View all logs table allows user to sort by checkboxes. (UIDATIMP-1190)
 * Autofocus does not work after pressing the save button on the mapping-profiles editing page (UIDATIMP-1176)
 * When go to Uploading jobs page or Settings Job profiles from View all page, an error is thrown (UIDATIMP-1192)
+* The enabled indicator for duplicated field mapping fields is set to false (UIDATIMP-1191)
 
 ## [5.1.3](https://github.com/folio-org/ui-data-import/tree/v5.1.3) (2022-05-24)
 

--- a/src/settings/MappingProfiles/MappingProfilesForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm.js
@@ -56,6 +56,7 @@ import {
   getInitialDetails,
   getInitialFields,
   getReferenceTables,
+  getMappingDetailsForDuplicated,
 } from './initialDetails';
 import {
   compose,
@@ -113,6 +114,7 @@ export const MappingProfilesFormComponent = ({
   const { layer } = queryString.parse(search);
 
   const isEditMode = layer === LAYER_TYPES.EDIT;
+  const isDuplicateMode = layer === LAYER_TYPES.DUPLICATE;
   const isSubmitDisabled = pristine || submitting;
 
   const [folioRecordType, setFolioRecordType] = useState(existingRecordType || null);
@@ -135,8 +137,9 @@ export const MappingProfilesFormComponent = ({
       return;
     }
 
+    const initialMappingDetails = isDuplicateMode ? getMappingDetailsForDuplicated(mappingDetails) : mappingDetails;
     const newInitDetails = folioRecordType === existingRecordType && !isEmpty(mappingDetails)
-      ? mappingDetails
+      ? initialMappingDetails
       : getInitialDetails(folioRecordType, true);
 
     const newInitials = {

--- a/src/settings/MappingProfiles/initialDetails/index.js
+++ b/src/settings/MappingProfiles/initialDetails/index.js
@@ -1,3 +1,5 @@
+import { omit } from 'lodash';
+
 import ITEM from './ITEM';
 import INSTANCE from './INSTANCE';
 import HOLDINGS from './HOLDINGS';
@@ -38,6 +40,34 @@ const modifyInvoiceLinesFieldDetails = field => {
   return {
     ...field,
     subfields: [invoiceLineSubfield],
+  };
+};
+
+/**
+ * Modifies duplicated mapping details to set the initial `enabled` field
+ *
+ * @param {object} mappingDetails
+ * @returns {{mappingFields}}
+ */
+export const getMappingDetailsForDuplicated = mappingDetails => {
+  const {
+    recordType,
+    mappingFields,
+  } = mappingDetails;
+
+  const initialMappingFields = initialValues[recordType].mappingFields;
+  const modifiedMappingFields = mappingFields.map(field => {
+    const enabled = initialMappingFields.find(item => (item.name === field.name) && (item.path === field.path))?.enabled;
+
+    return {
+      ...field,
+      enabled: enabled || field.enabled,
+    };
+  });
+
+  return {
+    ...omit(mappingDetails, 'mappingFields'),
+    mappingFields: modifiedMappingFields,
   };
 };
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
If a field mapping profile is created by duplicating one of the 'default' field mapping profiles - the 'enabled' indicator on the 'permanentLocationId' field (and the other fields) is set to false. This causes an error during the import - even if the permanentLocationId has been assigned a value.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Assign the initial `enabled` field for the duplicated mappingDetailes

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1191

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
