### PR TITLE
UIDATIMP-1557 long loading of data on UI-data import landing page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed:
 * The '[number of records] - records found' subtitle is displayed after clicking on the textLink error counter (UIDATIMP-1549)
+* Display loading spinners while running jobs and job log displays are loading. (UIDATIMP-1557)
 
 ## [7.0.1](https://github.com/folio-org/ui-data-import/tree/v7.0.1) (2023-10-27)
 

--- a/src/components/DataFetcher/DataFetcher.js
+++ b/src/components/DataFetcher/DataFetcher.js
@@ -109,11 +109,13 @@ export class DataFetcher extends Component {
         records: PropTypes.arrayOf(
           PropTypes.shape({ jobExecutions: PropTypes.arrayOf(jobExecutionPropTypes).isRequired }),
         ).isRequired,
+        hasLoaded: PropTypes.bool,
       }),
       logs: PropTypes.shape({
         records: PropTypes.arrayOf(
           PropTypes.shape({ jobExecutions: PropTypes.arrayOf(jobExecutionPropTypes).isRequired }),
         ).isRequired,
+        hasLoaded: PropTypes.bool,
       }),
       splitStatus: PropTypes.shape({
         hasLoaded: PropTypes.bool,
@@ -216,7 +218,7 @@ export class DataFetcher extends Component {
   mapResourcesToState(isEmpty) {
     const { resources: { jobs, logs } } = this.props;
 
-    const contextData = { hasLoaded: true };
+    const contextData = { hasLoaded: (jobs.hasLoaded && logs.hasLoaded)};
 
     forEach({ jobs, logs }, (resourceValue, resourceName) => {
       contextData[resourceName] = isEmpty ? [] : get(resourceValue, ['records', 0, 'jobExecutions'], []);

--- a/src/components/DataFetcher/DataFetcher.js
+++ b/src/components/DataFetcher/DataFetcher.js
@@ -218,7 +218,7 @@ export class DataFetcher extends Component {
   mapResourcesToState(isEmpty) {
     const { resources: { jobs, logs } } = this.props;
 
-    const contextData = { hasLoaded: (jobs.hasLoaded && logs.hasLoaded)};
+    const contextData = { hasLoaded: (jobs.hasLoaded && logs.hasLoaded) };
 
     forEach({ jobs, logs }, (resourceValue, resourceName) => {
       contextData[resourceName] = isEmpty ? [] : get(resourceValue, ['records', 0, 'jobExecutions'], []);

--- a/src/components/DataFetcher/DataFetcher.test.js
+++ b/src/components/DataFetcher/DataFetcher.test.js
@@ -32,6 +32,7 @@ const buildMutator = (resetFn, getFn) => ({
 
 const resources = buildResources({
   resourceName: 'logs',
+  hasLoaded: true,
   records: [{
     jobExecutions: [{
       id: '1',
@@ -57,6 +58,9 @@ const resources = buildResources({
     splitStatus: {
       hasLoaded: true,
       records: [{ splitStatus: true }]
+    },
+    jobs: {
+      hasLoaded: true,
     }
   }
 });


### PR DESCRIPTION
https://issues.folio.org/browse/UIDATIMP-1557

Adjust code to display loading spinners rather than the "No records found" messages.
