### PR TITLE
UIDATIMP-1466 Add composite job details to Job component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/data-import",
-  "version": "6.0.8",
+  "version": "6.0.10",
   "description": "Data Import manager",
   "main": "src/index.js",
   "repository": "folio-org/ui-data-import",
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@babel/core": "^7.17.12",
     "@babel/eslint-parser": "^7.17.0",
-    "@babel/plugin-proposal-class-properties": "^7.10.4",
+    "@babel/plugin-transform-class-properties": "^7.10.4",
     "@babel/plugin-proposal-decorators": "^7.10.5",
     "@babel/plugin-transform-runtime": "^7.10.5",
     "@babel/preset-react": "^7.10.4",

--- a/src/components/DataFetcher/DataFetcher.js
+++ b/src/components/DataFetcher/DataFetcher.js
@@ -40,6 +40,7 @@ const jobsUrlParams = [
   `uiStatusAny=${RUNNING}`,
   'limit=50',
   'sortBy=completed_date,desc',
+  'subordinationTypeNotAny=COMPOSITE_CHILD'
 ];
 
 const logsUrlParams = [
@@ -51,6 +52,7 @@ const logsUrlParams = [
   `fileNameNotAny=${NO_FILE_NAME}`,
   'limit=25',
   'sortBy=completed_date,desc',
+  'subordinationTypeNotAny=COMPOSITE_PARENT'
 ];
 
 const jobsUrl = createUrlFromArray('metadata-provider/jobExecutions', jobsUrlParams);
@@ -105,15 +107,19 @@ export class DataFetcher extends Component {
     },
   };
 
