### PR TITLE
UIDATIMP-1218: Make UI changes to the Data Import landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## **5.2.1** (in progress)
 
+### Features added:
+* Make UI changes to the Data Import landing page (UIDATIMP-1218)
+
 ### Bugs fixed:
 * Long titles do not fit in the confirmation modal window header (UIDATIMP-1196)
 * Long name doesn't fit in the header of profiles on the settings page (UIDATIMP-1206)
@@ -11,7 +14,7 @@
 
 ## [5.2.0](https://github.com/folio-org/ui-data-import/tree/v5.2.0) (2022-07-08)
 
-### Features added
+### Features added:
 * Add checkboxes and delete action to Data Import landing page (UIDATIMP-1077)
 * Add Admin note field to the Instance field mapping profile: Create/Edit (UIDATIMP-1118)
 * Add Admin note field to the Holdings field mapping profile: Create/Edit (UIDATIMP-1119)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## **5.2.2** (in progress)
 
+### Features added:
+* Make UI changes to the Data Import landing page (UIDATIMP-1218)
+
 ### Bugs fixed:
 * View all logs: filters are not updated after logs deletion (UIDATIMP-1219)
 * View all logs: User and Job filter contains only 10 records (UIDATIMP-1220)
 
 ## [5.2.1](https://github.com/folio-org/ui-data-import/tree/v5.2.1) (2022-07-27)
-
-### Features added:
-* Make UI changes to the Data Import landing page (UIDATIMP-1218)
 
 ### Bugs fixed:
 * Long titles do not fit in the confirmation modal window header (UIDATIMP-1196)

--- a/src/components/Jobs/Jobs.js
+++ b/src/components/Jobs/Jobs.js
@@ -2,18 +2,14 @@ import React, { memo } from 'react';
 
 import { AccordionSet } from '@folio/stripes/components';
 
-import {
-  PreviewsJobs,
-  RunningJobs,
-} from './components';
+import { RunningJobs } from './components';
 
 import css from './Jobs.css';
 
 export const Jobs = memo(() => (
   <div className={css.jobsPane}>
     <AccordionSet>
-      <PreviewsJobs />
       <RunningJobs />
-    </AccordionSet>
+    </AccordionSet>-
   </div>
 ));

--- a/src/components/Jobs/Jobs.js
+++ b/src/components/Jobs/Jobs.js
@@ -10,6 +10,6 @@ export const Jobs = memo(() => (
   <div className={css.jobsPane}>
     <AccordionSet>
       <RunningJobs />
-    </AccordionSet>-
+    </AccordionSet>
   </div>
 ));

--- a/src/components/Jobs/Jobs.test.js
+++ b/src/components/Jobs/Jobs.test.js
@@ -1,19 +1,18 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, within } from '@testing-library/react';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
 import '../../../test/jest/__mock__';
-import {
-  jobExecutions,
-  RUNNING_JOBS_LENGTH,
-} from '../../../test/bigtest/mocks';
 import { translationsProperties } from '../../../test/jest/helpers';
 
 import { DataFetcherContext } from '../DataFetcher';
 import { Jobs } from './Jobs';
 
