### PR TITLE
UIDATIMP-1348: Receiving value disappears from Order field mapping profile after default order line limit updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Order and Order line field mapping: Create/Edit screen updates (UIDATIMP-1305)
 * Error after selecting order option on field mapping profile (UIDATIMP-1344)
 * Error after selecting order option on field mapping profile: Part 2 (UIDATIMP-1346)
+* Receiving value disappears from Order field mapping profile after default order line limit updated (UIDATIMP-1348)
 
 ## [5.3.10](https://github.com/folio-org/ui-data-import/tree/v5.3.10) (2022-12-05)
 

--- a/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/POLineDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/POLineDetails.js
@@ -1,7 +1,4 @@
-import React, {
-  useCallback,
-  useState,
-} from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import {
   FormattedMessage,
@@ -42,7 +39,6 @@ import {
   BOOLEAN_ACTIONS,
   BOOLEAN_STRING_VALUES,
   validateMARCWithDate,
-  validateMARCWithElse,
 } from '../../../../../utils';
 
 export const POLineDetails = ({
@@ -52,7 +48,7 @@ export const POLineDetails = ({
 }) => {
   const { formatMessage } = useIntl();
 
-  const PO_LONE_DETAILS_FIELDS_MAP = {
+  const PO_LINE_DETAILS_FIELDS_MAP = {
     ACQ_METHOD: 29,
     AUTOMATIC_EXPORT: getBoolFieldName(30),
     ORDER_FORMAT: getFieldName(31),
@@ -68,8 +64,6 @@ export const POLineDetails = ({
     CANCELLATION_DESCRIPTION: getFieldName(42),
     LINE_DESCRIPTION: getFieldName(43),
   };
-
-  const [receivingWorkflow, setReceivingWorkflow] = useState();
 
   const validateDatepickerFieldValue = useCallback(
     value => validateMARCWithDate(value, false),
@@ -112,9 +106,8 @@ export const POLineDetails = ({
 
   const onReceivingWorkflowParse = useCallback(
     value => {
-      setReceivingWorkflow(value);
-      if (value === `"${RECEIVING_WORKFLOW.INDEPENDENT}"`) return BOOLEAN_STRING_VALUES.TRUE;
-      if (value === `"${RECEIVING_WORKFLOW.SYNCHRONIZED}"`) return BOOLEAN_STRING_VALUES.FALSE;
+      if (value === `"${RECEIVING_WORKFLOW.INDEPENDENT}"`) return `"${BOOLEAN_STRING_VALUES.TRUE}"`;
+      if (value === `"${RECEIVING_WORKFLOW.SYNCHRONIZED}"`) return `"${BOOLEAN_STRING_VALUES.FALSE}"`;
 
       return value;
     },
@@ -122,17 +115,11 @@ export const POLineDetails = ({
   );
 
   const onReceivingWorkflowFormat = useCallback(
-    () => receivingWorkflow,
-    [receivingWorkflow],
-  );
-
-  const validateReceivingWorkflow = useCallback(
     value => {
-      const valueToValidate = (value === BOOLEAN_STRING_VALUES.TRUE || value === BOOLEAN_STRING_VALUES.FALSE)
-        ? `"${value}"`
-        : value;
+      if (value === `"${BOOLEAN_STRING_VALUES.TRUE}"`) return `"${RECEIVING_WORKFLOW.INDEPENDENT}"`;
+      if (value === `"${BOOLEAN_STRING_VALUES.FALSE}"`) return `"${RECEIVING_WORKFLOW.SYNCHRONIZED}"`;
 
-      return validateMARCWithElse(valueToValidate);
+      return value;
     },
     [],
   );
@@ -149,7 +136,7 @@ export const POLineDetails = ({
         <Col xs={3}>
           <AcceptedValuesField
             component={TextField}
-            name={getFieldName(PO_LONE_DETAILS_FIELDS_MAP.ACQ_METHOD)}
+            name={getFieldName(PO_LINE_DETAILS_FIELDS_MAP.ACQ_METHOD)}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.acquisitionMethod`} />}
             optionValue="value"
             optionLabel="value"
@@ -159,7 +146,7 @@ export const POLineDetails = ({
               wrapperSourcePath: 'acquisitionMethods',
             }]}
             setAcceptedValues={setReferenceTables}
-            acceptedValuesPath={getAcceptedValuesPath(PO_LONE_DETAILS_FIELDS_MAP.ACQ_METHOD)}
+            acceptedValuesPath={getAcceptedValuesPath(PO_LINE_DETAILS_FIELDS_MAP.ACQ_METHOD)}
             okapi={okapi}
             required
           />
@@ -168,7 +155,7 @@ export const POLineDetails = ({
           <Field
             component={Checkbox}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.automaticExport`} />}
-            name={PO_LONE_DETAILS_FIELDS_MAP.AUTOMATIC_EXPORT}
+            name={PO_LINE_DETAILS_FIELDS_MAP.AUTOMATIC_EXPORT}
             type="checkbox"
             parse={value => (value ? BOOLEAN_ACTIONS.ALL_TRUE : BOOLEAN_ACTIONS.ALL_FALSE)}
             checked={automaticExportCheckbox === BOOLEAN_ACTIONS.ALL_TRUE}
@@ -178,7 +165,7 @@ export const POLineDetails = ({
         <Col xs={3}>
           <AcceptedValuesField
             component={TextField}
-            name={PO_LONE_DETAILS_FIELDS_MAP.ORDER_FORMAT}
+            name={PO_LINE_DETAILS_FIELDS_MAP.ORDER_FORMAT}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.orderFormat`} />}
             optionValue="value"
             optionLabel="label"
@@ -196,7 +183,7 @@ export const POLineDetails = ({
           <Field
             component={DatePickerDecorator}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.receiptDate`} />}
-            name={PO_LONE_DETAILS_FIELDS_MAP.RECEIPT_DATE}
+            name={PO_LINE_DETAILS_FIELDS_MAP.RECEIPT_DATE}
             wrappedComponent={TextField}
             wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
             validate={[validateDatepickerFieldValue]}
@@ -205,7 +192,7 @@ export const POLineDetails = ({
         <Col xs={3}>
           <AcceptedValuesField
             component={TextField}
-            name={PO_LONE_DETAILS_FIELDS_MAP.RECEIPT_STATUS}
+            name={PO_LINE_DETAILS_FIELDS_MAP.RECEIPT_STATUS}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.receiptStatus`} />}
             optionValue="value"
             optionLabel="label"
@@ -216,7 +203,7 @@ export const POLineDetails = ({
         <Col xs={3}>
           <AcceptedValuesField
             component={TextField}
-            name={PO_LONE_DETAILS_FIELDS_MAP.PAYMENT_STATUS}
+            name={PO_LINE_DETAILS_FIELDS_MAP.PAYMENT_STATUS}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.paymentStatus`} />}
             optionValue="value"
             optionLabel="label"
@@ -237,7 +224,7 @@ export const POLineDetails = ({
               <Field
                 component={TextField}
                 label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.donor`} />}
-                name={PO_LONE_DETAILS_FIELDS_MAP.DONOR}
+                name={PO_LINE_DETAILS_FIELDS_MAP.DONOR}
                 validate={[validation]}
               />
             )}
@@ -249,7 +236,7 @@ export const POLineDetails = ({
               <Field
                 component={TextField}
                 label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.selector`} />}
-                name={PO_LONE_DETAILS_FIELDS_MAP.SELECTOR}
+                name={PO_LINE_DETAILS_FIELDS_MAP.SELECTOR}
                 validate={[validation]}
               />
             )}
@@ -261,7 +248,7 @@ export const POLineDetails = ({
               <Field
                 component={TextField}
                 label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.requester`} />}
-                name={PO_LONE_DETAILS_FIELDS_MAP.REQUESTER}
+                name={PO_LINE_DETAILS_FIELDS_MAP.REQUESTER}
                 validate={[validation]}
               />
             )}
@@ -272,7 +259,7 @@ export const POLineDetails = ({
         <Col xs={4}>
           <AcceptedValuesField
             component={TextField}
-            name={PO_LONE_DETAILS_FIELDS_MAP.CANCELLATION_RESTRICTION}
+            name={PO_LINE_DETAILS_FIELDS_MAP.CANCELLATION_RESTRICTION}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.cancellationRestriction`} />}
             optionValue="value"
             optionLabel="label"
@@ -283,7 +270,7 @@ export const POLineDetails = ({
         <Col xs={4}>
           <AcceptedValuesField
             component={TextField}
-            name={PO_LONE_DETAILS_FIELDS_MAP.RUSH}
+            name={PO_LINE_DETAILS_FIELDS_MAP.RUSH}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.rush`} />}
             optionValue="value"
             optionLabel="label"
@@ -294,15 +281,14 @@ export const POLineDetails = ({
         <Col xs={4}>
           <AcceptedValuesField
             component={TextField}
-            name={PO_LONE_DETAILS_FIELDS_MAP.RECEIVING_WORKFLOW}
+            name={PO_LINE_DETAILS_FIELDS_MAP.RECEIVING_WORKFLOW}
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.receivingWorkflow`} />}
-            optionValue="label"
+            optionValue="value"
             optionLabel="label"
             wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}
             acceptedValuesList={receivingWorkflowOptions}
             parse={onReceivingWorkflowParse}
             format={onReceivingWorkflowFormat}
-            validation={validateReceivingWorkflow}
             required
           />
         </Col>
@@ -314,7 +300,7 @@ export const POLineDetails = ({
               <Field
                 component={TextArea}
                 label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.cancellationDescription`} />}
-                name={PO_LONE_DETAILS_FIELDS_MAP.CANCELLATION_DESCRIPTION}
+                name={PO_LINE_DETAILS_FIELDS_MAP.CANCELLATION_DESCRIPTION}
                 validate={[validation]}
               />
             )}
@@ -326,7 +312,7 @@ export const POLineDetails = ({
               <Field
                 component={TextArea}
                 label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.lineDescription`} />}
-                name={PO_LONE_DETAILS_FIELDS_MAP.LINE_DESCRIPTION}
+                name={PO_LINE_DETAILS_FIELDS_MAP.LINE_DESCRIPTION}
                 validate={[validation]}
               />
             )}

--- a/src/settings/MappingProfiles/detailsSections/view/OrderDetailsSection/POLineDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/view/OrderDetailsSection/POLineDetails.js
@@ -51,11 +51,15 @@ export const POLineDetails = ({ mappingDetails }) => {
 
   const receivingWorkflow = useMemo(
     () => {
-      if (checkinItemsValue === BOOLEAN_STRING_VALUES.TRUE) {
-        return formatMessage({ id: `${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.independent` });
+      if (checkinItemsValue === `"${BOOLEAN_STRING_VALUES.TRUE}"`) {
+        const independentLabel = formatMessage({ id: `${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.independent` });
+
+        return `"${independentLabel}"`;
       }
-      if (checkinItemsValue === BOOLEAN_STRING_VALUES.FALSE) {
-        return formatMessage({ id: `${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.synchronized` });
+      if (checkinItemsValue === `"${BOOLEAN_STRING_VALUES.FALSE}"`) {
+        const synchronizedLabel = formatMessage({ id: `${TRANSLATION_ID_PREFIX}.order.poLineDetails.field.synchronized` });
+
+        return `"${synchronizedLabel}"`;
       }
 
       return checkinItemsValue;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
To display the actual `PO lines limit` value from Order Settings on the view and create/edit screen. To send the `Receiving workflow` field value wrapped in quotes.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Wrap the `Receiving workflow` field value in quotes before sending to BE
- Fetch and display `PO lines limit` value from Order Settings

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1348

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