-  async componentDidMount() {
+  componentDidMount() {
     this.mounted = true;
-    await this.fetchResourcesData(true);
-    this.updateResourcesData();
+    this.initialize();
   }
 
   componentWillUnmount() {
     this.mounted = false;
     clearTimeout(this.timeoutId);
+  }
+
+  initialize = async () => {
+    await this.fetchResourcesData(true);
+    this.updateResourcesData();
   }
 
   updateResourcesData() {
@@ -134,7 +140,6 @@ export class DataFetcher extends Component {
     }
 
     const { mutator } = this.props;
-
     const fetchResourcesPromises = Object
       .values(mutator)
       .reduce((res, resourceMutator) => res.concat(this.fetchResourceData(resourceMutator)), []);

--- a/src/components/DataFetcher/DataFetcher.js
+++ b/src/components/DataFetcher/DataFetcher.js
@@ -62,9 +62,9 @@ const compositeLogsUrl = createUrlFromArray('metadata-provider/jobExecutions', [
 
 export function getJobSplittingURL(resources, splittingURL, nonSplitting) {
   if (!resources?.split_status.isPending) {
-    if (resources?.split_status?.records[0].splitStatus) {
+    if (resources?.split_status?.records[0]?.splitStatus) {
       return splittingURL;
-    } else if (resources?.split_status?.records[0].splitStatus === false) {
+    } else if (resources?.split_status?.records[0]?.splitStatus === false) {
       return nonSplitting;
     }
   }

--- a/src/components/DataFetcher/DataFetcher.test.js
+++ b/src/components/DataFetcher/DataFetcher.test.js
@@ -12,6 +12,7 @@ import '../../../test/jest/__mock__';
 import {
   DataFetcher,
   DataFetcherContext,
+  getJobSplittingURL,
 } from '.';
 
 const reset = () => {};
@@ -96,6 +97,23 @@ describe('DataFetcher component', () => {
       const { getByText } = await renderDataFetcher(mutator);
 
       await waitFor(() => expect(getByText('error')).toBeDefined());
+    });
+  });
+
+  describe('getJobSplittingURL', () => {
+    const trueResources = { split_status: { isPending: false, records: [{ splitStatus: true }] } };
+    const falseResources = { split_status: { isPending: false, records: [{ splitStatus: false }] } };
+    const pendingResources = { split_status: { isPending: true, records: [] } };
+    it('given a splitStatus of true, it provides the "trueUrl" parameter', () => {
+      expect(getJobSplittingURL(trueResources, 'trueUrl', 'falseUrl')).toBe('trueUrl');
+    });
+
+    it('given a splitStatus of true, it provides the "falseUrl" parameter', () => {
+      expect(getJobSplittingURL(falseResources, 'trueUrl', 'falseUrl')).toBe('falseUrl');
+    });
+
+    it('given a pending split status, it returns undefined', () => {
+      expect(getJobSplittingURL(pendingResources, 'trueUrl', 'falseUrl')).toBeUndefined();
     });
   });
 });

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -38,7 +38,7 @@ const JobLogsContainer = props => {
     ...rest
   } = props;
 
-  const { formatMessage } = useIntl();
+  const { formatMessage, formatNumber } = useIntl();
   const location = useLocation();
 
   const hasDeletePermission = stripes.hasPerm(permissions.DELETE_LOGS);
@@ -61,6 +61,7 @@ const JobLogsContainer = props => {
         selectedRecords,
         checkboxDisabled: checkboxesDisabled,
         fieldsConfig,
+        formatNumber
       }),
       fileName: record => fileNameCellFormatter(record, location),
       status: statusCellFormatter(formatMessage),

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
@@ -11,6 +11,7 @@ import {
   stripesShape,
   withStripes,
 } from '@folio/stripes/core';
+import { UploadingJobsContext } from '../UploadingJobsContextProvider/UploadingJobsContext';
 
 import {
   DEFAULT_JOB_LOG_COLUMNS_WIDTHS,
@@ -40,11 +41,19 @@ const JobLogsContainer = props => {
 
   const { formatMessage, formatNumber } = useIntl();
   const location = useLocation();
-
+  const { uploadConfiguration } = useContext(UploadingJobsContext);
   const hasDeletePermission = stripes.hasPerm(permissions.DELETE_LOGS);
 
+  const getVisibleColumns = () => {
+    const baseColumns = [...DEFAULT_JOB_LOG_COLUMNS];
+    if (uploadConfiguration?.canUseObjectStorage) {
+      baseColumns.splice(3, 0, 'jobParts');
+    }
+    return hasDeletePermission ? ['selected', ...baseColumns] : baseColumns;
+  };
+
   const customProperties = {
-    visibleColumns: hasDeletePermission ? ['selected', ...DEFAULT_JOB_LOG_COLUMNS] : DEFAULT_JOB_LOG_COLUMNS,
+    visibleColumns: getVisibleColumns(),
     columnWidths: DEFAULT_JOB_LOG_COLUMNS_WIDTHS,
   };
 
@@ -61,11 +70,12 @@ const JobLogsContainer = props => {
         selectedRecords,
         checkboxDisabled: checkboxesDisabled,
         fieldsConfig,
-        formatNumber
+        formatNumber,
       }),
       fileName: record => fileNameCellFormatter(record, location),
       status: statusCellFormatter(formatMessage),
       jobProfileName: jobProfileNameCellFormatter,
+      jobParts: record => formatMessage({ id: 'ui-data-import.logViewer.partOfTotal' }, { number: record.jobPartNumber, total: record.totalJobParts }),
     },
   };
 

--- a/src/components/JobLogsContainer/JobLogsContainer.test.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.test.js
@@ -12,6 +12,8 @@ import '../../../test/jest/__mock__';
 import JobLogsContainer from './JobLogsContainer';
 import { FILE_STATUSES } from '../../utils';
 
+import UploadJobsContext from '../UploadingJobsContextProvider/UploadingJobsContext';
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: () => ({
@@ -19,6 +21,13 @@ jest.mock('react-router-dom', () => ({
     search: '?testKey=testValue',
   }),
 }));
