### PR TITLE
UIDATIMP-1465: Allow to handle text/plain content type when error occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Sorting on landing page gives error (UIDATIMP-1454)
 * Refactor the ViewJobLog component to be a functional component (UIDATIMP-1457)
 * Job summary - format numbers in summary table (UIDATIMP-1459)
-* Handle errors for settings->JobProfile (UIDATIMP-1465)
+* Allow to handle text/plain content type when error occurs (UIDATIMP-1465)
 
 ### Bugs fixed:
 * Fix all the failed accessibility tests in ui-data-import (UIDATIMP-1393)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Sorting on landing page gives error (UIDATIMP-1454)
 * Refactor the ViewJobLog component to be a functional component (UIDATIMP-1457)
 * Job summary - format numbers in summary table (UIDATIMP-1459)
+* Handle errors for settings->JobProfile (UIDATIMP-1465)
 
 ### Bugs fixed:
 * Fix all the failed accessibility tests in ui-data-import (UIDATIMP-1393)

--- a/src/utils/tests/xhr.test.js
+++ b/src/utils/tests/xhr.test.js
@@ -28,4 +28,15 @@ describe('getXHRErrorMessage', () => {
 
     expect(await getXHRErrorMessage(fakeXmlResponse)).toBe('Xhr error');
   });
+
+  describe('when response type is text/plain', () => {
+    it('should return correct response text', async () => {
+      const fakeXmlResponse = {
+        headers: new Map([['Content-Type', 'text/plain']]),
+        text: async () => 'text/plain response',
+      };
+
+      expect(await getXHRErrorMessage(fakeXmlResponse)).toBe('text/plain response');
+    });
+  });
 });

--- a/src/utils/xhr.js
+++ b/src/utils/xhr.js
@@ -27,6 +27,10 @@ export const getXHRResponse = async response => {
     return response.json();
   }
 
+  if (contentType.startsWith('text/plain')) {
+    return response.text();
+  }
+
   return response;
 };
 
@@ -40,7 +44,7 @@ export const getXHRErrorMessage = async response => {
   try {
     const json = await getXHRResponse(response);
 
-    return get(json, 'errors.0.message', null);
+    return get(json, 'errors.0.message', null) || json;
   } catch (error) {
     return null;
   }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* Support 2 types of error responses (`application/json` and `text/plain`)

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
[UIDATIMP-1465](https://issues.folio.org/browse/UIDATIMP-1465)
