### PR TITLE
UIDATIMP-1404: Order field mapping profile: Fix the View UI for Fund value % and Currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Features added:
 * Add accessibility testing to automated tests in ui-data-import (UIDATIMP-1372)
 
+## **6.0.3** (in progress)
+
+### Bugs fixed:
+* Order field mapping profile: Fix the View UI for Fund value % and Currency (UIDATIMP-1404)
+
 ## [6.0.2](https://github.com/folio-org/ui-data-import/tree/v6.0.2) (2023-03-24)
 
 ### Bugs fixed:

--- a/src/settings/MappingProfiles/detailsSections/view/OrderDetailsSection/FundDistribution.js
+++ b/src/settings/MappingProfiles/detailsSections/view/OrderDetailsSection/FundDistribution.js
@@ -13,6 +13,7 @@ import { ViewRepeatableField } from '../ViewRepeatableField';
 
 import {
   getFieldValue,
+  getFieldValueFromDetails,
   renderAmountValue,
   transformSubfieldsData,
 } from '../../utils';
@@ -20,7 +21,10 @@ import {
   TRANSLATION_ID_PREFIX,
   FUND_DISTRIBUTION_VISIBLE_COLUMNS,
 } from '../../constants';
-import { mappingProfileFieldShape } from '../../../../../utils';
+import {
+  CURRENCY_FIELD,
+  mappingProfileFieldShape,
+} from '../../../../../utils';
 
 export const FundDistribution = ({ mappingDetails }) => {
   const {
@@ -28,6 +32,8 @@ export const FundDistribution = ({ mappingDetails }) => {
     EXPENSE_CLASS_ID,
     VALUE,
   } = FUND_DISTRIBUTION_VISIBLE_COLUMNS;
+
+  const currency = getFieldValueFromDetails(mappingDetails, CURRENCY_FIELD, true);
 
   const noValueElement = <NoValue />;
 
@@ -55,7 +61,7 @@ export const FundDistribution = ({ mappingDetails }) => {
     fundId: distribution => distribution?.fundId || noValueElement,
     expenseClassId: distribution => distribution?.expenseClassId || noValueElement,
     value: distribution => (
-      distribution.value ? renderAmountValue(distribution.value, distribution.distributionType) : noValueElement
+      distribution.value ? renderAmountValue(distribution.value, distribution.distributionType, currency) : noValueElement
     ),
   };
 
@@ -69,6 +75,10 @@ export const FundDistribution = ({ mappingDetails }) => {
     },
     {
       field: 'value',
+      key: 'value',
+    },
+    {
+      field: 'distributionType',
       key: 'value',
     },
   ];


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
If an Order field mapping profile is created with a fund code section, the user sees $ next to the value, no matter which currency was selected, and whether % or currency was selected.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Pass `currency` arg to `renderAmountValue` func to render currency symbol next to `Value`
- Add `distributionType` to repeatable fields map

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1404

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://user-images.githubusercontent.com/55138456/227978144-c99a61ad-2b74-4c77-bdd0-8e3169ed89c4.png)