+
+const splitRecord = {
+  status: FILE_STATUSES.COMMITTED,
+  progress: { current: 0 },
+  jobPartNumber: 2,
+  totalJobParts: 20
+};
 
 const successfulRecord = {
   status: FILE_STATUSES.COMMITTED,
@@ -50,8 +59,16 @@ const checkboxListProp = {
 };
 
 const stripes = buildStripes();
+const defaultUploadContext = {
+  uploadConfiguration: { splitStatus: false }
+};
 
-const renderJobLogsContainer = record => {
+const splittingUploadContext = {
+  uploadConfiguration: { splitStatus: true }
+};
+
+const renderJobLogsContainer = (record, context = defaultUploadContext) => {
+  const { Provider } = UploadJobsContext;
   const childComponent = listProps => {
     listProps.resultsFormatter.status(record);
     listProps.resultsFormatter.fileName(record);
@@ -65,9 +82,11 @@ const renderJobLogsContainer = record => {
   };
 
   const component = (
-    <JobLogsContainer checkboxList={checkboxListProp} stripes={stripes}>
-      {({ listProps }) => childComponent(listProps)}
-    </JobLogsContainer>
+    <Provider value={context}>
+      <JobLogsContainer checkboxList={checkboxListProp} stripes={stripes}>
+        {({ listProps }) => childComponent(listProps)}
+      </JobLogsContainer>
+    </Provider>
   );
 
   return renderWithIntl(component, translationsProperties);
@@ -115,6 +134,20 @@ describe('Job Logs container', () => {
       const { getByText } = renderJobLogsContainer(cancelledRecord);
 
       expect(getByText('Stopped by user')).toBeDefined();
+    });
+  });
+
+  describe('when large file splitting is enabled, display job parts column', () => {
+    it('then component should be rendered with appropriate text', () => {
+      const { getByText } = renderJobLogsContainer(splitRecord, splittingUploadContext);
+
+      expect(getByText('Job parts')).toBeInTheDocument();
+    });
+
+    it('should render the correct parts current and total for the job', () => {
+      const { getByText } = renderJobLogsContainer(splitRecord, splittingUploadContext);
+      const { jobPartNumber, totalJobParts } = splitRecord;
+      expect(getByText(`${jobPartNumber} of ${totalJobParts}`)).toBeInTheDocument();
     });
   });
 });

--- a/src/components/Jobs/Jobs.test.js
+++ b/src/components/Jobs/Jobs.test.js
@@ -73,9 +73,64 @@ const runningJobs = [
   },
 ];
 
+const runningCompositeJobs = [{
+  id: 'f4e1e42f-7c9b-45be-898f-25d8c563bf13',
+  hrId: 10,
+  parentJobId: 'f4e1e42f-7c9b-45be-898f-25d8c563bf13',
+  subordinationType: 'COMPOSITE_PARENT',
+  jobProfileInfo: {
+    id: '80898dee-449f-44dd-9c8e-37d5eb469b1d',
+    name: 'Default - Create Holdings and SRS MARC Holdings',
+    dataType: 'MARC',
+    hidden: false
+  },
+  sourcePath: '500 records.mrc',
+  fileName: '500 records.mrc',
+  runBy: {
+    firstName: 'DIKU',
+    lastName: 'ADMINISTRATOR'
+  },
+  progress: {
+    jobExecutionId: 'f4e1e42f-7c9b-45be-898f-25d8c563bf13',
+    current: 504,
+    total: 500
+  },
+  startedDate: '2023-06-16T18:22:18.484+00:00',
+  completedDate: '2023-06-16T18:50:11.105+00:00',
+  status: 'PROCESSING_IN_PROGRESS',
+  uiStatus: 'RUNNING',
+  userId: 'eb9e217c-0dcf-47ed-b3f0-22a928702631',
+  jobPartNumber: 1,
+  totalJobParts: 1,
+  compositeDetails: {
+    processingInProgressState: {
+      chunksCount: 5,
+      totalRecordsCount: 2500,
+      currentlyProcessedCount: 832
+    },
+    committedState: {
+      chunksCount: 3,
+      totalRecordsCount: 1500,
+      currentlyProcessedCount: 1500
+    },
+    errorState: {
+      chunksCount: 2,
+      totalRecordsCount: 1000,
+      currentlyProcessedCount: 1000
+    }
+  }
+}
+];
+
 const defaultContext = {
   hasLoaded: true,
   jobs: runningJobs,
+  logs: [],
+};
+
+const compositeContext = {
+  hasLoaded: true,
+  jobs: runningCompositeJobs,
   logs: [],
 };
 
