### PR TITLE
UIDATIMP-1563 - remove failed jobs listing form composite job details. Include failed jobs in part calculation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed:
 * The '[number of records] - records found' subtitle is displayed after clicking on the textLink error counter (UIDATIMP-1549)
+* Totals inaccurate on running composite job cards. Removed the 'failed jobs' display in those items and included erroneous jobs in the calculation of 'processed' job parts. (UIDATIMP-1563)
 
 ## [7.0.1](https://github.com/folio-org/ui-data-import/tree/v7.0.1) (2023-10-27)
 

--- a/src/components/Jobs/Jobs.test.js
+++ b/src/components/Jobs/Jobs.test.js
@@ -345,7 +345,7 @@ describe('Composite jobs - Jobs component', () => {
       const { getAllByRole } = renderCompositeJobs();
       // Composite cards display a nested list of progress data that has 3 items...
       // we expect 3 more items per card.
-      expect(getAllByRole('listitem').length).toBe(runningJobs.length + runningJobs.length * 3);
+      expect(getAllByRole('listitem').length).toBe(runningJobs.length + runningJobs.length * 2);
     });
 
     it('Composite jobs - should display appropriate message when there are no running jobs', () => {

--- a/src/components/Jobs/Jobs.test.js
+++ b/src/components/Jobs/Jobs.test.js
@@ -408,10 +408,6 @@ describe('Composite jobs - Jobs component', () => {
       it('Composite jobs - should display number of slices completed with error', () => {
         expect(within(jobCard).getByText('Completed with errors: 2')).toBeInTheDocument();
       });
-
-      it('Composite jobs - should display number of failed', () => {
-        expect(within(jobCard).getByText('Failed: 2')).toBeInTheDocument();
-      });
     });
 
     describe('Composite jobs - When delete button on running job card is clicked', () => {

--- a/src/components/Jobs/components/Job/Job.js
+++ b/src/components/Jobs/components/Job/Job.js
@@ -95,7 +95,7 @@ const renderCompositeDetails = (jobEntry, previousProgress = { processed: 0, tot
         id="ui-data-import.jobProgress.partsProcessed"
         tagName="div"
         values={{
-          current: completedSliceAmount,
+          current: failedSliceAmount + completedSliceAmount,
           total: totalSliceAmount,
         }}
       />
@@ -112,13 +112,6 @@ const renderCompositeDetails = (jobEntry, previousProgress = { processed: 0, tot
             id="ui-data-import.jobProgress.partsCompletedWithErrors"
             tagName="div"
             values={{ amount: erroredSliceAmount }}
-          />
-        </li>
-        <li className={css.listItem}>
-          <FormattedMessage
-            id="ui-data-import.jobProgress.partsFailed"
-            tagName="div"
-            values={{ amount: failedSliceAmount }}
           />
         </li>
       </ul>


### PR DESCRIPTION
https://issues.folio.org/browse/UIDATIMP-1563

It was difficult to differentiate between "failed" jobs and jobs "completed with errors" from the level of Composite Jobs, so the overlap in numbers was confusing for users. We opted to just remove the failed jobs line from the card details altogether.

Also, the 'Job parts processed' field was not accounting for failed jobs in its 'processed' number, so now those number make better sense since both processed and 'error' status jobs are considered.

After:
![image](https://github.com/folio-org/ui-data-import/assets/20704067/82bc3867-ca41-4ba6-ab20-4367af6eaac4)
