### PR TITLE
UIDATIMP-1562 - Job Profile view displaying multiple links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed:
 * The '[number of records] - records found' subtitle is displayed after clicking on the textLink error counter (UIDATIMP-1549)
+* Job profiles view - Jobs using this profile displaying multiple entries for single-part jobs. (UIDATIMP-1562)
 
 ## [7.0.1](https://github.com/folio-org/ui-data-import/tree/v7.0.1) (2023-10-27)
 

--- a/src/settings/JobProfiles/tests/JobProfiles.test.js
+++ b/src/settings/JobProfiles/tests/JobProfiles.test.js
@@ -21,6 +21,7 @@ import {
 import {
   createJobProfiles,
   jobProfilesShape,
+  getAssociatedJobsURL,
 } from '../JobProfiles';
 
 const history = createMemoryHistory();
@@ -242,6 +243,19 @@ describe('JobProfiles component', () => {
       fireEvent.click(closeButton);
 
       expect(getByText('Are you sure?')).toBeInTheDocument();
+    });
+  });
+
+  describe('getAssociatedJobsURL', () => {
+    const splittingTrueResources = { splitStatus: { records: [{ splitStatus: true }] } };
+    const splittingFalseResources = { splitStatus: { records: [{ splitStatus: false }] } };
+
+    it('returns splitting URL when splitting is active', () => {
+      expect(getAssociatedJobsURL(splittingTrueResources, 'splittingTrueUrl', 'splittingFalseUrl')).toEqual('splittingTrueUrl');
+    });
+
+    it('returns non-splitting URL when splitting is inactive', () => {
+      expect(getAssociatedJobsURL(splittingFalseResources, 'splittingTrueUrl', 'splittingFalseUrl')).toEqual('splittingFalseUrl');
     });
   });
 });

--- a/src/settings/JobProfiles/tests/JobProfiles.test.js
+++ b/src/settings/JobProfiles/tests/JobProfiles.test.js
@@ -21,7 +21,6 @@ import {
 import {
   createJobProfiles,
   jobProfilesShape,
-  getAssociatedJobsURL,
 } from '../JobProfiles';
 
 const history = createMemoryHistory();
@@ -243,19 +242,6 @@ describe('JobProfiles component', () => {
       fireEvent.click(closeButton);
 
       expect(getByText('Are you sure?')).toBeInTheDocument();
-    });
-  });
-
-  describe('getAssociatedJobsURL', () => {
-    const splittingTrueResources = { splitStatus: { records: [{ splitStatus: true }] } };
-    const splittingFalseResources = { splitStatus: { records: [{ splitStatus: false }] } };
-
-    it('returns splitting URL when splitting is active', () => {
-      expect(getAssociatedJobsURL(splittingTrueResources, 'splittingTrueUrl', 'splittingFalseUrl')).toEqual('splittingTrueUrl');
-    });
-
-    it('returns non-splitting URL when splitting is inactive', () => {
-      expect(getAssociatedJobsURL(splittingFalseResources, 'splittingTrueUrl', 'splittingFalseUrl')).toEqual('splittingFalseUrl');
     });
   });
 });

