### PR TITLE
UIDATIMP-1509 Update 'name' field in uploadDefinition to reflect object storage.

### DIFF
--- a/src/components/UploadingJobsDisplay/UploadingJobsDisplay.js
+++ b/src/components/UploadingJobsDisplay/UploadingJobsDisplay.js
@@ -352,13 +352,28 @@ export class UploadingJobsDisplay extends Component {
     this.updateFileState(fileKey, { uploadedValue });
   };
 
-  handleFileUploadSuccess = (response, fileKey) => {
-    const { uploadedDate } = response.fileDefinitions.find(fileDefinition => fileDefinition.uiKey === fileKey);
+  handleFileUploadSuccess = (response, fileKey, multipart = false) => {
+    const { uploadedDate, name } = response.fileDefinitions.find(fileDefinition => fileDefinition.uiKey === fileKey);
+    const { uploadDefinition, updateUploadDefinition } = this.context;
 
     this.updateFileState(fileKey, {
       status: FILE_STATUSES.UPLOADED,
       uploadedDate,
     });
+
+    // for multipart object storage uploads, we update the name in the upload definition to be
+    // the upload key.
+    if (multipart) {
+      const contextFileDefIndex = uploadDefinition.fileDefinitions.findIndex(fileDef => fileDef.uiKey === fileKey);
+      if (contextFileDefIndex !== -1) {
+        const updatedUploadDefinition = { ...uploadDefinition };
+        updatedUploadDefinition.fileDefinitions[contextFileDefIndex] = {
+          ...updatedUploadDefinition.fileDefinitions[contextFileDefIndex],
+          name
+        };
+        updateUploadDefinition(updatedUploadDefinition);
+      }
+    }
   };
 
   handleFileUploadFail = fileKey => {

--- a/src/components/UploadingJobsDisplay/UploadingJobsDisplay.js
+++ b/src/components/UploadingJobsDisplay/UploadingJobsDisplay.js
@@ -43,7 +43,7 @@ import {
 } from '../../utils';
 import * as API from '../../utils/upload';
 import { createJobProfiles } from '../../settings/JobProfiles';
-import { handleObjectStorageUpload } from '../../utils/multipartUpload';
+import { handleObjectStorageUpload, getUpdateUploadDefinitionForObjectStorage } from '../../utils/multipartUpload';
 import css from './UploadingJobsDisplay.css';
 import sharedCss from '../../shared.css';
 
@@ -364,15 +364,8 @@ export class UploadingJobsDisplay extends Component {
     // for multipart object storage uploads, we update the name in the upload definition to be
     // the upload key.
     if (multipart) {
-      const contextFileDefIndex = uploadDefinition.fileDefinitions.findIndex(fileDef => fileDef.uiKey === fileKey);
-      if (contextFileDefIndex !== -1) {
-        const updatedUploadDefinition = { ...uploadDefinition };
-        updatedUploadDefinition.fileDefinitions[contextFileDefIndex] = {
-          ...updatedUploadDefinition.fileDefinitions[contextFileDefIndex],
-          name
-        };
-        updateUploadDefinition(updatedUploadDefinition);
-      }
+      const updatedUploadDefinition = getUpdateUploadDefinitionForObjectStorage(uploadDefinition, fileKey, name);
+      updateUploadDefinition(updatedUploadDefinition);
     }
   };
 

--- a/src/utils/multipartUpload.js
+++ b/src/utils/multipartUpload.js
@@ -127,8 +127,8 @@ async function sliceAndUploadParts(file, ky, fileKey, errorHandler, progressHand
   }
   await finishUpload(eTags, _uploadKey, _uploadId, ky);
   // TODO - expect date string from backend when finishing the upload - creating the date stamp expected by the UI here for now...
-  const finishResponse = { fileDefinitions:[{ uiKey: fileKey, uploadedDate: new Date().toLocaleDateString() }] };
-  successHandler(finishResponse, fileKey);
+  const finishResponse = { fileDefinitions:[{ uiKey: fileKey, uploadedDate: new Date().toLocaleDateString(), name: _uploadKey }] };
+  successHandler(finishResponse, fileKey, true);
 }
 
 export function handleMultipartUpload(file, ky, fileKey, errorHandler, progressHandler, successHandler) {

--- a/src/utils/multipartUpload.js
+++ b/src/utils/multipartUpload.js
@@ -35,6 +35,19 @@ function getPartPresignedURL(partNumber, uploadId, key, ky) {
   return ky.get(requestPartUploadURL, { searchParams: { partNumber, key, uploadId } }).json();
 }
 
+export const getUpdateUploadDefinitionForObjectStorage = (uploadDefinition, fileKey, name) => {
+  const contextFileDefIndex = uploadDefinition.fileDefinitions.findIndex(fileDef => fileDef.uiKey === fileKey);
+  if (contextFileDefIndex !== -1) {
+    const updatedUploadDefinition = { ...uploadDefinition };
+    updatedUploadDefinition.fileDefinitions[contextFileDefIndex] = {
+      ...updatedUploadDefinition.fileDefinitions[contextFileDefIndex],
+      name
+    };
+    return updatedUploadDefinition;
+  }
+  return uploadDefinition;
+};
+
 function finishUpload(eTags, key, uploadId, ky) {
   return ky.post(
     finishMPUploadEndpoint,

--- a/src/utils/tests/multipartUpload.test.js
+++ b/src/utils/tests/multipartUpload.test.js
@@ -4,7 +4,8 @@ import {
   getStorageConfiguration,
   requestConfiguration,
   cancelMultipartJob,
-  cancelMultipartJobEndpoint
+  cancelMultipartJobEndpoint,
+  getUpdateUploadDefinitionForObjectStorage
 } from '../multipartUpload';
 
 const responseMock = jest.fn();
@@ -42,5 +43,39 @@ describe('cancelMultipartUpload function', () => {
   it('calls fetch with correct parameters', async () => {
     cancelMultipartJob('testid', 'test-header');
     expect(mockFetch).toBeCalledWith(cancelMultipartJobEndpoint('testid'), { headers: 'test-header', method: 'POST' });
+  });
+});
+
+describe('getUpdateUploadDefinitionForObjectStorage function', () => {
+  const uploadDefinition = {
+    fileDefinitions: [
+      {
+        uiKey: 'test1',
+        name: 'test1filename.mrc'
+      },
+      {
+        uiKey: 'test2',
+        name: 'test2filename.mrc'
+      },
+    ]
+  };
+
+  const expectedUploadDefinition = {
+    fileDefinitions: [
+      {
+        uiKey: 'test1',
+        name: 'test1filename.mrc'
+      },
+      {
+        uiKey: 'test2',
+        name: 'diku/test2filename.mrc'
+      },
+    ]
+  };
+  it('modifies appropriate file definition as expected', async () => {
+    expect(getUpdateUploadDefinitionForObjectStorage(uploadDefinition, 'test2', 'diku/test2filename.mrc')).toEqual(expectedUploadDefinition);
+  });
+  it('returns original configuration if file definition can\'t be matched', async () => {
+    expect(getUpdateUploadDefinitionForObjectStorage(uploadDefinition, 'test3', 'diku/test2filename.mrc')).toEqual(uploadDefinition);
   });
 });


### PR DESCRIPTION
[UIDATIMP-1509](https://issues.folio.org/browse/UIDATIMP-1509)

## Purpose
Since we're using S3 storage to process the files here forward, it only makes sense that the system retain the name as S3 knows it. vs the original filename.