@@ -87,6 +142,16 @@ const initialStore = {
 };
 
 const renderJobs = (context = defaultContext) => {
+  const component = (
+    <DataFetcherContext.Provider value={context}>
+      <Jobs />
+    </DataFetcherContext.Provider>
+  );
+
+  return renderWithIntl(renderWithRedux(component, initialStore), translationsProperties);
+};
+
+const renderCompositeJobs = (context = compositeContext) => {
   const component = (
     <DataFetcherContext.Provider value={context}>
       <Jobs />
@@ -231,6 +296,174 @@ describe('Jobs component', () => {
         const error = new Error('Something went wrong. Try again.');
         mockDeleteFile.mockRejectedValueOnce(error);
         const { getByRole } = renderJobs();
+
+        fireEvent.click(getByRole('button', { name: /delete/i }));
+        fireEvent.click(getByRole('button', { name: 'Yes, cancel import job' }));
+
+        expect(mockDeleteFile).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(mockConsoleError).toHaveBeenCalledWith(error));
+      });
+    });
+  });
+});
+
+// Composite jobs tests..
+describe('Composite jobs - Jobs component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    delete global.fetch;
+  });
+
+  it('Composite jobs - should be rendered with no axe errors', async () => {
+    const { container } = renderCompositeJobs();
+
+    await runAxeTest({ rootNode: container });
+  });
+
+  it('Composite jobs - should contain "Running" section', () => {
+    const { getByText } = renderCompositeJobs();
+
+    expect(getByText('Running')).toBeInTheDocument();
+  });
+
+  it('Composite jobs -  "Running" section accordion should be open by default', () => {
+    const { getByRole } = renderCompositeJobs();
+
+    expect(getByRole('button', { name: /running/i, expanded: true }));
+  });
+
+  describe('Composite jobs - "Running" section', () => {
+    it('should have correct amount of running job cards', () => {
+      const { getAllByRole } = renderCompositeJobs();
+      // Composite cards display a nested list of progress data that has 3 items...
+      // we expect 3 more items per card.
+      expect(getAllByRole('listitem').length).toBe(runningJobs.length + runningJobs.length * 3);
+    });
+
+    it('Composite jobs - should display appropriate message when there are no running jobs', () => {
+      const { getByText } = renderCompositeJobs({
+        ...defaultContext,
+        jobs: [],
+      });
+
+      expect(getByText('No running jobs to show')).toBeInTheDocument();
+    });
+
+    describe('Composite jobs - Job card', () => {
+      let jobCard;
+
+      beforeEach(() => {
+        const { getAllByRole } = renderCompositeJobs();
+        jobCard = getAllByRole('listitem')[0];
+      });
+
+      it('Composite jobs - should display job profile name', () => {
+        const jobProfileName = runningCompositeJobs[0].jobProfileInfo.name;
+
+        expect(within(jobCard).getByText(jobProfileName)).toBeInTheDocument();
+      });
+
+      it('Composite jobs - should display file name', () => {
+        const fileName = runningCompositeJobs[0].fileName;
+
+        expect(within(jobCard).getByText(fileName)).toBeInTheDocument();
+      });
+
+      it('Composite jobs - should display total number of records', () => {
+        const totalRecords = runningCompositeJobs[0].progress.total;
+
+        expect(within(jobCard).getByText(`${totalRecords} records`)).toBeInTheDocument();
+      });
+
+      it('Composite jobs - should display user full name', () => {
+        const {
+          firstName,
+          lastName,
+        } = runningCompositeJobs[0].runBy;
+        const fullName = `${firstName} ${lastName}`;
+
+        expect(within(jobCard).getByText(fullName, { exact: false })).toBeInTheDocument();
+      });
+
+      it('Composite jobs - should display number of processed slices', () => {
+        expect(within(jobCard).getByText(/processed/)).toBeInTheDocument();
+      });
+
+      it('Composite jobs - should display number of remaining slices', () => {
+        expect(within(jobCard).getByText(/remaining/)).toBeInTheDocument();
+      });
+
+      it('Composite jobs - should display number of completed slices', () => {
+        expect(within(jobCard).getByText('Completed: 3')).toBeInTheDocument();
+      });
+
+      it('Composite jobs - should display number of slices completed with error', () => {
+        expect(within(jobCard).getByText('Completed with errors: 2')).toBeInTheDocument();
+      });
+
+      it('Composite jobs - should display number of failed', () => {
+        expect(within(jobCard).getByText('Failed: 2')).toBeInTheDocument();
+      });
+    });
+
+    describe('Composite jobs - When delete button on running job card is clicked', () => {
+      it('Composite jobs - cancel import job modal should be opened', async () => {
+        const {
+          getByRole,
+          getByText,
+        } = renderCompositeJobs();
+
+        fireEvent.click(getByRole('button', { name: /delete/i }));
+
+        await waitFor(() => expect(getByText('Confirmation Modal')).toBeInTheDocument());
+      });
+
+      it('Composite jobs - correct text should be rendered on the job card', () => {
+        const {
+          getByText,
+          getByRole,
+        } = renderCompositeJobs();
+
+        fireEvent.click(getByRole('button', { name: /delete/i }));
+
+        expect(getByText('has been stopped', { exact: false })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Composite jobs - Opened cancel import job modal', () => {
+    it('Composite jobs - should be closed when cancel button is clicked', async () => {
+      const {
+        getByRole,
+        queryByText,
+      } = renderCompositeJobs();
+
+      fireEvent.click(getByRole('button', { name: /delete/i }));
+      fireEvent.click(getByRole('button', { name: 'No, do not cancel import' }));
+
+      await waitFor(() => expect(queryByText('Confirmation Modal')).not.toBeInTheDocument());
+    });
+
+    it('Composite jobs - should be closed when confirm button is clicked', async () => {
+      const {
+        getByRole,
+        queryByText,
+      } = renderCompositeJobs();
+
+      fireEvent.click(getByRole('button', { name: /delete/i }));
+      fireEvent.click(getByRole('button', { name: 'Yes, cancel import job' }));
+
+      await waitFor(() => expect(queryByText('Confirmation Modal')).not.toBeInTheDocument());
+    });
+
+    describe('Composite jobs - when there is a deletion error while cancelling job', () => {
+      it('Composite jobs - console.error should be called', async () => {
+        const error = new Error('Something went wrong. Try again.');
+        mockDeleteFile.mockRejectedValueOnce(error);
+        const { getByRole } = renderCompositeJobs();
 
         fireEvent.click(getByRole('button', { name: /delete/i }));
         fireEvent.click(getByRole('button', { name: 'Yes, cancel import job' }));

--- a/src/components/Jobs/components/Job/Job.css
+++ b/src/components/Jobs/components/Job/Job.css
@@ -69,3 +69,13 @@
 .deleteIcon {
   display: inline-block;
 }
+
+.compositeList {
+  list-style-type: disc;
+  margin-top: 6px;
+  & .listItem {
+    display: list-item;
+    padding: 0;
+    margin-bottom: 0;
+  }
+}

--- a/src/components/Jobs/components/Job/Job.js
+++ b/src/components/Jobs/components/Job/Job.js
@@ -37,6 +37,8 @@ import { jobMetaTypes } from './jobMetaTypes';
 import { jobExecutionPropTypes } from './jobExecutionPropTypes';
 
 import * as API from '../../../../utils/upload';
+import * as CompositeJobFields from '../../../../utils/compositeJobStatus';
+
 import {
   addHrid,
   deleteHrid,
@@ -142,6 +144,85 @@ const JobComponent = ({
     await deleteJob();
   };
 
+  const renderCompositeDetails = (jobEntry) => {
+    const {
+      compositeDetails,
+    } = jobEntry;
+
+    const {
+      calculateJobSliceStats,
+      inProgressStatuses,
+      completeStatuses,
+      failedStatuses,
+    } = CompositeJobFields;
+
+    const inProgressSliceAmount = calculateJobSliceStats(
+      compositeDetails,
+      inProgressStatuses
+    );
+
+    const completedSliceAmount = calculateJobSliceStats(
+      compositeDetails,
+      completeStatuses
+    );
+
+    const erroredSliceAmount = calculateJobSliceStats(
+      compositeDetails,
+      ['errorState']
+    );
+
+    const failedSliceAmount = calculateJobSliceStats(
+      compositeDetails,
+      failedStatuses
+    );
+
+    const totalSliceAmount = inProgressSliceAmount + completedSliceAmount + failedSliceAmount;
+
+    return (
+      <>
+        <FormattedMessage
+          id="ui-data-import.jobProgress.partsRemaining"
+          tagName="div"
+          values={{
+            current: totalSliceAmount - (failedSliceAmount + completedSliceAmount),
+            total: totalSliceAmount
+          }}
+        />
+        <FormattedMessage
+          id="ui-data-import.jobProgress.partsProcessed"
+          tagName="div"
+          values={{
+            current: completedSliceAmount,
+            total: totalSliceAmount,
+          }}
+        />
+        <ul className={css.compositeList}>
+          <li className={css.listItem}>
+            <FormattedMessage
+              id="ui-data-import.jobProgress.partsCompleted"
+              tagName="div"
+              values={{ amount: completedSliceAmount }}
+            />
+          </li>
+          <li className={css.listItem}>
+            <FormattedMessage
+              id="ui-data-import.jobProgress.partsCompletedWithErrors"
+              tagName="div"
+              values={{ amount: erroredSliceAmount }}
+            />
+          </li>
+          <li className={css.listItem}>
+            <FormattedMessage
+              id="ui-data-import.jobProgress.partsFailed"
+              tagName="div"
+              values={{ amount: failedSliceAmount }}
+            />
+          </li>
+        </ul>
+      </>
+    );
+  };
+
   const {
     jobProfileInfo: { name },
     fileName,
@@ -172,7 +253,7 @@ const JobComponent = ({
           {fileName}
           {isDeletionInProgress && (
             <>
-            &nbsp;
+              &nbsp;
               <FormattedMessage
                 id="ui-data-import.stoppedJob"
                 tagName="span"
@@ -232,7 +313,7 @@ const JobComponent = ({
               />
             </>
           )}
-
+          {job.compositeDetails && renderCompositeDetails(job)}
           {jobMeta.showPreview && (
             <div className={css.jobPreview}>
               <FormattedMessage id="ui-data-import.readyForPreview" />

--- a/src/components/Jobs/components/Job/jobExecutionPropTypes.js
+++ b/src/components/Jobs/components/Job/jobExecutionPropTypes.js
@@ -1,5 +1,11 @@
 import PropTypes from 'prop-types';
 
+const compositeDetailsShape = {
+  chunksCount: PropTypes.number,
+  totalRecordsCount: PropTypes.number,
+  currentlyProcessedCount: PropTypes.number,
+};
+
 export const jobExecutionPropTypes = PropTypes.shape({
   id: PropTypes.string.isRequired,
   hrId: PropTypes.number.isRequired,
@@ -26,4 +32,17 @@ export const jobExecutionPropTypes = PropTypes.shape({
   status: PropTypes.string.isRequired,
   uiStatus: PropTypes.string.isRequired,
   userId: PropTypes.string,
+  compositeDetails: PropTypes.shape({
+    committedState: PropTypes.shape(compositeDetailsShape),
+    newState: PropTypes.shape(compositeDetailsShape),
+    fileUploadedState: PropTypes.shape(compositeDetailsShape),
+    parsingInProgressState: PropTypes.shape(compositeDetailsShape),
+    parsingFinishedState: PropTypes.shape(compositeDetailsShape),
+    processingInProgressState: PropTypes.shape(compositeDetailsShape),
+    processingFinishedState: PropTypes.shape(compositeDetailsShape),
+    commitInProgressState:  PropTypes.shape(compositeDetailsShape),
+    errorState: PropTypes.shape(compositeDetailsShape),
+    discardedState: PropTypes.shape(compositeDetailsShape),
+    cancelledState: PropTypes.shape(compositeDetailsShape),
+  })
 });

--- a/src/utils/compositeJobStatus.js
+++ b/src/utils/compositeJobStatus.js
@@ -1,0 +1,29 @@
+export const inProgressStatuses = [
+  'newState',
+  'fileUploadedState',
+  'parsingInProgressState',
+  'parsingFinishedState',
+  'processingInProgressState',
+  'processingFinishedState',
+  'commitInProgressState'
+];
+
+export const failedStatuses = [
+  'errorState',
+  'discardedState',
+  'cancelledState'
+];
+
+export const completeStatuses = [
+  'committedState'
+];
+
+export const calculateJobSliceStats = (obj, arr) => {
+  let totalSlices = 0;
+  arr.forEach((status) => {
+    if (Object.prototype.hasOwnProperty.call(obj, status)) {
+      totalSlices += obj[status].chunksCount;
+    }
+  });
+  return totalSlices;
+};

--- a/src/utils/jobLogsListProperties.js
+++ b/src/utils/jobLogsListProperties.js
@@ -41,5 +41,6 @@ export const getJobLogsListColumnMapping = ({
     completedDate: <FormattedMessage id="ui-data-import.jobCompletedDate" />,
     runBy: <FormattedMessage id="ui-data-import.runBy" />,
     hrId: <FormattedMessage id="ui-data-import.jobExecutionHrId" />,
+    jobParts: <FormattedMessage id="ui-data-import.jobParts" />,
   };
 };

--- a/test/jest/babel.config.js
+++ b/test/jest/babel.config.js
@@ -5,9 +5,9 @@ module.exports = {
   ],
   plugins: [
     ['@babel/plugin-proposal-decorators', { legacy: true }],
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-proposal-private-methods', { loose: true }],
-    ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
+    ['@babel/plugin-transform-class-properties', { loose: true }],
+    ['@babel/plugin-transform-private-methods', { loose: true }],
+    ['@babel/plugin-transform-private-property-in-object', { loose: true }],
     '@babel/plugin-transform-runtime',
   ],
 };

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -170,6 +170,7 @@
   "records": "Records",
   "jobStartedDate": "Started running",
   "jobCompletedDate": "Ended running",
+  "jobParts": "Job parts",
   "status": "Status",
   "failed": "Failed",
   "completed": "Completed",

--- a/translations/ui-data-import/en_GB.json
+++ b/translations/ui-data-import/en_GB.json
@@ -17,6 +17,7 @@
     "jobProfileName": "Job profile",
     "jobExecutionHrId": "ID",
     "jobCompletedDate": "Ended running",
+    "jobParts": "Job parts",
     "noPreviewsJobsMessage": "No previews to show",
     "noRunningJobsMessage": "No running jobs to show",
     "loading": "Loading",

--- a/translations/ui-data-import/en_SE.json
+++ b/translations/ui-data-import/en_SE.json
@@ -17,6 +17,7 @@
     "jobProfileName": "Job profile",
     "jobExecutionHrId": "ID",
     "jobCompletedDate": "Ended running",
+    "jobParts": "Job parts",
     "noPreviewsJobsMessage": "No previews to show",
     "noRunningJobsMessage": "No running jobs to show",
     "loading": "Loading",

--- a/translations/ui-data-import/en_US.json
+++ b/translations/ui-data-import/en_US.json
@@ -17,6 +17,7 @@
     "jobProfileName": "Job profile",
     "jobExecutionHrId": "ID",
     "jobCompletedDate": "Ended running",
+    "jobParts": "Job parts",
     "noPreviewsJobsMessage": "No previews to show",
     "noRunningJobsMessage": "No running jobs to show",
     "loading": "Loading",


### PR DESCRIPTION
[UIDATIMP-1466](https://issues.folio.org/browse/UIDATIMP-1466)
and
[UIDATIMP-1464](https://issues.folio.org/browse/UIDATIMP-1464)

## Purpose
Jobs-in-progress cards present data regarding the progress of a running job. With the addition of file-splitting/submission of multiple jobs, we consolidate multiple child job entities to a single card that displays the number of file slices remaining to be processed, the number of finished slices, errored slices, and canceled/discarded slices.

![image](https://github.com/folio-org/ui-data-import/assets/20704067/6e82f084-c458-4328-9226-de9f71bf4ca2)

The job log display is also rendered with a 'Job parts' column when the configuration is active.

![image](https://github.com/folio-org/ui-data-import/assets/20704067/e2fa4f8b-027d-40d3-ab1c-6c54f2687851)

## Approach

The query needed to be adjusted to include 'subordinationTypeNotAny=COMPOSITE_CHILD' to pull down the composite job, as well as 'subordinationTypeNotAny=COMPOSITE_PARENT' for the job logs listing.
If the 'job' data for the card contains a `CompositeDetails` field, it will render the extra progress information.

The trickiest part is probably varying the query parameters for the jobs/logs request in `<DataFetcher/>`...
It makes use of `stripes-connect`'s functional path capability and waits for a return from the configuration call before requesting the jobs/logs. For composite data, an additional query parameter is required : `subordinationTypeNotAny`

##TO-DO 
Update/add tests for job component...