### PR TITLE
UIDATIMP-1357: Add ability to go back to defaults in Data Import Field Mappings (Item, Holdings, Instance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Create the field mapping profile for Orders and Order Lines: View (UIDATIMP-1217)
 * Update the Action profile UI for Orders (UIDATIMP-1231)
 * Update the Action profile UI again: Create/Edit screen (UIDATIMP-1246)
+* Create hotlink from "Created" in DI Log Orders column to POL (UIDATIMP-1258)
 * Create the UI for the Orders Log info in the DI job log (UIDATIMP-1264)
 * Add required field asterisks & validation action to Order field mapping profile (UIDATIMP-1265)
 * Add required info icons to Order field mapping profile (UIDATIMP-1266)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Error after selecting order option on field mapping profile (UIDATIMP-1344)
 * Error after selecting order option on field mapping profile: Part 2 (UIDATIMP-1346)
 * Receiving value disappears from Order field mapping profile after default order line limit updated (UIDATIMP-1348)
+* Data Import Field Mappings (Item, Holdings, Instance) Inability to go back to defaults (UIDATIMP-1357)
 * Empty Order type after switching to another FOLIO record type on existing order field mapping profile (UIDATIMP-1359)
 * Order field mapping profile: Update the list of product identifier types (UIDATIMP-1362)
 * "Something went wrong" error message appears after trying to reach JSON tab (UIDATIMP-1363)

--- a/src/components/BooleanActionField/BooleanActionField.js
+++ b/src/components/BooleanActionField/BooleanActionField.js
@@ -15,6 +15,7 @@ export const BooleanActionField = ({
   name,
   label,
   placeholder,
+  onBooleanFieldChange,
   required,
   disabled,
 }) => {
@@ -28,6 +29,16 @@ export const BooleanActionField = ({
 
   const defaultPlaceholderId = 'ui-data-import.settings.mappingProfiles.map.administrativeData.field.selectCheckboxFieldMapping';
   const checkboxPlaceholder = placeholder || intl.formatMessage({ id: defaultPlaceholderId });
+  const defaultDataOption = { label: checkboxPlaceholder, value: '' };
+
+  const handleBooleanActionChange = e => {
+    e.preventDefault();
+    e.target.blur();
+
+    if (!e.target.value) {
+      onBooleanFieldChange(name, null);
+    }
+  };
 
   return (
     <Field
@@ -35,8 +46,8 @@ export const BooleanActionField = ({
       component={Select}
       name={name}
       label={label}
-      placeholder={checkboxPlaceholder}
-      dataOptions={dataOptions}
+      dataOptions={[defaultDataOption, ...dataOptions]}
+      onChange={handleBooleanActionChange}
       required={required}
       disabled={disabled}
     />
@@ -45,6 +56,7 @@ export const BooleanActionField = ({
 
 BooleanActionField.propTypes = {
   name: PropTypes.string.isRequired,
+  onBooleanFieldChange: PropTypes.func.isRequired,
   id: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   placeholder: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),

--- a/src/components/BooleanActionField/BooleanActionField.test.js
+++ b/src/components/BooleanActionField/BooleanActionField.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
@@ -10,12 +11,15 @@ import {
 
 import { BooleanActionField } from './BooleanActionField';
 
+const onBooleanFieldChangeMock = jest.fn();
+
 const renderBooleanActionField = ({ placeholder }) => {
   const component = () => (
     <BooleanActionField
       label="testLabel"
       name="testField"
       placeholder={placeholder}
+      onBooleanFieldChange={onBooleanFieldChangeMock}
     />
   );
 
@@ -23,6 +27,10 @@ const renderBooleanActionField = ({ placeholder }) => {
 };
 
 describe('Boolean action field component', () => {
+  afterEach(() => {
+    onBooleanFieldChangeMock.mockClear();
+  });
+
   describe('when a form has wrapped component', () => {
     it('then the wrapped component should be rendered', () => {
       expect(renderBooleanActionField({})).toBeDefined();
@@ -48,6 +56,17 @@ describe('Boolean action field component', () => {
       const { getByText } = renderBooleanActionField({ placeholder: 'testPlaceholder' });
 
       expect(getByText('testPlaceholder')).toBeDefined();
+    });
+  });
+
+  describe('when select default value', () => {
+    it('function for changing value should be called', () => {
+      const { container } = renderBooleanActionField({ placeholder: 'testPlaceholder' });
+      const selectElement = container.querySelector('[name="testField"]');
+
+      fireEvent.change(selectElement, { target: { value: 'testPlaceholder' } });
+
+      expect(onBooleanFieldChangeMock).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/RepeatableActionsField/RepeatableActionsField.js
+++ b/src/components/RepeatableActionsField/RepeatableActionsField.js
@@ -22,6 +22,8 @@ import {
   repeatableFieldActionShape,
 } from '../../utils';
 
+import { getInitialDetails } from '../../settings/MappingProfiles';
+
 import styles from './RepeatableActionsField.css';
 
 export const RepeatableActionsField = memo(({
@@ -36,6 +38,7 @@ export const RepeatableActionsField = memo(({
   actionToClearFields,
   subfieldsToClearPath,
   disabled,
+  recordType,
   children,
 }) => {
   const [isAddButtonDisabled, setIsAddButtonDisabled] = useState(false);
@@ -57,10 +60,16 @@ export const RepeatableActionsField = memo(({
   );
 
   const handleRepeatableActionChange = e => {
+    e.preventDefault();
     e.target.blur();
 
     if (e.target.value === actionToClearFields) {
       onRepeatableActionChange(subfieldsToClearPath || `profile.mappingDetails.mappingFields[${repeatableFieldIndex}].subfields`, []);
+    }
+
+    if (!e.target.value) {
+      const initialDetails = getInitialDetails(recordType, true).mappingFields[repeatableFieldIndex];
+      onRepeatableActionChange(`profile.mappingDetails.mappingFields[${repeatableFieldIndex}]`, initialDetails);
     }
   };
 
@@ -84,12 +93,11 @@ export const RepeatableActionsField = memo(({
         <WithTranslation
           wrapperLabel={wrapperPlaceholder}
         >
-          {placeholder => (
+          {label => (
             <Field
               name={wrapperFieldName}
               component={Select}
-              dataOptions={dataOptions}
-              placeholder={placeholder}
+              dataOptions={[{ label, value: '' }, ...dataOptions]}
               disabled={disabled}
               onChange={handleRepeatableActionChange}
               validate={[validateRepeatableActions]}
@@ -113,6 +121,7 @@ RepeatableActionsField.propTypes = {
   repeatableFieldIndex: PropTypes.number.isRequired,
   hasRepeatableFields: PropTypes.bool.isRequired,
   onRepeatableActionChange: PropTypes.func.isRequired,
+  recordType: PropTypes.string.isRequired,
   actions: PropTypes.arrayOf(repeatableFieldActionShape),
   actionToClearFields: PropTypes.string,
   subfieldsToClearPath: PropTypes.string,

--- a/src/components/RepeatableActionsField/RepeatableActionsField.test.js
+++ b/src/components/RepeatableActionsField/RepeatableActionsField.test.js
@@ -74,6 +74,7 @@ const renderRepeatableActionsField = ({
       actions={actions}
       actionToClearFields={actionToClearFields}
       subfieldsToClearPath={subfieldsToClearPath}
+      recordType="INSTANCE"
     >
       {props => childComponent(props)}
     </RepeatableActionsField>

--- a/src/components/RepeatableActionsField/RepeatableActionsField.test.js
+++ b/src/components/RepeatableActionsField/RepeatableActionsField.test.js
@@ -1,8 +1,5 @@
 import React from 'react';
-
 import { fireEvent } from '@testing-library/react';
-
-import { noop } from 'lodash';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
@@ -20,8 +17,10 @@ import {
 
 import { RepeatableActionsField } from './RepeatableActionsField';
 
+const onRepeatableActionChangeMock = jest.fn();
+
 const repeatableActionsFieldProps = {
-  wrapperFieldName: '',
+  wrapperFieldName: 'testName',
   legend: 'Repeatable Actions',
   disabled: false,
   wrapperPlaceholder: 'ui-data-import.settings.mappingProfiles.map.wrapper.repeatableActions',
@@ -31,7 +30,6 @@ const repeatableActionsFieldProps = {
   repeatableFieldIndex: 15,
   hasRepeatableFields: true,
   repeatableFieldAction: REPEATABLE_ACTIONS.EXTEND_EXISTING,
-  onRepeatableActionChange: noop,
 };
 
 const renderRepeatableActionsField = ({
@@ -42,7 +40,6 @@ const renderRepeatableActionsField = ({
   repeatableFieldAction,
   repeatableFieldIndex,
   hasRepeatableFields,
-  onRepeatableActionChange,
   actions,
   actionToClearFields,
   subfieldsToClearPath,
@@ -70,7 +67,7 @@ const renderRepeatableActionsField = ({
       repeatableFieldAction={repeatableFieldAction}
       repeatableFieldIndex={repeatableFieldIndex}
       hasRepeatableFields={hasRepeatableFields}
-      onRepeatableActionChange={onRepeatableActionChange}
+      onRepeatableActionChange={onRepeatableActionChangeMock}
       actions={actions}
       actionToClearFields={actionToClearFields}
       subfieldsToClearPath={subfieldsToClearPath}
@@ -84,6 +81,10 @@ const renderRepeatableActionsField = ({
 };
 
 describe('RepeatableActionsField component', () => {
+  afterEach(() => {
+    onRepeatableActionChangeMock.mockClear();
+  });
+
   it('should be rendered with child component', () => {
     const { getByText } = renderRepeatableActionsField(repeatableActionsFieldProps);
 
@@ -104,6 +105,17 @@ describe('RepeatableActionsField component', () => {
         fireEvent.change(selectRepeatableAction, { target: { value: 'DELETE_EXISTING' } });
         expect(addFieldButton).toBeDisabled();
       });
+    });
+  });
+
+  describe('when select default value', () => {
+    it('function for changing value should be called', () => {
+      const { container } = renderRepeatableActionsField(repeatableActionsFieldProps);
+      const selectElement = container.querySelector('[name="testName"]');
+
+      fireEvent.change(selectElement, { target: { value: 'Select action' } });
+
+      expect(onRepeatableActionChangeMock).toHaveBeenCalled();
     });
   });
 });

--- a/src/routes/JobSummary/components/RecordsTable.js
+++ b/src/routes/JobSummary/components/RecordsTable.js
@@ -217,7 +217,20 @@ export const RecordsTable = ({
 
       return getHotlinkCellFormatter(isHotlink, entityLabel, path, 'authority');
     },
-    orderStatus: ({ poLineActionStatus }) => getRecordActionStatusLabel(poLineActionStatus),
+    orderStatus: ({
+      poLineActionStatus,
+      sourceRecordId,
+    }) => {
+      const entityLabel = getRecordActionStatusLabel(poLineActionStatus);
+      const sourceRecord = jobLogRecords.find(item => item.sourceRecordId === sourceRecordId);
+      const orderLineId = sourceRecord?.relatedPoLineInfo.idList[0];
+      const path = `/orders/lines/view/${orderLineId}`;
+
+      const isPathCorrect = !!orderLineId;
+      const isHotlink = isPathCorrect && poLineActionStatus === RECORD_ACTION_STATUS.CREATED;
+
+      return getHotlinkCellFormatter(isHotlink, entityLabel, path, 'order');
+    },
     invoiceStatus: ({
       invoiceActionStatus,
       sourceRecordId,

--- a/src/routes/JobSummary/components/RecordsTable.test.js
+++ b/src/routes/JobSummary/components/RecordsTable.test.js
@@ -6,7 +6,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 import {
   buildMutator,
-  buildResources
+  buildResources,
 } from '@folio/stripes-data-transfer-components/test/helpers';
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
@@ -20,6 +20,7 @@ window.open.mockReturnValue({ focus: jest.fn() });
 
 const firstRecordJobExecutionId = faker.random.uuid();
 const sourceRecordsIds = [
+  faker.random.uuid(),
   faker.random.uuid(),
   faker.random.uuid(),
   faker.random.uuid(),
@@ -82,6 +83,14 @@ const jobLogEntriesResources = buildResources({
     sourceRecordId: sourceRecordsIds[5],
     sourceRecordOrder: '5',
     sourceRecordTitle: 'Test item 6',
+  }, {
+    sourceRecordActionStatus: 'CREATED',
+    sourceRecordType: 'MARC_BIBLIOGRAPHIC',
+    poLineActionStatus: 'CREATED',
+    jobExecutionId: faker.random.uuid(),
+    sourceRecordId: sourceRecordsIds[6],
+    sourceRecordOrder: '6',
+    sourceRecordTitle: 'Test item 7',
   }],
 });
 const jobLogResources = buildResources({
@@ -106,6 +115,10 @@ const jobLogResources = buildResources({
       actionStatus: 'CREATED',
       idList: [authorityId],
     },
+    relatedPoLineInfo: {
+      actionStatus: 'CREATED',
+      idList: [faker.random.uuid()],
+    },
   }, {
     sourceRecordId: sourceRecordsIds[1],
     sourceRecordOrder: '1',
@@ -125,6 +138,10 @@ const jobLogResources = buildResources({
     relatedAuthorityInfo: {
       actionStatus: 'UPDATED',
       idList: [authorityId],
+    },
+    relatedPoLineInfo: {
+      actionStatus: 'CREATED',
+      idList: [faker.random.uuid()],
     },
   }, {
     sourceRecordId: sourceRecordsIds[2],
@@ -146,6 +163,10 @@ const jobLogResources = buildResources({
       actionStatus: 'MULTIPLE',
       idList: [faker.random.uuid()],
     },
+    relatedPoLineInfo: {
+      actionStatus: 'CREATED',
+      idList: [faker.random.uuid()],
+    },
   }, {
     sourceRecordId: sourceRecordsIds[3],
     sourceRecordOrder: '3',
@@ -164,6 +185,34 @@ const jobLogResources = buildResources({
     },
     relatedAuthorityInfo: {
       actionStatus: 'DISCARDED',
+      idList: [faker.random.uuid()],
+    },
+    relatedPoLineInfo: {
+      actionStatus: 'CREATED',
+      idList: [faker.random.uuid()],
+    },
+  }, {
+    sourceRecordId: sourceRecordsIds[6],
+    sourceRecordOrder: '6',
+    sourceRecordTitle: 'Test item 7',
+    relatedInstanceInfo: {
+      actionStatus: 'DISCARDED',
+      idList: [faker.random.uuid()],
+    },
+    relatedHoldingsInfo: {
+      actionStatus: 'DISCARDED',
+      idList: [faker.random.uuid()],
+    },
+    relatedItemInfo: {
+      actionStatus: 'DISCARDED',
+      idList: [faker.random.uuid()],
+    },
+    relatedAuthorityInfo: {
+      actionStatus: 'DISCARDED',
+      idList: [faker.random.uuid()],
+    },
+    relatedPoLineInfo: {
+      actionStatus: 'CREATED',
       idList: [faker.random.uuid()],
     },
   }],

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/AdministrativeData.js
@@ -10,6 +10,7 @@ import {
   RepeatableField,
   TextField,
 } from '@folio/stripes/components';
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 
 import {
   BooleanActionField,
@@ -59,6 +60,7 @@ export const AdministrativeData = ({
           <BooleanActionField
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.discoverySuppress`} />}
             name={getBoolFieldName(0)}
+            onBooleanFieldChange={setReferenceTables}
           />
         </Col>
       </Row>
@@ -87,6 +89,7 @@ export const AdministrativeData = ({
             repeatableFieldIndex={2}
             hasRepeatableFields={!!formerIds.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.HOLDINGS.type}
           >
             {isDisabled => (
               <RepeatableField
@@ -151,6 +154,7 @@ export const AdministrativeData = ({
             repeatableFieldIndex={4}
             hasRepeatableFields={!!statisticalCodeIds.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.HOLDINGS.type}
           >
             {isDisabled => (
               <RepeatableField
@@ -205,6 +209,7 @@ export const AdministrativeData = ({
             repeatableFieldIndex={5}
             hasRepeatableFields={!!administrativeNotes.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.HOLDINGS.type}
           >
             {isDisabled => (
               <RepeatableField

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/ElectronicAccess.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/ElectronicAccess.js
@@ -10,6 +10,7 @@ import {
   RepeatableField,
   TextField,
 } from '@folio/stripes/components';
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 
 import {
   AcceptedValuesField,
@@ -56,6 +57,7 @@ export const ElectronicAccess = ({
             repeatableFieldIndex={23}
             hasRepeatableFields={!!electronicAccess.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.HOLDINGS.type}
           >
             {isDisabled => (
               <RepeatableField

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsDetails.js
@@ -10,6 +10,7 @@ import {
   RepeatableField,
   TextField,
 } from '@folio/stripes/components';
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 
 import {
   AcceptedValuesField,
@@ -78,6 +79,7 @@ export const HoldingsDetails = ({
             repeatableFieldIndex={16}
             hasRepeatableFields={!!holdingsStatements.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.HOLDINGS.type}
           >
             {isDisabled => (
               <RepeatableField
@@ -144,6 +146,7 @@ export const HoldingsDetails = ({
             repeatableFieldIndex={17}
             hasRepeatableFields={!!holdingsStatementsForSupplements.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.HOLDINGS.type}
           >
             {isDisabled => (
               <RepeatableField
@@ -210,6 +213,7 @@ export const HoldingsDetails = ({
             repeatableFieldIndex={18}
             hasRepeatableFields={!!holdingsStatementsForIndexes.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.HOLDINGS.type}
           >
             {isDisabled => (
               <RepeatableField

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsNotes.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/HoldingsNotes.js
@@ -10,6 +10,7 @@ import {
   RepeatableField,
   TextField,
 } from '@folio/stripes/components';
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 
 import {
   AcceptedValuesField,
@@ -58,6 +59,7 @@ export const HoldingsNotes = ({
             repeatableFieldIndex={22}
             hasRepeatableFields={!!notes.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.HOLDINGS.type}
           >
             {isDisabled => (
               <RepeatableField
@@ -107,6 +109,7 @@ export const HoldingsNotes = ({
                       <BooleanActionField
                         label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.staffOnly`} />}
                         name={getBoolSubfieldName(22, 2, index)}
+                        onBooleanFieldChange={setReferenceTables}
                         required
                       />
                     </Col>

--- a/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/ReceivingHistory.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/HoldingsDetailsSections/ReceivingHistory.js
@@ -10,6 +10,7 @@ import {
   RepeatableField,
   TextField,
 } from '@folio/stripes/components';
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 
 import {
   BooleanActionField,
@@ -49,6 +50,7 @@ export const ReceivingHistory = ({
             repeatableFieldIndex={24}
             hasRepeatableFields={!!receivingHistory.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.HOLDINGS.type}
           >
             {isDisabled => (
               <RepeatableField
@@ -66,6 +68,7 @@ export const ReceivingHistory = ({
                       <BooleanActionField
                         label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.publicDisplay`} />}
                         name={getBoolSubfieldName(24, 0, index)}
+                        onBooleanFieldChange={setReferenceTables}
                       />
                     </Col>
                     <Col xs={4}>

--- a/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/AdministrativeData.js
@@ -10,6 +10,7 @@ import {
   RepeatableField,
   TextField,
 } from '@folio/stripes/components';
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 
 import {
   BooleanActionField,
@@ -65,6 +66,7 @@ export const AdministrativeData = ({
           <BooleanActionField
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.discoverySuppress`} />}
             name={getBoolFieldName(0)}
+            onBooleanFieldChange={setReferenceTables}
           />
         </Col>
         <Col
@@ -74,6 +76,7 @@ export const AdministrativeData = ({
           <BooleanActionField
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.staffSuppress`} />}
             name={getBoolFieldName(1)}
+            onBooleanFieldChange={setReferenceTables}
           />
         </Col>
         <Col
@@ -83,6 +86,7 @@ export const AdministrativeData = ({
           <BooleanActionField
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.previouslyHeld`} />}
             name={getBoolFieldName(2)}
+            onBooleanFieldChange={setReferenceTables}
           />
         </Col>
       </Row>
@@ -172,6 +176,7 @@ export const AdministrativeData = ({
             repeatableFieldIndex={8}
             hasRepeatableFields={!!statisticalCodes.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.INSTANCE.type}
           >
             {isDisabled => (
               <RepeatableField
@@ -226,6 +231,7 @@ export const AdministrativeData = ({
             repeatableFieldIndex={9}
             hasRepeatableFields={!!administrativeNotes.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.INSTANCE.type}
           >
             {isDisabled => (
               <RepeatableField

--- a/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/Contributor.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/Contributor.js
@@ -21,7 +21,10 @@ import {
 import { TRANSLATION_ID_PREFIX } from '../../constants';
 import { mappingProfileSubfieldShape } from '../../../../../utils';
 
-export const Contributor = ({ contributors }) => {
+export const Contributor = ({
+  contributors,
+  setReferenceTables,
+}) => {
   return (
     <Accordion
       id="contributors"
@@ -79,6 +82,7 @@ export const Contributor = ({ contributors }) => {
                   <BooleanActionField
                     label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.instance.contributors.field.primary`} />}
                     name={getBoolSubfieldName(17, 4, index)}
+                    onBooleanFieldChange={setReferenceTables}
                     disabled
                   />
                 </Col>
@@ -91,4 +95,7 @@ export const Contributor = ({ contributors }) => {
   );
 };
 
-Contributor.propTypes = { contributors: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired };
+Contributor.propTypes = {
+  contributors: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
+  setReferenceTables: PropTypes.func.isRequired,
+};

--- a/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/DescriptiveData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/DescriptiveData.js
@@ -11,6 +11,7 @@ import {
   RepeatableField,
   TextField,
 } from '@folio/stripes/components';
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 
 import {
   AcceptedValuesField,
@@ -183,6 +184,7 @@ export const DescriptiveData = ({
             repeatableFieldIndex={22}
             hasRepeatableFields={!!natureOfContentTermIds.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.INSTANCE.type}
           >
             {isDisabled => (
               <RepeatableField

--- a/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/InstanceNotes.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/InstanceNotes.js
@@ -21,7 +21,10 @@ import {
 import { TRANSLATION_ID_PREFIX } from '../../constants';
 import { mappingProfileSubfieldShape } from '../../../../../utils';
 
-export const InstanceNotes = ({ notes }) => {
+export const InstanceNotes = ({
+  notes,
+  setReferenceTables,
+}) => {
   return (
     <Accordion
       id="instance-notes"
@@ -63,6 +66,7 @@ export const InstanceNotes = ({ notes }) => {
                   <BooleanActionField
                     label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.staffOnly`} />}
                     name={getBoolSubfieldName(27, 2, index)}
+                    onBooleanFieldChange={setReferenceTables}
                     disabled
                   />
                 </Col>
@@ -75,4 +79,7 @@ export const InstanceNotes = ({ notes }) => {
   );
 };
 
-InstanceNotes.propTypes = { notes: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired };
+InstanceNotes.propTypes = {
+  notes: PropTypes.arrayOf(mappingProfileSubfieldShape).isRequired,
+  setReferenceTables: PropTypes.func.isRequired,
+};

--- a/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/InstanceRelationship.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/InstanceRelationship.js
@@ -10,6 +10,7 @@ import {
   RepeatableField,
   TextField,
 } from '@folio/stripes/components';
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 
 import {
   RepeatableActionsField,
@@ -58,6 +59,7 @@ export const InstanceRelationship = ({
             repeatableFieldIndex={31}
             hasRepeatableFields={!!parentInstances.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.INSTANCE.type}
           >
             {isDisabled => (
               <RepeatableField
@@ -120,6 +122,7 @@ export const InstanceRelationship = ({
             repeatableFieldIndex={32}
             hasRepeatableFields={!!childInstances.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.INSTANCE.type}
           >
             {isDisabled => (
               <RepeatableField

--- a/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/TitleData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InstanceDetailsSections/TitleData.js
@@ -11,6 +11,7 @@ import {
   RepeatableField,
   TextField,
 } from '@folio/stripes/components';
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 
 import { RepeatableActionsField } from '../../../../../components';
 
@@ -141,6 +142,7 @@ export const TitleData = ({
             repeatableFieldIndex={14}
             hasRepeatableFields={!!precedingTitles.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.INSTANCE.type}
             disabled
           >
             {() => (
@@ -203,6 +205,7 @@ export const TitleData = ({
             repeatableFieldIndex={15}
             hasRepeatableFields={!!succeedingTitles.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.INSTANCE.type}
             disabled
           >
             {() => (

--- a/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceLineFundDistribution.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/InvoiceDetailSection/InvoiceLineFundDistribution.js
@@ -12,6 +12,7 @@ import {
   TextField,
 } from '@folio/stripes/components';
 import { TypeToggle } from '@folio/stripes-acq-components';
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 
 import {
   AcceptedValuesField,
@@ -80,6 +81,7 @@ export const InvoiceLineFundDistribution = ({
             actions={MAPPING_FUND_DISTRIBUTION_FIELD_SOURCES}
             actionToClearFields={FUND_DISTRIBUTION_SOURCE.USE_FUND_DISTRIBUTION_FROM_POL}
             subfieldsToClearPath={getInnerSubfieldsPath(26, 0, 14)}
+            recordType={FOLIO_RECORD_TYPES.INVOICE.type}
           >
             {isDisabled => (
               <RepeatableField

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/AdministrativeData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/AdministrativeData.js
@@ -11,6 +11,7 @@ import {
   TextField,
 } from '@folio/stripes/components';
 
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 import {
   BooleanActionField,
   AcceptedValuesField,
@@ -57,6 +58,7 @@ export const AdministrativeData = ({
         >
           <BooleanActionField
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.administrativeData.field.discoverySuppress`} />}
+            onBooleanFieldChange={setReferenceTables}
             name={getBoolFieldName(0)}
           />
         </Col>
@@ -131,6 +133,7 @@ export const AdministrativeData = ({
             repeatableFieldIndex={5}
             hasRepeatableFields={!!formerIds.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.ITEM.type}
           >
             {isDisabled => (
               <RepeatableField
@@ -173,6 +176,7 @@ export const AdministrativeData = ({
             repeatableFieldIndex={6}
             hasRepeatableFields={!!statisticalCodeIds.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.ITEM.type}
           >
             {isDisabled => (
               <RepeatableField
@@ -227,6 +231,7 @@ export const AdministrativeData = ({
             repeatableFieldIndex={7}
             hasRepeatableFields={!!administrativeNotes.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.ITEM.type}
           >
             {isDisabled => (
               <RepeatableField

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/ElectronicAccess.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/ElectronicAccess.js
@@ -10,6 +10,7 @@ import {
   TextField,
   RepeatableField,
 } from '@folio/stripes/components';
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 
 import {
   AcceptedValuesField,
@@ -56,6 +57,7 @@ export const ElectronicAccess = ({
             repeatableFieldIndex={32}
             hasRepeatableFields={!!electronicAccess.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.ITEM.type}
           >
             {isDisabled => (
               <RepeatableField

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/EnumerationData.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/EnumerationData.js
@@ -11,6 +11,7 @@ import {
   RepeatableField,
 } from '@folio/stripes/components';
 
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 import {
   RepeatableActionsField,
   WithValidation,
@@ -98,6 +99,7 @@ export const EnumerationData = ({
             repeatableFieldIndex={19}
             hasRepeatableFields={!!yearCaption.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.ITEM.type}
           >
             {isDisabled => (
               <RepeatableField

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/ItemNotes.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/ItemNotes.js
@@ -11,6 +11,7 @@ import {
   RepeatableField,
 } from '@folio/stripes/components';
 
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 import {
   AcceptedValuesField,
   BooleanActionField,
@@ -58,6 +59,7 @@ export const ItemNotes = ({
             repeatableFieldIndex={25}
             hasRepeatableFields={!!notes.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.ITEM.type}
           >
             {isDisabled => (
               <RepeatableField
@@ -107,6 +109,7 @@ export const ItemNotes = ({
                       <BooleanActionField
                         label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.staffOnly`} />}
                         name={getBoolSubfieldName(25, 2, index)}
+                        onBooleanFieldChange={setReferenceTables}
                         required
                       />
                     </Col>

--- a/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/LoanAndAvailability.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/ItemDetailSection/LoanAndAvailability.js
@@ -14,6 +14,7 @@ import {
   RepeatableField,
 } from '@folio/stripes/components';
 
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 import {
   AcceptedValuesField,
   BooleanActionField,
@@ -163,6 +164,7 @@ export const LoanAndAvailability = ({
             repeatableFieldIndex={29}
             hasRepeatableFields={!!circulationNotes.length}
             onRepeatableActionChange={setReferenceTables}
+            recordType={FOLIO_RECORD_TYPES.ITEM.type}
           >
             {isDisabled => (
               <RepeatableField
@@ -210,6 +212,7 @@ export const LoanAndAvailability = ({
                       <BooleanActionField
                         label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.field.notes.staffOnly`} />}
                         name={getBoolSubfieldName(29, 2, index)}
+                        onBooleanFieldChange={setReferenceTables}
                         required
                       />
                     </Col>

--- a/src/settings/MappingProfiles/detailsSections/edit/MappingInstanceDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/MappingInstanceDetails.js
@@ -82,6 +82,7 @@ export const MappingInstanceDetails = ({
         />
         <Contributor
           contributors={contributors}
+          setReferenceTables={setReferenceTables}
         />
         <DescriptiveData
           publications={publications}
@@ -99,6 +100,7 @@ export const MappingInstanceDetails = ({
         />
         <InstanceNotes
           notes={notes}
+          setReferenceTables={setReferenceTables}
         />
         <ElectronicAccess
           electronicAccess={electronicAccess}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
*  For field mappings for the item, holdings, and instance, for the suppress from discovery, staff suppress and previously held for the instance, and any drop down that has "Delete all existing values", once this is selected, it is impossible to go back to the default. This is especially a problem when you duplicate a field mapping or just need to mistakenly selected something and need to go back to the default.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* In `BooleanActionField ` component when select default value, set `null` for the `booleanFieldAction` field
* In `RepeatableActionsField` component when select default value, set initial values for selected field

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
[UIDATIMP-1357](https://issues.folio.org/browse/UIDATIMP-1357)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://user-images.githubusercontent.com/85172747/217835756-16a2cc07-7bcf-4887-bd2a-4b7a69d62b5d.mp4

