### PR TITLE
UIDATIMP-1369: "parentProfiles" and "childProfiles" properties are populated on profile update that causes to size-bloat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * "Something went wrong" error message appears after trying to reach JSON tab (UIDATIMP-1363)
 * Order field mapping profile: Show the fund and code when default fund is selected (UIDATIMP-1367)
 * Order field mapping profile: Show the expense class and code when default expense class is selected (UIDATIMP-1368)
+* "parentProfiles" and "childProfiles" properties are populated on profile update that causes to size-bloat (UIDATIMP-1369)
 
 ## [5.3.10](https://github.com/folio-org/ui-data-import/tree/v5.3.10) (2022-12-05)
 

--- a/src/settings/ActionProfiles/EditActionProfile/EditActionProfile.js
+++ b/src/settings/ActionProfiles/EditActionProfile/EditActionProfile.js
@@ -12,12 +12,16 @@ import { Preloader } from '@folio/stripes-data-transfer-components';
 
 import { ActionProfilesForm } from '../ActionProfilesForm';
 
-import { LAYER_TYPES } from '../../../utils';
+import {
+  LAYER_TYPES,
+  omitAssociatedProfiles,
+} from '../../../utils';
 
 const EditActionProfileComponent = ({
   resources: { actionProfile },
   fullWidthContainer,
   layerType,
+  onSubmit,
   ...routeProps
 }) => {
   const { formatMessage } = useIntl();
@@ -47,6 +51,7 @@ const EditActionProfileComponent = ({
     >
       <ActionProfilesForm
         {...routeProps}
+        onSubmit={omitAssociatedProfiles(onSubmit)}
         initialValues={initialValues}
         layerType={layerType}
       />
@@ -64,6 +69,7 @@ EditActionProfileComponent.manifest = Object.freeze({
 });
 
 EditActionProfileComponent.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
   resources: PropTypes.shape({ actionProfile: PropTypes.object }).isRequired,
   fullWidthContainer: PropTypes.instanceOf(Element),
   layerType: PropTypes.string,

--- a/src/settings/MappingProfiles/EditMappingProfile/EditMappingProfile.js
+++ b/src/settings/MappingProfiles/EditMappingProfile/EditMappingProfile.js
@@ -12,12 +12,16 @@ import { Preloader } from '@folio/stripes-data-transfer-components';
 
 import { MappingProfilesForm } from '../MappingProfilesForm';
 
-import { LAYER_TYPES } from '../../../utils';
+import {
+  LAYER_TYPES,
+  omitAssociatedProfiles,
+} from '../../../utils';
 
 const EditMappingProfileComponent = ({
   resources: { mappingProfile },
   fullWidthContainer,
   layerType,
+  onSubmit,
   ...routeProps
 }) => {
   const { formatMessage } = useIntl();
@@ -47,6 +51,7 @@ const EditMappingProfileComponent = ({
     >
       <MappingProfilesForm
         {...routeProps}
+        onSubmit={omitAssociatedProfiles(onSubmit)}
         initialValues={initialValues}
         layerType={layerType}
       />
@@ -65,6 +70,7 @@ EditMappingProfileComponent.manifest = Object.freeze({
 });
 
 EditMappingProfileComponent.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
   resources: PropTypes.shape({ mappingProfile: PropTypes.object }).isRequired,
   fullWidthContainer: PropTypes.instanceOf(Element),
   layerType: PropTypes.string,

--- a/src/utils/formUtils.js
+++ b/src/utils/formUtils.js
@@ -5,6 +5,7 @@ import {
   get,
   isEmpty,
   isEqual,
+  omit,
 } from 'lodash';
 
 import { FormattedDate } from '@folio/stripes/components';
@@ -174,4 +175,19 @@ export const handleProfileSave = (handleSubmit, resetForm, transitionToParams, p
     resetForm();
     transitionToParams({ _path: `${path}/view/${record.id}` });
   }
+};
+
+/**
+ * Normalize record on form submit - suppress "parentProfiles" and "childProfiles"
+ *
+ * @param {function} onSubmit
+ * @returns {function(*): *}
+ */
+export const omitAssociatedProfiles = onSubmit => record => {
+  const recordToEdit = {
+    ...record,
+    profile: omit(record.profile, ['parentProfiles', 'childProfiles']),
+  };
+
+  return onSubmit(recordToEdit);
 };


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
When updating action/mapping profile that is already linked with another profile the "parentProfiles" and "childProfiles" properties are sent populated with read-only data to the back-end, which causes profile to increase in size.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Omit "parentProfiles" and "childProfiles" properties on form submit

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1369

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
