### PR TITLE
UIDATIMP-1467 display jobParts column in Jobs using this profile section

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,9 @@ class DataImport extends Component {
     if (showSettings) {
       return (
         <CommandList commands={keyboardCommands}>
-          <DataImportSettings {...this.props} />
+          <UploadingJobsContextProvider>
+            <DataImportSettings {...this.props} />
+          </UploadingJobsContextProvider>
         </CommandList>
       );
     }

--- a/src/index.js
+++ b/src/index.js
@@ -39,48 +39,41 @@ class DataImport extends Component {
       match: { path },
     } = this.props;
 
-    if (showSettings) {
-      return (
-        <CommandList commands={keyboardCommands}>
-          <UploadingJobsContextProvider>
-            <DataImportSettings {...this.props} />
-          </UploadingJobsContextProvider>
-        </CommandList>
-      );
-    }
-
     return (
       <CommandList commands={keyboardCommands}>
         <UploadingJobsContextProvider>
-          <Switch>
-            <Route
-              path={path}
-              exact
-              render={props => (
-                <DataFetcher>
-                  <Home {...props} />
-                </DataFetcher>
-              )}
-            />
-            <Route
-              path={`${path}/job-profile`}
-              component={JobProfile}
-            />
-            <Route
-              path={`${path}/log/:id/:recordId`}
-              exact
-              component={ViewJobLog}
-            />
-            <Route
-              path={`${path}/job-summary/:id`}
-              exact
-              component={JobSummary}
-            />
-            <Route
-              path={`${path}/job-logs`}
-              component={ViewAllLogs}
-            />
-          </Switch>
+          { showSettings ?
+            <DataImportSettings {...this.props} /> :
+            <Switch>
+              <Route
+                path={path}
+                exact
+                render={props => (
+                  <DataFetcher>
+                    <Home {...props} />
+                  </DataFetcher>
+                )}
+              />
+              <Route
+                path={`${path}/job-profile`}
+                component={JobProfile}
+              />
+              <Route
+                path={`${path}/log/:id/:recordId`}
+                exact
+                component={ViewJobLog}
+              />
+              <Route
+                path={`${path}/job-summary/:id`}
+                exact
+                component={JobSummary}
+              />
+              <Route
+                path={`${path}/job-logs`}
+                component={ViewAllLogs}
+              />
+            </Switch>
+          }
         </UploadingJobsContextProvider>
       </CommandList>
     );

--- a/src/settings/JobProfiles/ViewJobProfile/ViewJobProfile.js
+++ b/src/settings/JobProfiles/ViewJobProfile/ViewJobProfile.js
@@ -384,6 +384,7 @@ const ViewJobProfileComponent = props => {
                     hrId: <FormattedMessage id="ui-data-import.settings.jobProfiles.jobID" />,
                     completedDate: <FormattedMessage id="ui-data-import.jobCompletedDate" />,
                     runBy: <FormattedMessage id="ui-data-import.runBy" />,
+                    jobParts: <FormattedMessage id="ui-data-import.jobParts" />
                   }}
                   visibleColumns={getVisibleColumns(uploadConfiguration)}
                   formatter={jobsUsingThisProfileFormatter}

