### PR TITLE
UIDATIMP-1417: Order field mapping profile: Inactivate Locations and Material Types fields when Order status is Open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Features added:
 * Add accessibility testing to automated tests in ui-data-import (UIDATIMP-1372)
 
+## **6.0.3** (in progress)
+
+### Bugs fixed:
+* Order field mapping profile: Inactivate Locations and Material Types fields when Order status is Open (UIDATIMP-1417)
+
 ## [6.0.2](https://github.com/folio-org/ui-data-import/tree/v6.0.2) (2023-03-24)
 
 ### Bugs fixed:

--- a/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/EResourcesDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/EResourcesDetails.js
@@ -78,7 +78,10 @@ export const EResourcesDetails = ({
 
   useEffect(() => {
     if (dismissCreateInventory) {
-      clearFieldValue({ paths: [E_RESOURCES_DETAILS_FIELDS_MAP.CREATE_INVENTORY], setReferenceTables });
+      clearFieldValue({
+        paths: [E_RESOURCES_DETAILS_FIELDS_MAP.CREATE_INVENTORY, E_RESOURCES_DETAILS_FIELDS_MAP.MATERIAL_TYPE],
+        setReferenceTables,
+      });
     }
   }, [dismissCreateInventory]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -194,7 +197,7 @@ export const EResourcesDetails = ({
             setAcceptedValues={setReferenceTables}
             acceptedValuesPath={getAcceptedValuesPath(MATERIAL_TYPE_INDEX)}
             okapi={okapi}
-            disabled={dismissElectronicDetails}
+            disabled={dismissElectronicDetails || dismissCreateInventory}
           />
         </Col>
         <Col xs={3}>

--- a/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/Location.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/Location.js
@@ -28,6 +28,7 @@ import {
   WRAPPER_SOURCE_LINKS,
 } from '../../constants';
 import {
+  clearFieldValue,
   clearSubfieldValue,
   getRepeatableAcceptedValuesPath,
   getRepeatableFieldName,
@@ -50,20 +51,30 @@ export const Location = ({
   setReferenceTables,
   okapi,
 }) => {
+  const LOCATIONS_INDEX = 57;
   const LOCATION_FIELDS_MAP = {
-    LOCATIONS: 57,
-    NAME: index => getSubfieldName(LOCATION_FIELDS_MAP.LOCATIONS, 0, index),
-    QUANTITY_PHYSICAL: index => getSubfieldName(LOCATION_FIELDS_MAP.LOCATIONS, 1, index),
-    QUANTITY_ELECTRONIC: index => getSubfieldName(LOCATION_FIELDS_MAP.LOCATIONS, 2, index),
+    NAME: index => getSubfieldName(LOCATIONS_INDEX, 0, index),
+    QUANTITY_PHYSICAL: index => getSubfieldName(LOCATIONS_INDEX, 1, index),
+    QUANTITY_ELECTRONIC: index => getSubfieldName(LOCATIONS_INDEX, 2, index),
   };
 
   const [locations] = useFieldMappingRefValues([LOCATIONS_FIELD]);
-  const { dismissPhysicalDetails, dismissElectronicDetails } = useDisabledOrderFields();
+  const { dismissCreateInventory, dismissPhysicalDetails, dismissElectronicDetails } = useDisabledOrderFields();
+
+  useEffect(() => {
+    if (dismissCreateInventory) {
+      clearFieldValue({
+        paths: [`profile.mappingDetails.mappingFields[${LOCATIONS_INDEX}].subfields`],
+        setReferenceTables,
+        isSubfield: true,
+      });
+    }
+  }, [dismissCreateInventory]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (dismissPhysicalDetails) {
       clearSubfieldValue({
-        mappingFieldIndex: LOCATION_FIELDS_MAP.LOCATIONS,
+        mappingFieldIndex: LOCATIONS_INDEX,
         setReferenceTables,
         subfields: locations,
         subfieldName: QUANTITY_PHYSICAL_FIELD,
@@ -74,7 +85,7 @@ export const Location = ({
   useEffect(() => {
     if (dismissElectronicDetails) {
       clearSubfieldValue({
-        mappingFieldIndex: LOCATION_FIELDS_MAP.LOCATIONS,
+        mappingFieldIndex: LOCATIONS_INDEX,
         setReferenceTables,
         subfields: locations,
         subfieldName: QUANTITY_ELECTRONIC_FIELD,
@@ -103,9 +114,9 @@ export const Location = ({
         handleRepeatableFieldAndActionAdd(repeatableFieldActionPath, fieldsPath, refTable, setReferenceTables, isFirstSubfield);
       };
 
-      return onAdd(locations, 'locations', LOCATION_FIELDS_MAP.LOCATIONS, initialFields, onLocationAdd, 'order');
+      return onAdd(locations, 'locations', LOCATIONS_INDEX, initialFields, onLocationAdd, 'order');
     },
-    [LOCATION_FIELDS_MAP.LOCATIONS, initialFields, locations, setReferenceTables],
+    [LOCATIONS_INDEX, initialFields, locations, setReferenceTables],
   );
 
   const handleLocationClean = useCallback(
@@ -116,9 +127,9 @@ export const Location = ({
         handleRepeatableFieldAndActionClean(repeatableFieldActionPath, fieldsPath, refTable, setReferenceTables, isLastSubfield);
       };
 
-      return onRemove(index, locations, LOCATION_FIELDS_MAP.LOCATIONS, onLocationClean, 'order');
+      return onRemove(index, locations, LOCATIONS_INDEX, onLocationClean, 'order');
     },
-    [LOCATION_FIELDS_MAP.LOCATIONS, locations, setReferenceTables],
+    [LOCATIONS_INDEX, locations, setReferenceTables],
   );
 
   return (
@@ -131,6 +142,7 @@ export const Location = ({
         addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.location.field.locations.addLabel`} />}
         onAdd={handleLocationAdd}
         onRemove={handleLocationClean}
+        canAdd={!dismissCreateInventory}
         renderField={(field, index) => {
           return (
             <Row left="xs">
@@ -147,7 +159,7 @@ export const Location = ({
                     wrapperSourcePath: 'locations'
                   }]}
                   setAcceptedValues={setReferenceTables}
-                  acceptedValuesPath={getRepeatableAcceptedValuesPath(LOCATION_FIELDS_MAP.LOCATIONS, 0, index)}
+                  acceptedValuesPath={getRepeatableAcceptedValuesPath(LOCATIONS_INDEX, 0, index)}
                   optionTemplate="**name** (**code**)"
                   okapi={okapi}
                 />

--- a/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/tests/PhysicalResourceDetails.test.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/tests/PhysicalResourceDetails.test.js
@@ -33,6 +33,10 @@ jest.mock('../../../hooks', () => ({
       value: '',
     }],
   }]],
+  useDisabledOrderFields: () => ({
+    dismissCreateInventory: false,
+    dismissPhysicalDetails: false,
+  }),
 }));
 
 const setReferenceTablesMock = jest.fn();


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
If the Order status in the field mapping profile is Open, the Holdings and Item creation will be controlled by the Import job profile, rather than the Create inventory fields of the POL. Inactivate Locations and Material Type fields, and then the system will automatically populate them appropriately, based on the details of mapping profiles included in the job profile.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Disable Locations repeatable fields and Material type fields when PO status field value is "Open"

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1417

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![chrome_GBUZFhLKrf](https://user-images.githubusercontent.com/55138456/227874089-bea7bee4-72ac-4864-a41b-30effcb4c5d3.gif)
