### PR TITLE
UIDATIMP-1397: Add info icon to the Purchase order status field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Data Import Action/Field mapping profiles in modal window are not in alpha order by default on Create screen (UIDATIMP-1390)
 * Field mapping profile Invoice: enabled prop set to false when the value exists for Accounting code field (UIDATIMP-1392)
 * Order field mapping profile: Make Purchase order status a required field (UIDATIMP-1396)
+* Order field mapping profile: Add info icon to the Purchase order status fieldPurchase order status a required field (UIDATIMP-1397)
 * Order field mapping profile: Adjust text for info icon for Physical resource Create inventory field (UIDATIMP-1398)
 * Order field mapping profile: Adjust text for info icon for E-resources Create inventory field (UIDATIMP-1399)
 

--- a/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/OrderInformation.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/OrderInformation.js
@@ -39,6 +39,7 @@ import {
   getSubfieldName,
   onAdd,
   onRemove,
+  renderFieldLabelWithInfo,
 } from '../../utils';
 import {
   DEFAULT_PO_LINES_LIMIT_VALUE,
@@ -109,6 +110,11 @@ const OrderInformationComponent = ({
         setReferenceTables(ORDER_INFO_FIELDS_MAP.PO_LINES_LIMIT, `"${purchaseOrderLinesLimitValue}"`);
       });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const purchaseOrderStatusLabel = renderFieldLabelWithInfo(
+    `${TRANSLATION_ID_PREFIX}.order.orderInformation.field.purchaseOrderStatus`,
+    `${TRANSLATION_ID_PREFIX}.order.orderInformation.field.purchaseOrderStatus.info`,
+  );
 
   const isApprovalRequiredValue = useMemo(
     () => {
@@ -200,7 +206,7 @@ const OrderInformationComponent = ({
           <AcceptedValuesField
             component={TextField}
             name={ORDER_INFO_FIELDS_MAP.PO_STATUS}
-            label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.orderInformation.field.purchaseOrderStatus`} />}
+            label={purchaseOrderStatusLabel}
             optionValue="value"
             optionLabel="label"
             wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}

--- a/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/tests/OrderInformation.test.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/tests/OrderInformation.test.js
@@ -18,6 +18,11 @@ import { OrderInformation } from '../OrderInformation';
 
 import { BOOLEAN_ACTIONS } from '../../../../../../utils';
 
+jest.mock('@folio/stripes/components', () => ({
+  ...jest.requireActual('@folio/stripes/components'),
+  InfoPopover: () => <span>InfoPopover</span>,
+}));
+
 const setReferenceTablesMock = jest.fn();
 
 const okapiProp = {
@@ -138,6 +143,12 @@ describe('OrderInformation', () => {
     expect(within(queryByText('Purchase order status')).getByText(/\*/i)).toBeDefined();
     expect(within(queryByText('Vendor')).getByText(/\*/i)).toBeDefined();
     expect(within(queryByText('Order type')).getByText(/\*/i)).toBeDefined();
+  });
+
+  it('should render info icons for the particular fields', () => {
+    const { queryByText } = renderOrderInformation();
+
+    expect(within(queryByText('Purchase order status')).getByText(/InfoPopover/i)).toBeDefined();
   });
 
   describe('should render validation error message when "Override purchase order lines limit setting" field value', () => {

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -752,6 +752,7 @@
   "settings.mappingProfiles.map.order": "Order",
   "settings.mappingProfiles.map.order.orderInformation.section": "Order information",
   "settings.mappingProfiles.map.order.orderInformation.field.purchaseOrderStatus": "Purchase order status",
+  "settings.mappingProfiles.map.order.orderInformation.field.purchaseOrderStatus.info": "When Purchase order status is Pending, do not include any Inventory actions in the job profile. When Purchase order status is Open, include the desired Inventory actions in the job profile, preceded by the Create orders action",
   "settings.mappingProfiles.map.order.orderInformation.field.pending": "Pending",
   "settings.mappingProfiles.map.order.orderInformation.field.open": "Open",
   "settings.mappingProfiles.map.order.orderInformation.field.approved": "Approved",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* The behavior of the PO status field and Inventory interactions can be confusing. Add an information icon that helps to explain the behavior

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Added `InfoPopover` to the label with the defined text

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
[UIDATIMP-1397](https://issues.folio.org/browse/UIDATIMP-1397)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
### Before
![image](https://user-images.githubusercontent.com/85172747/224310410-be298cdd-dcd5-4e88-a3a6-06d2107bfa11.png)

### After
![image](https://user-images.githubusercontent.com/85172747/224310500-b0781211-7901-4b19-b233-07c1196213f0.png)

