### PR TITLE
UIDATIMP-1557 Slow initial load times

### DIFF
--- a/src/components/DataFetcher/DataFetcher.js
+++ b/src/components/DataFetcher/DataFetcher.js
@@ -62,7 +62,7 @@ const compositeLogsUrl = createUrlFromArray('metadata-provider/jobExecutions', [
 
 export function getJobSplittingURL(resources, splittingURL, nonSplitting) {
   const { split_status: splitStatus } = resources;
-  if (!splitStatus?.isPending) {
+  if (splitStatus?.records.length > 0 || !splitStatus?.isPending) {
     if (splitStatus?.records[0]?.splitStatus) {
       return splittingURL;
     } else if (splitStatus?.records[0]?.splitStatus === false) {
@@ -143,7 +143,9 @@ export class DataFetcher extends Component {
     this.initialFetchPending = false;
     if (!statusLoaded && splitStatus?.hasLoaded) {
       this.setState({ statusLoaded: true }, () => {
-        if (!this.initialFetchPending) this.initialize();
+        if (!this.initialFetchPending) {
+          this.initialize();
+        }
       });
     }
   }
@@ -153,7 +155,9 @@ export class DataFetcher extends Component {
     const { statusLoaded } = state;
     if (!statusLoaded && splitStatus?.hasLoaded) {
       this.setState({ statusLoaded: true }, () => {
-        if (!this.initialFetchPending) this.initialize();
+        if (!this.initialFetchPending) {
+          this.initialize();
+        }
       });
     }
   }


### PR DESCRIPTION
In a previous PR, we changed it so that the listings would display a loading spinner rather than an empty records message. This PR resolves slowness in the initial load of data.

Since the queries for logs and running jobs can change depending on the response of the `splitStatus` endpoint, we have to wait for that resource to come back in order send the correct query for logs/job items. The behavior was strange - An initial load would be pretty quick, but if you navigated away from the app and came back, it would be noticibly slower.
The returns of the `splitStatus` endpoint are stored in redux, so they persist. The code was only making use of the `isPending` field for the request, but not checking to see if any data was already existing that it could use. This could potentially cause the GETs for logs and jobs to not return data due to the resulting path being `undefined`, which could cause the UI to wait a whole cycle of its `setTimeout` data polling before it received the data.

The update just includes a check for existing data, and if it's there - if the `splitStatus` has already loaded, it goes ahead and uses that rather than waiting.