### PR TITLE
UIDATIMP-1317: Upgrade moment from 2.24.0 to >= 2.29.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-data-import
 
+## **5.3.8** (in progress)
+
+### Bugs fixed:
+* Upgrade moment from 2.24.0 to >= 2.29.4 fixing vulns (UIDATIMP-1317)
+
 ## [5.3.7](https://github.com/folio-org/ui-data-import/tree/v5.3.7) (2022-11-28)
 
 ### Bugs fixed:

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "inflected": "^2.0.4",
     "lodash": "^4.17.21",
     "miragejs": "^0.1.40",
-    "moment": "~2.24.0",
+    "moment": "~2.29.4",
     "prop-types": "^15.6.0",
     "react-final-form": "^6.3.0",
     "redux-form": "^8.3.7"
@@ -91,7 +91,7 @@
     "redux": "*"
   },
   "resolutions": {
-    "moment": "~2.24.0"
+    "moment": "~2.29.4"
   },
   "optionalDependencies": {
     "@folio/plugin-find-organization": "*"


### PR DESCRIPTION
## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
[UIDATIMP-1317](https://issues.folio.org/browse/UIDATIMP-1317)