--- a/src/settings/JobProfiles/tests/ViewJobProfile.test.js
+++ b/src/settings/JobProfiles/tests/ViewJobProfile.test.js
@@ -369,8 +369,10 @@ describe('ViewJobProfile component', () => {
   });
 
   describe('getAssociatedJobsURL', () => {
-    const splittingTrueResources = { splitStatus: { records: [{ splitStatus: true }] } };
-    const splittingFalseResources = { splitStatus: { records: [{ splitStatus: false }] } };
+    const splittingTrueResources = { splitStatus: { isPending: false, records: [{ splitStatus: true }] } };
+    const splittingFalseResources = { splitStatus: { isPending: false, records: [{ splitStatus: false }] } };
+    const undefinedResources = {}
+    const undefinedResourcesEmpty = { splitStatus: { isPending: false, records: [] } };
 
     it('returns splitting URL when splitting is active', () => {
       expect(getAssociatedJobsURL(splittingTrueResources, 'splittingTrueUrl', 'splittingFalseUrl')).toEqual('splittingTrueUrl');
@@ -378,6 +380,14 @@ describe('ViewJobProfile component', () => {
 
     it('returns non-splitting URL when splitting is inactive', () => {
       expect(getAssociatedJobsURL(splittingFalseResources, 'splittingTrueUrl', 'splittingFalseUrl')).toEqual('splittingFalseUrl');
+    });
+
+    it('returns undefined when resource isn\'t ready', () => {
+      expect(getAssociatedJobsURL(undefinedResources, 'splittingTrueUrl', 'splittingFalseUrl')).toEqual(undefined);
+    });
+
+    it('returns undefined when resource returns empty', () => {
+      expect(getAssociatedJobsURL(undefinedResourcesEmpty, 'splittingTrueUrl', 'splittingFalseUrl')).toEqual(undefined);
     });
   });
 });

--- a/src/settings/JobProfiles/tests/ViewJobProfile.test.js
+++ b/src/settings/JobProfiles/tests/ViewJobProfile.test.js
@@ -20,7 +20,7 @@ import '../../../../test/jest/__mock__';
 
 import { STATUS_CODES } from '../../../utils';
 
-import { ViewJobProfile } from '../ViewJobProfile';
+import { ViewJobProfile, getAssociatedJobsURL } from '../ViewJobProfile';
 import { UploadingJobsContext } from '../../../components';
 
 const uploadContext = (canUseObjectStorage) => (
@@ -365,6 +365,19 @@ describe('ViewJobProfile component', () => {
       fireEvent.click(cancelButton[0]);
 
       await waitFor(() => expect(queryByText('Are you sure you want to run this job?')).not.toBeInTheDocument());
+    });
+  });
+
+  describe('getAssociatedJobsURL', () => {
+    const splittingTrueResources = { splitStatus: { records: [{ splitStatus: true }] } };
+    const splittingFalseResources = { splitStatus: { records: [{ splitStatus: false }] } };
+
+    it('returns splitting URL when splitting is active', () => {
+      expect(getAssociatedJobsURL(splittingTrueResources, 'splittingTrueUrl', 'splittingFalseUrl')).toEqual('splittingTrueUrl');
+    });
+
+    it('returns non-splitting URL when splitting is inactive', () => {
+      expect(getAssociatedJobsURL(splittingFalseResources, 'splittingTrueUrl', 'splittingFalseUrl')).toEqual('splittingFalseUrl');
     });
   });
 });

--- a/src/settings/JobProfiles/tests/ViewJobProfile.test.js
+++ b/src/settings/JobProfiles/tests/ViewJobProfile.test.js
@@ -371,7 +371,7 @@ describe('ViewJobProfile component', () => {
   describe('getAssociatedJobsURL', () => {
     const splittingTrueResources = { splitStatus: { isPending: false, records: [{ splitStatus: true }] } };
     const splittingFalseResources = { splitStatus: { isPending: false, records: [{ splitStatus: false }] } };
-    const undefinedResources = {}
+    const undefinedResources = {};
     const undefinedResourcesEmpty = { splitStatus: { isPending: false, records: [] } };
 
     it('returns splitting URL when splitting is active', () => {


### PR DESCRIPTION
https://issues.folio.org/browse/UIDATIMP-1562

The Job Profile view in settings displayed multiple links for assocated jobs. This was confusing as some links contained the link to download the split source file, and others did not...

The approach was to adjust the query for the items to include only the child jobs - same behavior as the Job Log.

before:
![AssociatedJobs_before](https://github.com/folio-org/ui-data-import/assets/20704067/74859fd1-df14-41af-a89d-7f457acc5ca7)

after:
![image](https://github.com/folio-org/ui-data-import/assets/20704067/de13a470-3ecf-4c73-9f25-2878fd0331f6)

