### PR TITLE
UIDATIMP-1422: Mock `react-virtualized-auto-sizer` module for unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Features added:
 * Add accessibility testing to automated tests in ui-data-import (UIDATIMP-1372)
 
+## **6.0.3** (in progress)
+
+### Bugs fixed:
+* Mock `react-virtualized-auto-sizer` module for unit tests (UIDATIMP-1422)
+
 ## [6.0.2](https://github.com/folio-org/ui-data-import/tree/v6.0.2) (2023-03-24)
 
 ### Bugs fixed:

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -1,6 +1,7 @@
 import './currencyData.mock';
 import './documentCreateRange.mock';
 import './matchMedia.mock';
+import './reactVirtializedAutoSizer.mock';
 import './stripesConfig.mock';
 import './stripesIcon.mock';
 import './stripesCore.mock';

--- a/test/jest/__mock__/reactVirtializedAutoSizer.mock.js
+++ b/test/jest/__mock__/reactVirtializedAutoSizer.mock.js
@@ -1,0 +1,1 @@
+jest.mock('react-virtualized-auto-sizer', () => ({ children }) => children({ height: 500, width: 500 }));


### PR DESCRIPTION
A bunch of Jest unit tests started to fail during the build on Github so PRs cannot be merged.
After an investigation was figured out that `react-virtualized-auto-sizer` module should be mocked for all tests.

https://issues.folio.org/browse/UIDATIMP-1422