### PR TITLE
UIDATIMP-1459: Job summary - format numbers in summary table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * DI Log: Make some changes to the Log header (UIDATIMP-1447)
 * DI Job profiles: Redirect when job profile was deleted (UIDATIMP-1450)
 * Refactor the ViewJobLog component to be a functional component (UIDATIMP-1457)
+* Job summary - format numbers in summary table (UIDATIMP-1459)
 
 ### Bugs fixed:
 * Log page "Authority" tab of imported Marc Authority record is not displaying record's details (UIDATIMP-1458)

--- a/src/routes/JobSummary/components/SummaryTable.js
+++ b/src/routes/JobSummary/components/SummaryTable.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  FormattedNumber,
+} from 'react-intl';
 import { useLocation } from 'react-router-dom';
 import { isEmpty } from 'lodash';
 
@@ -76,6 +79,7 @@ const SummaryTableComponent = ({
 
     const totalEntitiesKeys = ['totalCreatedEntities', 'totalUpdatedEntities', 'totalDiscardedEntities', 'totalErrors'];
     const cellContent = column[totalEntitiesKeys[rowIndex]];
+    const formattedCount = <FormattedNumber value={cellContent} />;
 
     if (isLastRow(rowIndex) && cellContent > 0) {
       return (
@@ -86,12 +90,12 @@ const SummaryTableComponent = ({
             state: { from: `${pathname}${search}` }
           }}
         >
-          {cellContent}
+          {formattedCount}
         </TextLink>
       );
     }
 
-    return cellContent;
+    return formattedCount;
   };
 
   const resultsFormatter = {
@@ -113,7 +117,7 @@ const SummaryTableComponent = ({
                 state: { from: `${pathname}${search}` }
               }}
             >
-              {totalErrors}
+              <FormattedNumber value={totalErrors} />
             </TextLink>
           )
           : totalErrors;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Format values in the summary table with <NumberFormat> in order to display them in a locale-friendly way.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Render cell content with FormattedNumber

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1459

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://github.com/folio-org/ui-data-import/assets/55138456/290f5a81-2ff8-4cc7-ac44-f8d0b7a76c36)
