### PR TITLE
UIDATIMP-1549: The '[number of records] - records found' subtitle is displayed after clicking on the textLink error counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-data-import
 
+## **7.0.2** (in progress)
+
+### Bugs fixed:
+* The '[number of records] - records found' subtitle is displayed after clicking on the textLink error counter (UIDATIMP-1549)
+
 ## [7.0.1](https://github.com/folio-org/ui-data-import/tree/v7.0.1) (2023-10-27)
 
 ### Features added:

--- a/src/routes/JobSummary/JobSummary.js
+++ b/src/routes/JobSummary/JobSummary.js
@@ -154,6 +154,7 @@ const JobSummaryComponent = props => {
 
   const renderHeader = renderProps => {
     const resultCountMessageId = 'stripes-smart-components.searchResultsCountHeader';
+    const errorsCountMessageId = 'ui-data-import.errorsCountHeader';
     const label = (
       <SettingsLabel
         iconKey={isEdifactType ? FOLIO_RECORD_TYPES.INVOICE.iconKey : 'app'}
@@ -179,7 +180,7 @@ const JobSummaryComponent = props => {
               values={{ hrId: jobExecutionsHrId }}
             />
             <FormattedMessage
-              id={resultCountMessageId}
+              id={!isErrorsOnly ? resultCountMessageId : errorsCountMessageId}
               values={{ count: getSource().totalCount() }}
             />
           </>

--- a/src/routes/JobSummary/JobSummary.test.js
+++ b/src/routes/JobSummary/JobSummary.test.js
@@ -69,11 +69,11 @@ const jobLogEntriesResources = {
 const jobLogResources = {
   jobLog: { records: [{}] },
 };
-const getResources = (dataType, jobExecutionsId) => ({
+const getResources = ({ dataType, jobExecutionsId, isErrorsOnly = false }) => ({
   ...getJobExecutionsResources(dataType, jobExecutionsId),
   ...jobLogEntriesResources,
   ...jobLogResources,
-  query: { errorsOnly: false },
+  query: { errorsOnly: isErrorsOnly },
   resultCount: 1,
 });
 
@@ -82,12 +82,17 @@ const mutator = {
 };
 const stripesMock = buildStripes();
 
-const renderJobSummary = ({ dataType = 'MARC', resources, context = defaultUploadContext }) => {
+const renderJobSummary = ({
+  dataType = 'MARC',
+  isErrorsOnly = false,
+  resources,
+  context = defaultUploadContext,
+}) => {
   const component = (
     <Router>
       <UploadingJobsContext.Provider value={context}>
         <JobSummary
-          resources={resources || getResources(dataType)}
+          resources={resources || getResources({ dataType, isErrorsOnly })}
           mutator={mutator}
           location={{
             search: '',
@@ -131,6 +136,12 @@ describe('Job summary page', () => {
       const { getByText } = renderJobSummary({});
 
       expect(getByText(/1 record found/i)).toBeDefined();
+    });
+
+    it('should render total count of errors if it is filtered down by errors', () => {
+      const { getByText } = renderJobSummary({ isErrorsOnly: true });
+
+      expect(getByText(/1 error found/i)).toBeDefined();
     });
 
     it('should render hrId', () => {
@@ -186,7 +197,7 @@ describe('Job summary page', () => {
       >
         <Router>
           <JobSummary
-            resources={getResources('MARC', jobExecutionsId)}
+            resources={getResources({ dataType: 'MARC', jobExecutionsId })}
             mutator={mutator}
             location={{
               search: '',

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -39,7 +39,7 @@
   "import-log": "Import Log for Record <b>{recordOrder} ({recordTitle})</b>",
   "noRecord": "No record",
   "recordsCount": "{count, plural, one {# record} other {# records}}",
-  "errorsCount": "{count, plural, one {# error} other {# errors}}",
+  "errorsCountHeader": "{count, plural, one {# error found} other {# errors found}}",
   "emptyMessage": "This {type} contains no items",
   "warning": "WARNING!",
   "list": "list",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
The **'[number of records] - records found'** instead of the **'[number of records] - errors found'** subtitle is displayed after clicking on the textLink error counter.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Display the correct translations key

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1549

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
<img width="1512" alt="image" src="https://github.com/folio-org/ui-data-import/assets/55138456/0c0400ec-8e81-4ff2-9948-8aaee40fb85b">


<img width="1512" alt="image" src="https://github.com/folio-org/ui-data-import/assets/55138456/25494462-b526-45fc-8586-dbbca327b75b">
