### PR TITLE
UIDATIMP-1323: Loose plugin dependencies permit incompatible versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-data-import
 
+## **5.3.8** (in progress)
+
+### Bugs fixed:
+* Loose plugin dependencies permit incompatible versions (UIDATIMP-1323)
+
 ## [5.3.7](https://github.com/folio-org/ui-data-import/tree/v5.3.7) (2022-11-28)
 
 ### Bugs fixed:

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "moment": "~2.24.0"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-organization": "*"
+    "@folio/plugin-find-organization": "^3.3.0"
   },
   "stripes": {
     "stripesDeps": [


### PR DESCRIPTION
## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
[UIDATIMP-1323](https://issues.folio.org/browse/UIDATIMP-1323)