### PR TITLE
UIDATIMP-1223: Change options for invoice level adjustments in Invoice field mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bugs fixed:
 * View all logs: filters are not updated after logs deletion (UIDATIMP-1219)
 * View all logs: User and Job filter contains only 10 records (UIDATIMP-1220)
+* Change options for invoice level adjustments in Invoice field mapping (UIDATIMP-1223)
 
 ## [5.2.1](https://github.com/folio-org/ui-data-import/tree/v5.2.1) (2022-07-27)
 

--- a/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceAdjustments.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceAdjustments.js
@@ -46,6 +46,7 @@ import {
   INOVOICE_ADJUSTMENTS_PRORATE_OPTIONS,
   INOVOICE_ADJUSTMENTS_RELATION_TO_TOTAL_OPTIONS,
   BOOLEAN_ACTIONS,
+  RELATION_TO_TOTAL_OPTIONS,
   validateQuotedString,
 } from '../../../../../utils';
 
@@ -61,16 +62,30 @@ export const InvoiceAdjustments = ({
   const { formatMessage } = useIntl();
 
   const [isFundDistribution, setIsFundDistribution] = useState(false);
+  const [isNotProratedSelected, setIsNotProratedSelected] = useState(false);
+  const [isSeparateFromSelected, setIsSeparateFromSelected] = useState(false);
 
-  const prorateList = createOptionsList(INOVOICE_ADJUSTMENTS_PRORATE_OPTIONS, formatMessage);
-  const relationToTotalList = createOptionsList(INOVOICE_ADJUSTMENTS_RELATION_TO_TOTAL_OPTIONS, formatMessage);
+  const prorateList = createOptionsList(INOVOICE_ADJUSTMENTS_PRORATE_OPTIONS, formatMessage)
+    .filter(option => !(isSeparateFromSelected && option.value === PRORATE_OPTIONS.NOT_PRORATED));
+  const relationToTotalList = createOptionsList(INOVOICE_ADJUSTMENTS_RELATION_TO_TOTAL_OPTIONS, formatMessage)
+    .filter(option => !(isNotProratedSelected && option.value === RELATION_TO_TOTAL_OPTIONS.SEPARATE_FORM));
 
   const handleProRateChange = index => value => {
     if (value === `"${PRORATE_OPTIONS.NOT_PRORATED}"`) {
       setIsFundDistribution(true);
+      setIsNotProratedSelected(true);
     } else {
       setIsFundDistribution(false);
       setReferenceTables(getInnerSubfieldsPath(15, index, 6), []);
+      setIsNotProratedSelected(false);
+    }
+  };
+
+  const handleRelationToTotalChange = () => value => {
+    if (value === `"${RELATION_TO_TOTAL_OPTIONS.SEPARATE_FORM}"`) {
+      setIsSeparateFromSelected(true);
+    } else {
+      setIsSeparateFromSelected(false);
     }
   };
 
@@ -251,6 +266,7 @@ export const InvoiceAdjustments = ({
               isRemoveValueAllowed
               wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
               acceptedValuesList={relationToTotalList}
+              onChange={handleRelationToTotalChange()}
               validation={validateQuotedString}
               okapi={okapi}
             />

--- a/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceAdjustments.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceAdjustments.js
@@ -36,6 +36,7 @@ import {
   getRepeatableFieldName,
   handleRepeatableFieldAndActionAdd,
   handleRepeatableFieldAndActionClean,
+  filterOptionsList,
 } from '../../utils';
 import { TRANSLATION_ID_PREFIX } from '../../constants';
 import {
@@ -62,30 +63,37 @@ export const InvoiceAdjustments = ({
   const { formatMessage } = useIntl();
 
   const [isFundDistribution, setIsFundDistribution] = useState(false);
-  const [isNotProratedSelected, setIsNotProratedSelected] = useState(false);
-  const [isSeparateFromSelected, setIsSeparateFromSelected] = useState(false);
+  const [canShowNotProratedOption, setCanShowNotProratedOption] = useState(true);
+  const [canShowSeparateFromOption, setCanShowSeparateFromOption] = useState(true);
 
-  const prorateList = createOptionsList(INOVOICE_ADJUSTMENTS_PRORATE_OPTIONS, formatMessage)
-    .filter(option => !(isSeparateFromSelected && option.value === PRORATE_OPTIONS.NOT_PRORATED));
-  const relationToTotalList = createOptionsList(INOVOICE_ADJUSTMENTS_RELATION_TO_TOTAL_OPTIONS, formatMessage)
-    .filter(option => !(isNotProratedSelected && option.value === RELATION_TO_TOTAL_OPTIONS.SEPARATE_FORM));
+  const prorateList = filterOptionsList(
+    createOptionsList(INOVOICE_ADJUSTMENTS_PRORATE_OPTIONS, formatMessage),
+    [PRORATE_OPTIONS.NOT_PRORATED],
+    canShowNotProratedOption,
+  );
+
+  const relationToTotalList = filterOptionsList(
+    createOptionsList(INOVOICE_ADJUSTMENTS_RELATION_TO_TOTAL_OPTIONS, formatMessage),
+    [RELATION_TO_TOTAL_OPTIONS.SEPARATE_FROM],
+    canShowSeparateFromOption,
+  );
 
   const handleProRateChange = index => value => {
     if (value === `"${PRORATE_OPTIONS.NOT_PRORATED}"`) {
       setIsFundDistribution(true);
-      setIsNotProratedSelected(true);
+      setCanShowSeparateFromOption(false);
     } else {
       setIsFundDistribution(false);
       setReferenceTables(getInnerSubfieldsPath(15, index, 6), []);
-      setIsNotProratedSelected(false);
+      setCanShowSeparateFromOption(true);
     }
   };
 
   const handleRelationToTotalChange = () => value => {
-    if (value === `"${RELATION_TO_TOTAL_OPTIONS.SEPARATE_FORM}"`) {
-      setIsSeparateFromSelected(true);
+    if (value === `"${RELATION_TO_TOTAL_OPTIONS.SEPARATE_FROM}"`) {
+      setCanShowNotProratedOption(false);
     } else {
-      setIsSeparateFromSelected(false);
+      setCanShowNotProratedOption(true);
     }
   };
 

--- a/src/settings/MappingProfiles/detailsSections/utils.js
+++ b/src/settings/MappingProfiles/detailsSections/utils.js
@@ -233,3 +233,15 @@ export const renderCheckbox = (labelPathId, fieldValue) => (
     )}
   </FormattedMessage>
 );
+
+/**
+ * Removes disallowed options from options list
+ *
+ * @param {Array<{value: string, label: string}>} optionsList
+ * @param {Array<string>} disallowedOptions
+ * @param {boolean} canShowAll
+ * @return {Array<{value: string, label: string}>}
+ */
+export const filterOptionsList = (optionsList = [], disallowedOptions = [], canShowAll = false) => {
+  return canShowAll ? optionsList : optionsList.filter(option => !disallowedOptions.includes(option.value));
+};

--- a/src/settings/MappingProfiles/detailsSections/utils.js
+++ b/src/settings/MappingProfiles/detailsSections/utils.js
@@ -233,15 +233,3 @@ export const renderCheckbox = (labelPathId, fieldValue) => (
     )}
   </FormattedMessage>
 );
-
-/**
- * Removes disallowed options from options list
- *
- * @param {Array<{value: string, label: string}>} optionsList
- * @param {Array<string>} disallowedOptions
- * @param {boolean} canShowAll
- * @return {Array<{value: string, label: string}>}
- */
-export const filterOptionsList = (optionsList = [], disallowedOptions = [], canShowAll = false) => {
-  return canShowAll ? optionsList : optionsList.filter(option => !disallowedOptions.includes(option.value));
-};

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -502,7 +502,7 @@ export const PRORATE_OPTIONS = {
 export const RELATION_TO_TOTAL_OPTIONS = {
   IN_ADDITION_TO: 'In addition to',
   INCLUDED_IN: 'Included in',
-  SEPARATE_FORM: 'Separate from',
+  SEPARATE_FROM: 'Separate from',
 };
 
 export const ACTION_OPTIONS = [
@@ -650,7 +650,7 @@ export const INOVOICE_ADJUSTMENTS_RELATION_TO_TOTAL_OPTIONS = [
     value: RELATION_TO_TOTAL_OPTIONS.INCLUDED_IN,
     label: 'ui-data-import.settings.mappingProfiles.map.invoice.invoiceAdjustments.field.prorate.IncludedIn',
   }, {
-    value: RELATION_TO_TOTAL_OPTIONS.SEPARATE_FORM,
+    value: RELATION_TO_TOTAL_OPTIONS.SEPARATE_FROM,
     label: 'ui-data-import.settings.mappingProfiles.map.invoice.invoiceAdjustments.field.prorate.SeparateFrom',
   },
 ];

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -499,6 +499,12 @@ export const PRORATE_OPTIONS = {
   NOT_PRORATED: 'Not prorated',
 };
 
+export const RELATION_TO_TOTAL_OPTIONS = {
+  IN_ADDITION_TO: 'In addition to',
+  INCLUDED_IN: 'Included in',
+  SEPARATE_FORM: 'Separate from',
+};
+
 export const ACTION_OPTIONS = [
   {
     value: MAPPING_DETAILS_ACTIONS.ADD,
@@ -638,13 +644,13 @@ export const INOVOICE_ADJUSTMENTS_PRORATE_OPTIONS = [
 
 export const INOVOICE_ADJUSTMENTS_RELATION_TO_TOTAL_OPTIONS = [
   {
-    value: 'In addition to',
+    value: RELATION_TO_TOTAL_OPTIONS.IN_ADDITION_TO,
     label: 'ui-data-import.settings.mappingProfiles.map.invoice.invoiceAdjustments.field.prorate.InAdditionTo',
   }, {
-    value: 'Included in',
+    value: RELATION_TO_TOTAL_OPTIONS.INCLUDED_IN,
     label: 'ui-data-import.settings.mappingProfiles.map.invoice.invoiceAdjustments.field.prorate.IncludedIn',
   }, {
-    value: 'Separate from',
+    value: RELATION_TO_TOTAL_OPTIONS.SEPARATE_FORM,
     label: 'ui-data-import.settings.mappingProfiles.map.invoice.invoiceAdjustments.field.prorate.SeparateFrom',
   },
 ];


### PR DESCRIPTION
## Purpose
- When `Pro rate` field has `Not prorated` value, hide `Separate from` value from `Relation to total` field list.
- When `Relation to total` field has `Separate from` value, hide `Not prorated` value from `Pro rate` list.
- Also, I found a bug with `Add fund distribution button`. The problem is that when there are more than 1 `Invoice adjustments` and one of them enable `Add fund distribution button`, other `adjustments`'s buttons will be enabled even though others don't enable their buttons.

## Approach
- Remove shared state `isFundDistribution` which caused shared state problem
- Scope field values and fund distribution button logic in `renderAdjustment` function.

## Refs
- https://issues.folio.org/browse/UIDATIMP-1223

## Screenshots
### Add fund distribution button bug

https://user-images.githubusercontent.com/89512426/181759221-d027dd85-c295-4aea-baac-82ae68132c2b.mp4

### After

https://user-images.githubusercontent.com/89512426/181759713-e1e70e90-4a18-44d6-a67b-7ed64a5be84c.mp4