-import { DEFAULT_TIMEOUT_BEFORE_JOB_DELETION } from '../../utils';
+import {
+  DEFAULT_TIMEOUT_BEFORE_JOB_DELETION,
+  JOB_STATUSES,
+} from '../../utils';
 import { deleteFile } from '../../utils/upload';
 
 jest.mock('../../utils/upload', () => ({
@@ -25,9 +24,31 @@ jest.spyOn(console, 'error').mockImplementation(() => {});
 
 global.fetch = jest.fn();
 
+const runningJobs = [
+  {
+    id: '469eba83-41d1-4161-bd1a-0f46d5554c6a',
+    hrId: 182982989,
+    subordinationType: 'PARENT_SINGLE',
+    jobProfileInfo: { name: 'Main bib jobs' },
+    fileName: 'import_1.mrc',
+    sourcePath: 'import_1.mrc',
+    runBy: {
+      firstName: 'Mark',
+      lastName: 'Curie',
+    },
+    progress: {
+      current: 290,
+      total: 500,
+    },
+    startedDate: '2018-11-22T12:00:31.000',
+    uiStatus: JOB_STATUSES.RUNNING,
+    status: 'PROCESSING_FINISHED',
+  },
+];
+
 const defaultContext = {
   hasLoaded: true,
-  jobs: jobExecutions,
+  jobs: runningJobs,
   logs: [],
 };
 
@@ -41,7 +62,7 @@ const renderJobs = (context = defaultContext) => {
   return renderWithIntl(component, translationsProperties);
 };
 
-describe('<Jobs>', () => {
+describe('Jobs', () => {
   beforeEach(() => {
     global.fetch.mockClear();
   });
@@ -62,14 +83,60 @@ describe('<Jobs>', () => {
     expect(getByRole('button', { name: /running/i, expanded: true }));
   });
 
-  it('should have correct job items amount', () => {
-    const { getAllByRole } = renderJobs();
-
-    expect(getAllByRole('listitem').length).toBe(RUNNING_JOBS_LENGTH);
-  });
-
   describe('"Running" section', () => {
-    describe('when clicked delete button', () => {
+    it('should have correct amount of running job cards', () => {
+      const { getAllByRole } = renderJobs();
+
+      expect(getAllByRole('listitem').length).toBe(runningJobs.length);
+    });
+
+    it('should display appropriate message when there are no running jobs', () => {
+      const { getByText } = renderJobs({
+        ...defaultContext,
+        jobs: [],
+      });
+
+      expect(getByText('No running jobs to show')).toBeInTheDocument();
+    });
+
+    describe('Job card', () => {
+      let jobCard;
+
+      beforeEach(() => {
+        const { getByRole } = renderJobs();
+        jobCard = getByRole('listitem');
+      });
+
+      it('should display job profile name', () => {
+        const jobProfileName = runningJobs[0].jobProfileInfo.name;
+
+        expect(within(jobCard).getByText(jobProfileName)).toBeInTheDocument();
+      });
+
+      it('should display file name', () => {
+        const fileName = runningJobs[0].fileName;
+
+        expect(within(jobCard).getByText(fileName)).toBeInTheDocument();
+      });
+
+      it('should display total number of records', () => {
+        const totalRecords = runningJobs[0].progress.total;
+
+        expect(within(jobCard).getByText(`${totalRecords} records`)).toBeInTheDocument();
+      });
+
+      it('should display user full name', () => {
+        const {
+          firstName,
+          lastName,
+        } = runningJobs[0].runBy;
+        const fullName = `${firstName} ${lastName}`;
+
+        expect(within(jobCard).getByText(fullName, { exact: false })).toBeInTheDocument();
+      });
+    });
+
+    describe('when clicked delete button on running job card', () => {
       it('should handle deletion errors', () => {
         const { getAllByRole } = renderJobs();
 

--- a/src/components/Jobs/Jobs.test.js
+++ b/src/components/Jobs/Jobs.test.js
@@ -1,5 +1,8 @@
 import React from 'react';
-import { fireEvent, within } from '@testing-library/react';
+import {
+  fireEvent,
+  within,
+} from '@testing-library/react';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
@@ -77,7 +80,7 @@ describe('Jobs', () => {
     expect(getByText('Running')).toBeInTheDocument();
   });
 
-  it('"Running" section should be open by default', () => {
+  it('"Running" section accordion should be open by default', () => {
     const { getByRole } = renderJobs();
 
     expect(getByRole('button', { name: /running/i, expanded: true }));


### PR DESCRIPTION
## Purpose
- Remove `Preview` section from landing page.

## Approach
- Remove `PreviewJobs` component and refactor tests.

## Refs
- https://issues.folio.org/browse/UIDATIMP-1218

## Screenshots
### Before
<img src="https://user-images.githubusercontent.com/89512426/181202377-ca7d49db-2880-480c-b1ee-b313d483204c.png" width="400" />

### After
<img src="https://user-images.githubusercontent.com/89512426/181202438-27423067-c96b-47f3-afcf-dfd81d5afeb0.png" width="400" />
