### PR TITLE
avoid webpack's context

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "@folio/stripes-cli": "^2.6.0",
     "@folio/stripes-components": "^10.3.3",
     "@folio/stripes-core": "^8.1.0",
+    "@folio/stripes-final-form": "^6.1.0",
+    "@folio/stripes-form": "^7.1.0",
     "@folio/stripes-smart-components": "^7.3.3",
     "@formatjs/cli": "^4.2.10",
     "@testing-library/jest-dom": "^5.14.1",

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -2,6 +2,9 @@ import './currencyData.mock';
 import './documentCreateRange.mock';
 import './matchMedia.mock';
 import './stripesConfig.mock';
-import './stripesCore.mock';
+
+import './stripesComponents.mock';
 import './stripesIcon.mock';
+
+import './stripesCore.mock';
 import './stripesSmartComponents.mock';

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+// jest.mock('@folio/stripes-components/lib/Icon', () => {
+//   return (props) => (
+//     <span data-testid={props?.['data-testid']}>Icon</span>
+//   );
+// });
+
+jest.mock('@folio/stripes/components', () => ({
+  ...jest.requireActual('@folio/stripes-components'),
+  Headline: jest.fn(({ children }) => <div>{children}</div>),
+  Icon: jest.fn((props) => (props && props.children ? props.children : <span />)),
+}));

--- a/test/jest/__mock__/stripesConfig.mock.js
+++ b/test/jest/__mock__/stripesConfig.mock.js
@@ -1,1 +1,1 @@
-jest.mock('stripes-config', () => ({ modules: [] }), { virtual: true });
+jest.mock('stripes-config', () => ({ modules: [], metadata: {} }), { virtual: true });

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -71,7 +71,8 @@ jest.mock('@folio/stripes/core', () => {
   STRIPES.connect = stripesConnect;
 
   return {
-    ...jest.requireActual('@folio/stripes/core'),
+    ...jest.requireActual('@folio/stripes-core'),
+//    AppIcon: jest.fn(({ ariaLabel }) => <span>{ariaLabel}</span>),
     stripesConnect,
     withStripes,
     withRoot,

--- a/test/jest/__mock__/stripesSmartComponents.mock.js
+++ b/test/jest/__mock__/stripesSmartComponents.mock.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
 jest.mock('@folio/stripes/smart-components', () => ({
-  ...jest.requireActual('@folio/stripes/smart-components'),
+  ...jest.requireActual('@folio/stripes-smart-components'),
   LocationLookup: () => <div>LocationLookup</div>,
 }), { virtual: true });


### PR DESCRIPTION
Mock components using webpack's context since it's not available when components aren't being pulled through webpack.

This doesn't fix _all_ the webapack context errors, but it makes a significant dent, changing the stats from 
```
Test Suites: 115 failed, 41 passed, 156 total
Tests:       116 passed, 116 total
```
to 
```
Test Suites: 71 failed, 1 skipped, 84 passed, 155 of 156 total
Tests:       12 failed, 12 skipped, 413 passed, 437 total
```
I've sunk enough time into this already; the rest is up to you. 

Additionally, there are a few components here that rely on `ACTION_TYPES` being exported from `stripes-data-transfer-components` alongside `FOLIO_RECORD_TYPES`, but it isn't and there is no mention of pending work in SDTC in the PR description :/ 

If you have plans to make that change, you should mention the PR this one is blocked on in the PR description, and you'll also need to bump the minimum version of `stripes-data-transfer-components` to `^5.4.0`, the version where that constant will become available. 