### PR TITLE
UIDATIMP-1367: Order field mapping profile: Show the fund and code when default fund is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Empty Order type after switching to another FOLIO record type on existing order field mapping profile (UIDATIMP-1359)
 * Order field mapping profile: Update the list of product identifier types (UIDATIMP-1362)
 * "Something went wrong" error message appears after trying to reach JSON tab (UIDATIMP-1363)
+* Order field mapping profile: Show the fund and code when default fund is selected (UIDATIMP-1367)
 
 ## [5.3.10](https://github.com/folio-org/ui-data-import/tree/v5.3.10) (2022-12-05)
 

--- a/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/FundDistribution.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/FundDistribution.js
@@ -111,6 +111,7 @@ export const FundDistribution = ({
                     wrapperSourceLink: WRAPPER_SOURCE_LINKS.FUNDS,
                     wrapperSourcePath: 'funds'
                   }]}
+                  optionTemplate="**name** (**code**)"
                   setAcceptedValues={setReferenceTables}
                   acceptedValuesPath={getRepeatableAcceptedValuesPath(FUND_DISTRIBUTION_FIELDS_MAP.FUND_DISTRIBUTION, 0, index)}
                   okapi={okapi}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
For the Order field mapping profile's Fund field, when displaying the values in the dropdown list or in the field mapping field, the fund codes do not display - only the fund names. This applies to the Create/Edit screen and the View screen for the Order field mapping profile.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add `optionTemplate` to show the correct format of options.

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1367

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://user-images.githubusercontent.com/55138456/216642356-afce4948-205b-4f57-9e62-403878fd28f0.png)

![image](https://user-images.githubusercontent.com/55138456/216642264-2e52db30-6109-455d-828e-a6c30830fb73.png)
