### PR TITLE
UIDATIMP-1405: Order field mapping profile: Fix the View UI for Discount Currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Features added:
 * Add accessibility testing to automated tests in ui-data-import (UIDATIMP-1372)
 
+## **6.0.3** (in progress)
+
+### Bugs fixed:
+* Order field mapping profile: Fix the View UI for Discount Currency (UIDATIMP-1405)
+
 ## [6.0.2](https://github.com/folio-org/ui-data-import/tree/v6.0.2) (2023-03-24)
 
 ### Bugs fixed:

--- a/src/settings/MappingProfiles/detailsSections/utils.js
+++ b/src/settings/MappingProfiles/detailsSections/utils.js
@@ -234,12 +234,12 @@ export const getAccountingNumberOptions = vendor => {
   }));
 };
 
-export const renderAmountValue = (amounValue, amountType, currency) => {
+export const renderAmountValue = (amountValue, amountType, currency) => {
   const amountSymbol = amountType === 'percentage' ?
     <FormattedMessage id="stripes-acq-components.fundDistribution.type.sign.percent" /> :
     <CurrencySymbol currency={currency} />;
 
-  return <> {amounValue}{amountSymbol} </>;
+  return <> {amountValue}{amountSymbol} </>;
 };
 
 export const renderCheckbox = (labelPathId, fieldValue) => (

--- a/src/settings/MappingProfiles/detailsSections/view/OrderDetailsSection/CostDetails.js
+++ b/src/settings/MappingProfiles/detailsSections/view/OrderDetailsSection/CostDetails.js
@@ -31,6 +31,8 @@ export const CostDetails = ({ mappingDetails }) => {
   const discount = getFieldValue(mappingDetails, 'discount', 'value');
   const discountType = getFieldValue(mappingDetails, 'discountType', 'value');
 
+  const trimmedCurrencyValue = currency?.replace(/['"]+/g, '');
+
   const useExchangeRateCheckbox = renderCheckbox('order.costDetails.useExchangeRate', exchangeRate ? BOOLEAN_ACTIONS.ALL_TRUE : false);
 
   return (
@@ -121,7 +123,7 @@ export const CostDetails = ({ mappingDetails }) => {
         >
           <KeyValue
             label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.costDetails.discount`} />}
-            value={renderAmountValue(discount, discountType)}
+            value={renderAmountValue(discount, discountType, trimmedCurrencyValue)}
           />
         </Col>
       </Row>


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
If an Order field mapping profile is created with a discount indicating currency instead of percentage, the user sees $ on the View screen, no matter which currency is indicated.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Pass `currency` arg to the `renderAmountValue` func to render currency symbol next to `Discount` value

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1405

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://user-images.githubusercontent.com/55138456/227974005-9d74f6d7-cd50-4ddf-9a5e-ba775034ac32.png)
