### PR TITLE
UIDATIMP-1429: Activate "Location" field for Open Order field mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Order field mapping profile: Disable Organization lookup-up when Access provider field disabled (UIDATIMP-1418)
 * Order field mapping profile: Cannot save the profile when switching between Order formats (UIDATIMP-1419)
 * Mock `react-virtualized-auto-sizer` module for unit tests (UIDATIMP-1422)
+* Activate "Location" field for Open Order field mapping (UIDATIMP-1429)
 
 ## [6.0.2](https://github.com/folio-org/ui-data-import/tree/v6.0.2) (2023-03-24)
 

--- a/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/Location.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/Location.js
@@ -24,12 +24,10 @@ import {
 } from '../../hooks';
 
 import {
-  FIELD_NAME_PREFIX,
   TRANSLATION_ID_PREFIX,
   WRAPPER_SOURCE_LINKS,
 } from '../../constants';
 import {
-  clearFieldValue,
   clearSubfieldValue,
   getRepeatableAcceptedValuesPath,
   getRepeatableFieldName,
@@ -60,17 +58,7 @@ export const Location = ({
   };
 
   const [locations] = useFieldMappingRefValues([LOCATIONS_FIELD]);
-  const { dismissCreateInventory, dismissPhysicalDetails, dismissElectronicDetails } = useDisabledOrderFields();
-
-  useEffect(() => {
-    if (dismissCreateInventory) {
-      clearFieldValue({
-        paths: [`${FIELD_NAME_PREFIX}[${LOCATIONS_INDEX}]`],
-        setReferenceTables,
-        isSubfield: true,
-      });
-    }
-  }, [dismissCreateInventory]); // eslint-disable-line react-hooks/exhaustive-deps
+  const { dismissPhysicalDetails, dismissElectronicDetails } = useDisabledOrderFields();
 
   useEffect(() => {
     if (dismissPhysicalDetails) {
@@ -143,7 +131,6 @@ export const Location = ({
         addLabel={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.location.field.locations.addLabel`} />}
         onAdd={handleLocationAdd}
         onRemove={handleLocationClean}
-        canAdd={!dismissCreateInventory}
         renderField={(field, index) => {
           return (
             <Row left="xs">


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
To activate "Location" field when PO status is "Open".

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Remove `canAdd` condition from Locations field and do not clean the field when status is Open

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1429

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
