### PR TITLE
UIDATIMP-1426: Order field mapping: Add info icon to the Acq unit field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Create hotlink from file name in job profile detail view to job log details (UIDATIMP-1356)
 * Add accessibility testing to automated tests in ui-data-import (UIDATIMP-1372)
 * Avoid private paths in stripes-core imports (UIDATIMP-1414)
+* Order field mapping: Add info icon to the Acq unit field (UIDATIMP-1426)
 * View all: Create hotlink from job profile name in log to the job profile details (UIDATIMP-1428)
 
 ## [6.0.8](https://github.com/folio-org/ui-data-import/tree/v6.0.8) (2023-04-04)

--- a/src/components/FieldOrganization/FieldOrganization.js
+++ b/src/components/FieldOrganization/FieldOrganization.js
@@ -144,7 +144,10 @@ FieldOrganization.propTypes = {
   ]),
   name: PropTypes.string,
   required: PropTypes.bool,
-  validate: PropTypes.func,
+  validate: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.arrayOf(PropTypes.func),
+  ]),
   mappingValue: PropTypes.string,
 };
 

--- a/src/components/ProfileTree/ProfileLinker/ProfileLinker.test.js
+++ b/src/components/ProfileTree/ProfileLinker/ProfileLinker.test.js
@@ -52,7 +52,6 @@ const renderProfileLinker = ({
       initialData={initialData}
       setInitialData={setInitialData}
       okapi={okapi}
-      profileType="test profile type"
     />
   );
 

--- a/src/routes/JobSummary/components/RecordsTable.test.js
+++ b/src/routes/JobSummary/components/RecordsTable.test.js
@@ -250,7 +250,7 @@ const renderRecordsTable = ({ isEdifactType = false }) => {
         source={source}
         resultCountIncrement={5}
         pageAmount={5}
-        history={{ push: noop }}
+        history={history}
         location="test location"
       />
     </BrowserRouter>

--- a/src/settings/FileExtensions/FileExtensionForm.test.js
+++ b/src/settings/FileExtensions/FileExtensionForm.test.js
@@ -67,7 +67,6 @@ const renderFileExtensionForm = ({
         onSubmitSuccess={onSubmitSuccess}
         onCancel={noop}
         transitionToParams={transitionToParams}
-        baseUrl="base-url"
       />
     </Router>
   );

--- a/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/OrderInformation.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/OrderInformation.js
@@ -133,6 +133,10 @@ const OrderInformationComponent = ({
     `${TRANSLATION_ID_PREFIX}.order.orderInformation.field.purchaseOrderStatus`,
     `${TRANSLATION_ID_PREFIX}.order.orderInformation.field.purchaseOrderStatus.info`,
   );
+  const acqUnitsLabel = renderFieldLabelWithInfo(
+    `${TRANSLATION_ID_PREFIX}.order.orderInformation.field.acquisitionUnits`,
+    `${TRANSLATION_ID_PREFIX}.order.orderInformation.field.acquisitionUnits.info`,
+  );
 
   const isApprovalRequiredValue = useMemo(
     () => {
@@ -340,7 +344,7 @@ const OrderInformationComponent = ({
           <AcceptedValuesField
             component={TextField}
             name={getFieldName(ORDER_INFO_FIELDS_MAP.ACQ_UNITS)}
-            label={<FormattedMessage id={`${TRANSLATION_ID_PREFIX}.order.orderInformation.field.acquisitionUnits`} />}
+            label={acqUnitsLabel}
             optionValue="name"
             optionLabel="name"
             wrapperLabel={`${TRANSLATION_ID_PREFIX}.wrapper.acceptedValues`}

--- a/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/tests/OrderInformation.test.js
+++ b/src/settings/MappingProfiles/detailsSections/edit/OrderDetailSection/tests/OrderInformation.test.js
@@ -40,6 +40,7 @@ jest.mock('../../../hooks', () => ({
   }]],
 }));
 
+global.fetch = jest.fn();
 const setReferenceTablesMock = jest.fn();
 
 const okapi = buildOkapi();
@@ -98,8 +99,21 @@ const renderOrderInformation = () => {
 };
 
 describe('OrderInformation edit component', () => {
+  beforeAll(() => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+  });
+
   afterEach(() => {
     setReferenceTablesMock.mockClear();
+  });
+
+  afterAll(() => {
+    global.fetch.mockClear();
+    delete global.fetch;
   });
 
   it('should be rendered with no axe errors', async () => {
@@ -144,6 +158,7 @@ describe('OrderInformation edit component', () => {
     const { queryByText } = renderOrderInformation();
 
     expect(within(queryByText('Purchase order status')).getByText(/InfoPopover/i)).toBeDefined();
+    expect(within(queryByText('Acquisition units')).getByText(/InfoPopover/i)).toBeDefined();
   });
 
   describe('should render validation error message when "Override purchase order lines limit setting" field value', () => {

--- a/src/utils/shapes.js
+++ b/src/utils/shapes.js
@@ -195,9 +195,9 @@ export const mappingHoldingsRefTablesShape = PropTypes.shape({
 });
 
 export const okapiShape = PropTypes.shape({
-  tenant: PropTypes.string.isRequired,
-  token: PropTypes.string.isRequired,
-  url: PropTypes.string.isRequired,
+  tenant: PropTypes.string,
+  token: PropTypes.string,
+  url: PropTypes.string,
 });
 
 export const qualifierShape = PropTypes.shape({

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -765,6 +765,7 @@
   "settings.mappingProfiles.map.order.orderInformation.field.vendor": "Vendor",
   "settings.mappingProfiles.map.order.orderInformation.field.orderType": "Order type",
   "settings.mappingProfiles.map.order.orderInformation.field.acquisitionUnits": "Acquisition units",
+  "settings.mappingProfiles.map.order.orderInformation.field.acquisitionUnits.info": "Order creation will error unless the importing user is a member of the specified acquisitions unit",
   "settings.mappingProfiles.map.order.orderInformation.field.assignedTo": "Assigned to",
   "settings.mappingProfiles.map.order.orderInformation.field.billToName": "Bill to name",
   "settings.mappingProfiles.map.order.orderInformation.field.billToAddress": "Bill to address",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Importer cannot create an order or invoice for a designated acquisitions unit unless the user is a member of that acquisitions unit. This story adds an info icon to the Order field mapping profile to make that more clear

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Render info icon next to acq units field
- Add unit tests
- Test tests warnings and adjust prop types

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1426

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://user-images.githubusercontent.com/55138456/231474732-492448a8-9594-46c7-bee3-38454f562e61.png)
