### PR TITLE
UIDATIMP-1220: View all logs: User and Job filter contains only 10 records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Long titles don't fit in the green popup notification about a profile (UIDATIMP-1208)
 * Log navigation problem when filtered error list is closed (UIDATIMP-1207)
 * View all logs: filters are not updated after logs deletion (UIDATIMP-1219)
+* View all logs: User and Job filter contains only 10 records (UIDATIMP-1220)
 
 ## [5.2.0](https://github.com/folio-org/ui-data-import/tree/v5.2.0) (2022-07-08)
 

--- a/src/components/Jobs/Jobs.js
+++ b/src/components/Jobs/Jobs.js
@@ -3,6 +3,7 @@ import React, { memo } from 'react';
 import { AccordionSet } from '@folio/stripes/components';
 
 import {
+  PreviewsJobs,
   RunningJobs,
 } from './components';
 
@@ -11,6 +12,7 @@ import css from './Jobs.css';
 export const Jobs = memo(() => (
   <div className={css.jobsPane}>
     <AccordionSet>
+      <PreviewsJobs />
       <RunningJobs />
     </AccordionSet>
   </div>

--- a/src/components/Jobs/Jobs.js
+++ b/src/components/Jobs/Jobs.js
@@ -3,7 +3,6 @@ import React, { memo } from 'react';
 import { AccordionSet } from '@folio/stripes/components';
 
 import {
-  PreviewsJobs,
   RunningJobs,
 } from './components';
 
@@ -12,7 +11,6 @@ import css from './Jobs.css';
 export const Jobs = memo(() => (
   <div className={css.jobsPane}>
     <AccordionSet>
-      <PreviewsJobs />
       <RunningJobs />
     </AccordionSet>
   </div>

--- a/src/routes/ViewAllLogs/ViewAllLogs.js
+++ b/src/routes/ViewAllLogs/ViewAllLogs.js
@@ -69,6 +69,8 @@ const {
 
 const INITIAL_RESULT_COUNT = 100;
 const RESULT_COUNT_INCREMENT = 100;
+const USERS_LIMIT_PER_REQUEST = 500;
+const JOB_PROFILES_LIMIT_PER_REQUEST = 1000;
 
 const entityKey = 'jobLogs';
 
@@ -127,6 +129,7 @@ export const ViewAllLogsManifest = Object.freeze({
     path: 'metadata-provider/jobExecutions/users',
     throwErrors: false,
     accumulate: true,
+    perRequest: USERS_LIMIT_PER_REQUEST,
   },
   jobProfilesList: {
     type: 'okapi',
@@ -134,6 +137,7 @@ export const ViewAllLogsManifest = Object.freeze({
     path: 'metadata-provider/jobExecutions/jobProfiles',
     throwErrors: false,
     accumulate: true,
+    perRequest: JOB_PROFILES_LIMIT_PER_REQUEST,
   },
 });
 


### PR DESCRIPTION
## Purpose
- View all logs: User and Job filter contains only 10 records

## Approach
- The problem was that by default `endpoint` returns `10` records.
- Increase `limit` of records per request.

## Refs
- https://issues.folio.org/browse/UIDATIMP-1220