### PR TITLE
UIDATIMP-1551: Remove error message after clicking on the link in holdings and item column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed:
 * Align stripes dependencies (UIDATIMP-1550)
+* Remove 'Something went wrong' message after clicking on the link in holdings and item column (UIDATIMP-1551)
 
 ## [7.0.0](https://github.com/folio-org/ui-data-import/tree/v7.0.0) (2023-10-13)
 

--- a/src/routes/JobSummary/components/cells/HoldingsCell.js
+++ b/src/routes/JobSummary/components/cells/HoldingsCell.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { useStripes } from '@folio/stripes/core';
+
 import {
   getRecordActionStatusLabel,
   getHotlinkCellFormatter,
@@ -15,6 +17,8 @@ export const HoldingsCell = ({
   itemInfo,
   locations,
 }) => {
+  const stripes = useStripes();
+
   const holdingsInfoCell = holdingsInfo?.map((holdings, index) => {
     const entityLabel = getRecordActionStatusLabel(holdings.actionStatus);
     const holdingsId = holdings.id;
@@ -34,7 +38,7 @@ export const HoldingsCell = ({
 
     return (
       <div key={index} style={{ paddingBottom: '7px' }}>
-        {getHotlinkCellFormatter(isHotlink, entityLabel, path, 'holdings')}
+        {getHotlinkCellFormatter(isHotlink, entityLabel, path, 'holdings', stripes)}
         {!isDiscarded && locationCode ? ` (${locationCode})` : ''}
         {spacing}
       </div>

--- a/src/routes/JobSummary/components/cells/HoldingsCell.js
+++ b/src/routes/JobSummary/components/cells/HoldingsCell.js
@@ -17,7 +17,7 @@ export const HoldingsCell = ({
   itemInfo,
   locations,
 }) => {
-  const stripes = useStripes();
+  const { okapi: { tenant } } = useStripes();
 
   const holdingsInfoCell = holdingsInfo?.map((holdings, index) => {
     const entityLabel = getRecordActionStatusLabel(holdings.actionStatus);
@@ -38,7 +38,7 @@ export const HoldingsCell = ({
 
     return (
       <div key={index} style={{ paddingBottom: '7px' }}>
-        {getHotlinkCellFormatter(isHotlink, entityLabel, path, 'holdings', stripes)}
+        {getHotlinkCellFormatter(isHotlink, entityLabel, path, 'holdings', tenant)}
         {!isDiscarded && locationCode ? ` (${locationCode})` : ''}
         {spacing}
       </div>

--- a/src/routes/JobSummary/components/cells/ItemCell.js
+++ b/src/routes/JobSummary/components/cells/ItemCell.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { useStripes } from '@folio/stripes/core';
+
 import {
   getRecordActionStatusLabel,
   getHotlinkCellFormatter,
@@ -12,6 +14,8 @@ export const ItemCell = ({
   sortedItemData,
   instanceId,
 }) => {
+  const stripes = useStripes();
+
   const itemsInfoCell = sortedItemData?.map((sortedItems, itemIndex) => {
     const groupOfItems = sortedItems?.map((item, index) => {
       const entityLabel = getRecordActionStatusLabel(item.actionStatus);
@@ -28,7 +32,7 @@ export const ItemCell = ({
 
       return (
         <span key={index}>
-          {getHotlinkCellFormatter(isHotlink, entityLabel, path, 'item')}
+          {getHotlinkCellFormatter(isHotlink, entityLabel, path, 'item', stripes)}
           {!isDiscarded && hrId ? ` (${hrId})` : ''}
           <br />
         </span>

--- a/src/routes/JobSummary/components/cells/ItemCell.js
+++ b/src/routes/JobSummary/components/cells/ItemCell.js
@@ -14,7 +14,7 @@ export const ItemCell = ({
   sortedItemData,
   instanceId,
 }) => {
-  const stripes = useStripes();
+  const { okapi: { tenant } } = useStripes();
 
   const itemsInfoCell = sortedItemData?.map((sortedItems, itemIndex) => {
     const groupOfItems = sortedItems?.map((item, index) => {
@@ -32,7 +32,7 @@ export const ItemCell = ({
 
       return (
         <span key={index}>
-          {getHotlinkCellFormatter(isHotlink, entityLabel, path, 'item', stripes)}
+          {getHotlinkCellFormatter(isHotlink, entityLabel, path, 'item', tenant)}
           {!isDiscarded && hrId ? ` (${hrId})` : ''}
           <br />
         </span>

--- a/src/routes/JobSummary/components/utils.js
+++ b/src/routes/JobSummary/components/utils.js
@@ -22,13 +22,16 @@ export const BaseLineCell = ({ children }) => (
   </div>
 );
 
-export const getHotlinkCellFormatter = (isHotlink, entityLabel, path, entity) => {
+export const getHotlinkCellFormatter = (isHotlink, entityLabel, path, entity, stripes) => {
   if (isHotlink) {
     return (
       <BaseLineCell>
         <TextLink
           data-test-entity-name={entity}
-          to={path}
+          to={{
+            pathname: path,
+            state: { tenantTo: stripes?.okapi?.tenant }
+          }}
         >
           {entityLabel}
         </TextLink>

--- a/src/routes/JobSummary/components/utils.js
+++ b/src/routes/JobSummary/components/utils.js
@@ -22,7 +22,7 @@ export const BaseLineCell = ({ children }) => (
   </div>
 );
 
-export const getHotlinkCellFormatter = (isHotlink, entityLabel, path, entity, stripes) => {
+export const getHotlinkCellFormatter = (isHotlink, entityLabel, path, entity, tenant) => {
   if (isHotlink) {
     return (
       <BaseLineCell>
@@ -30,7 +30,7 @@ export const getHotlinkCellFormatter = (isHotlink, entityLabel, path, entity, st
           data-test-entity-name={entity}
           to={{
             pathname: path,
-            state: { tenantTo: stripes?.okapi?.tenant }
+            state: { tenantTo: tenant }
           }}
         >
           {entityLabel}


### PR DESCRIPTION
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* When user clicks on holdings and item hotlink, send `state` prop with current tenantId

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
[UIDATIMP-1551](https://issues.folio.org/browse/UIDATIMP-1551)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-data-import/assets/85172747/9d949b24-8de6-4999-b811-a3e23b3a30da


