### PR TITLE
UIDATIMP-1371: Order line field mapping: Fix organizations on edit screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * "Something went wrong" error message appears after trying to reach JSON tab (UIDATIMP-1363)
 * Order field mapping profile: Show the fund and code when default fund is selected (UIDATIMP-1367)
 * Order field mapping profile: Show the expense class and code when default expense class is selected (UIDATIMP-1368)
+* Order line field mapping: Fix organizations on edit screen (UIDATIMP-1371)
 
 ## [5.3.10](https://github.com/folio-org/ui-data-import/tree/v5.3.10) (2022-12-05)
 

--- a/src/settings/MappingProfiles/detailsSections/edit/MappingOrderDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/MappingOrderDetails.js
@@ -76,10 +76,10 @@ export const MappingOrderDetails = ({
   const vendorIdMatch = vendorFromDetails?.match(UUID_IN_QUOTES_PATTERN);
   const filledVendorId = vendorIdMatch ? vendorIdMatch[1] : null;
   const assignedToId = getFieldValueFromDetails(mappingDetails?.mappingFields, ASSIGNED_TO_FIELD);
-  const materialSupplierFromDetails = getFieldValueFromDetails(mappingDetails?.mappingFields, MATERIAL_SUPPLIER_FIELD);
+  const materialSupplierFromDetails = getFieldValueFromDetails(mappingDetails?.mappingFields, MATERIAL_SUPPLIER_FIELD, false);
   const materialSupplierMatch = materialSupplierFromDetails?.match(UUID_IN_QUOTES_PATTERN);
   const materialSupplierId = materialSupplierMatch ? materialSupplierMatch[1] : null;
-  const accessProviderFromDetails = getFieldValueFromDetails(mappingDetails?.mappingFields, ACCESS_PROVIDER_FIELD);
+  const accessProviderFromDetails = getFieldValueFromDetails(mappingDetails?.mappingFields, ACCESS_PROVIDER_FIELD, false);
   const accessProviderMatch = accessProviderFromDetails?.match(UUID_IN_QUOTES_PATTERN);
   const accessProviderId = accessProviderMatch ? accessProviderMatch[1] : null;
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
To correct the Material supplier and Access provider details in the Data Import field mapping Edit screen for Orders and Order line to display the organization name instead of UUID.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Do not trim quotes of field value to match the pattern

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1371

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
### Before
![image](https://user-images.githubusercontent.com/55138456/217643636-443668b6-99fa-4352-8a54-61f87fe5b580.png)

### After
![image](https://user-images.githubusercontent.com/55138456/217643687-5e6f0bf6-eacd-442b-bd71-e3efa3fc0981.png)