--- a/src/settings/JobProfiles/ViewJobProfile/ViewJobProfile.js
+++ b/src/settings/JobProfiles/ViewJobProfile/ViewJobProfile.js
@@ -271,9 +271,34 @@ const ViewJobProfileComponent = props => {
   const jobsUsingThisProfileFormatter = {
     ...listTemplate({}),
     fileName: record => fileNameCellFormatter(record, location),
+    jobParts: record => (
+      <FormattedMessage
+        id="ui-data-import.logViewer.partOfTotal"
+        values={{
+          number: record.jobPartNumber,
+          total: record.totalJobParts
+        }}
+      />
+    )
   };
+
   const tagsEntityLink = `data-import-profiles/jobProfiles/${jobProfileRecord.id}`;
   const isSettingsEnabled = stripes.hasPerm(permissions.SETTINGS_MANAGE) || stripes.hasPerm(permissions.SETTINGS_VIEW_ONLY);
+
+  const getVisibleColumns = (context) => {
+    const defaultVisibleColumns = [
+      'fileName',
+      'hrId',
+      'completedDate',
+      'runBy',
+    ];
+    if (context?.canUseObjectStorage) {
+      const columns = [...defaultVisibleColumns];
+      columns.splice(2, 0, 'jobParts');
+      return columns;
+    }
+    return defaultVisibleColumns;
+  };
 
   return (
     <DetailsKeyShortcutsWrapper
@@ -360,12 +385,7 @@ const ViewJobProfileComponent = props => {
                     completedDate: <FormattedMessage id="ui-data-import.jobCompletedDate" />,
                     runBy: <FormattedMessage id="ui-data-import.runBy" />,
                   }}
-                  visibleColumns={[
-                    'fileName',
-                    'hrId',
-                    'completedDate',
-                    'runBy',
-                  ]}
+                  visibleColumns={getVisibleColumns(uploadConfiguration)}
                   formatter={jobsUsingThisProfileFormatter}
                   width="100%"
                 />
@@ -458,7 +478,6 @@ ViewJobProfileComponent.manifest = Object.freeze({
     type: 'okapi',
     path: (_q, _p) => {
       const { id } = _p;
-
       return createUrlFromArray('metadata-provider/jobExecutions', [
         `statusAny=${COMMITTED}`,
         `statusAny=${ERROR}`,

--- a/src/settings/JobProfiles/tests/ViewJobProfile.test.js
+++ b/src/settings/JobProfiles/tests/ViewJobProfile.test.js
@@ -5,7 +5,6 @@ import {
   fireEvent,
   waitFor,
   getByText as getByTextScreen,
-  within
 } from '@testing-library/react';
 import { runAxeTest } from '@folio/stripes-testing';
 
@@ -21,17 +20,16 @@ import '../../../../test/jest/__mock__';
 import { ViewJobProfile } from '../ViewJobProfile';
 import { UploadingJobsContext } from '../../../components';
 
-const defaultContext = {
-  uploadConfiguration: {
-    canUseObjectStorage: false,
+const uploadContext = (canUseObjectStorage) => (
+  {
+    uploadDefinition: {
+      id: 'testUploadDefinitionId'
+    },
+    uploadConfiguration: {
+      canUseObjectStorage,
+    }
   }
-};
-
-const multipartContext = {
-  uploadConfiguration: {
-    canUseObjectStorage: true,
-  }
-};
+);
 
 const jobProfile = {
   records: [
@@ -103,7 +101,7 @@ const renderViewJobProfile = ({
   location,
   resources,
   actionMenuItems,
-  context = defaultContext
+  context = uploadContext(false)
 }) => {
   const component = () => (
     <Router>
@@ -198,7 +196,7 @@ describe('<ViewJobProfile>', () => {
 
   describe('Jobs using this profile section - multipart capabilities', () => {
     it('should display the "Job parts" column', () => {
-      const { getByRole } = renderViewJobProfile({ ...viewJobProfileProps(jobProfile), context: multipartContext });
+      const { getByRole } = renderViewJobProfile({ ...viewJobProfileProps(jobProfile), context: uploadContext(true) });
 
       expect(getByRole('columnheader', { name: 'Job parts' })).toBeInTheDocument();
     });
@@ -294,13 +292,11 @@ describe('<ViewJobProfile>', () => {
 
       fireEvent.click(getByTextScreen(actionsMenu, 'Run'));
 
-      const confirmationModal = getByRole('dialog');
-
-      const confirmButton = within(confirmationModal).getByRole('button', { name: /run/i });
+      const confirmButton = document.querySelector('#clickable-run-job-profile-modal-confirm');
 
       fireEvent.click(confirmButton);
 
-      await waitFor(() => expect(within(confirmationModal).getByRole('button', { name: /run/i })).toBeDisabled());
+      await waitFor(() => expect(confirmButton).toBeDisabled());
     });
   });
 


### PR DESCRIPTION
Displays the "Job parts" column in the data-import settings Job Profile detail view.
[UIDATIMP-1467](https://issues.folio.org/browse/UIDATIMP-1467)

![image](https://github.com/folio-org/ui-data-import/assets/20704067/6aedfd34-3512-401f-8620-80416e38086d)

## Approach
This column is conditionally displayed based on the objectStorage capability/multipart job splitting. I moved the settings view into the children of the context provider to receive the value from there rather than rendering multiple, separate context providiers.
