### PR TITLE
UIDATIMP-1368: Order field mapping profile: Show the expense class and code when default expense class is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Empty Order type after switching to another FOLIO record type on existing order field mapping profile (UIDATIMP-1359)
 * Order field mapping profile: Update the list of product identifier types (UIDATIMP-1362)
 * "Something went wrong" error message appears after trying to reach JSON tab (UIDATIMP-1363)
+* Order field mapping profile: Show the expense class and code when default expense class is selected (UIDATIMP-1368)
 
 ## [5.3.10](https://github.com/folio-org/ui-data-import/tree/v5.3.10) (2022-12-05)
 

--- a/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/FundDistribution.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/FundDistribution.js
@@ -128,6 +128,7 @@ export const FundDistribution = ({
                     wrapperSourceLink: WRAPPER_SOURCE_LINKS.EXPENSE_CLASSES,
                     wrapperSourcePath: 'expenseClasses'
                   }]}
+                  optionTemplate="**name** (**code**)"
                   setAcceptedValues={setReferenceTables}
                   acceptedValuesPath={getRepeatableAcceptedValuesPath(FUND_DISTRIBUTION_FIELDS_MAP.FUND_DISTRIBUTION, 1, index)}
                   okapi={okapi}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
For the Order field mapping profile's Expense class field, when displaying the values in the dropdown list or in the field mapping field, the expense class codes do not display - only the expense class names. This applies to the Create/Edit screen and the View screen for the Order field mapping profile.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add `optionTemplate` to show the correct format of options.

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1368

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://user-images.githubusercontent.com/55138456/216644679-66af2412-bfb0-4103-a5cc-363fb2084aaa.png)

![image](https://user-images.githubusercontent.com/55138456/216644602-dd74c64f-7f9c-4f7a-a1af-e88c333eaef0.png)
