### PR TITLE
UIDATIMP-1219: View all logs: filters are not updated after logs deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Long titles do not fit in the confirmation modal window header (UIDATIMP-1196)
 * Long name doesn't fit in the header of profiles on the settings page (UIDATIMP-1206)
 * Long titles don't fit in the green popup notification about a profile (UIDATIMP-1208)
+* View all logs: filters are not updated after logs deletion (UIDATIMP-1219)
 
 ## [5.2.0](https://github.com/folio-org/ui-data-import/tree/v5.2.0) (2022-07-08)
 

--- a/src/routes/ViewAllLogs/ViewAllLogs.js
+++ b/src/routes/ViewAllLogs/ViewAllLogs.js
@@ -212,9 +212,6 @@ class ViewAllLogs extends Component {
       if (this.state.isLogsDeletionInProgress) {
         this.setState({ isLogsDeletionInProgress: false });
       }
-
-      this.props.mutator.usersList.GET();
-      this.props.mutator.jobProfilesList.GET();
     }
   }
 
@@ -337,6 +334,12 @@ class ViewAllLogs extends Component {
       deselectAll();
       this.hideDeleteConfirmation();
       this.showDeleteLogsSuccessfulMessage(jobExecutionDetails.length);
+
+      mutator.usersList.reset();
+      mutator.jobProfilesList.reset();
+
+      mutator.usersList.GET();
+      mutator.jobProfilesList.GET();
     };
 
     // disable all checkboxes while deletion in progress


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* Filters on the View all logs page are not updated after logs deletion

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* reset `usersList` and `jobProfilesList` after deletion logs using `mutator`

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->https://issues.folio.org/browse/UIDATIMP-1219

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://user-images.githubusercontent.com/85172747/180396577-9486b5e9-a49a-4f36-b02c-b2824d642e16.mp4


