### PR TITLE
UIDATIMP-1230: Field Mapping profile: "Batch group field" contains only 10 records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * View all logs: filters are not updated after logs deletion (UIDATIMP-1219)
 * View all logs: User and Job filter contains only 10 records (UIDATIMP-1220)
 * Change options for invoice level adjustments in Invoice field mapping (UIDATIMP-1223)
+* Invoice Field Mapping profile: The 'Accepted values' dropdown contains only 10 records in the 'Batch group' field (UIDATIMP-1230)
 
 ## [5.2.1](https://github.com/folio-org/ui-data-import/tree/v5.2.1) (2022-07-27)
 

--- a/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceInformation.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceInformation.js
@@ -158,7 +158,7 @@ export const InvoiceInformation = ({
             optionLabel="name"
             wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
             wrapperSources={[{
-              wrapperSourceLink: '/batch-groups',
+              wrapperSourceLink: '/batch-groups?limit=500',
               wrapperSourcePath: 'batchGroups',
             }]}
             isRemoveValueAllowed


### PR DESCRIPTION
## Purpose
- The Batch group `Accepted values` dropdown has a limit of 10 records, but it should show all values.

## Approach
- Make `limit` 500 records.

## Refs
- https://issues.folio.org/browse/UIDATIMP-1230