### PR TITLE
UIDATIMP-1236: Acq unit and Batch group dropdown lists should be in alphabetical order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Change UI flow for import jobs cancelled by users  (UIDATIMP-1173)
 * Update the Match profile UI: Create/Edit screen (UIDATIMP-1214)
 
+### Bugs fixed:
+* Invoice Field Mapping profile: Acq unit and Batch group dropdown lists should be in alphabetical order (UIDATIMP-1236)
+
 ## [5.2.3](https://github.com/folio-org/ui-data-import/tree/v5.2.3) (2022-08-11)
 
 ### Bugs fixed:

--- a/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceInformation.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceInformation.js
@@ -107,7 +107,7 @@ export const InvoiceInformation = ({
             optionLabel="name"
             wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
             wrapperSources={[{
-              wrapperSourceLink: '/acquisitions-units/units?limit=1000',
+              wrapperSourceLink: '/acquisitions-units/units?limit=1000&query=cql.allRecords=1 sortby name',
               wrapperSourcePath: 'acquisitionsUnits',
             }]}
             isRemoveValueAllowed
@@ -158,7 +158,7 @@ export const InvoiceInformation = ({
             optionLabel="name"
             wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
             wrapperSources={[{
-              wrapperSourceLink: '/batch-groups?limit=500',
+              wrapperSourceLink: '/batch-groups?limit=500&query=cql.allRecords=1 sortby name',
               wrapperSourcePath: 'batchGroups',
             }]}
             isRemoveValueAllowed


### PR DESCRIPTION
## Purpose
- The 'Accepted values' dropdown lists for Acquisitions unit and Batch group are not in alphabetical order in the Invoice field mapping profile. All dropdown lists in field mapping profiles should be in alphabetical order unless otherwise specified.

## Approach
- Add search param to get the sorted list of records from the back-end.

## Refs
- https://issues.folio.org/browse/UIDATIMP-1236
