### PR TITLE
UIDATIMP-1571: Order field is nor populated during linking/unlinking profiles to job profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@
 
 ### Bugs fixed:
 * Set per-tenant limit to retrieve the data. (UIDATIMP-1566)
+
+## **7.0.4** (in progress)
+
+### Bugs fixed:
 * Action profiles links to wrong job profile. (UIDATIMP-1568)
 * Fix inconsistent behavior during editing job profiles (UIDATIMP-1530)
+* Order field is nor populated during linking/unlinking profiles to job profile (UIDATIMP-1571)
 
 ## [7.0.3](https://github.com/folio-org/ui-data-import/tree/v7.0.3) (2023-11-09)
 

--- a/src/components/ProfileTree/ProfileTree.js
+++ b/src/components/ProfileTree/ProfileTree.js
@@ -99,7 +99,7 @@ export const ProfileTree = memo(({
   const findRelIndex = (relations, masterId, line, reactTo) => {
     return relations.findIndex(rel => rel.masterProfileId === masterId
       && rel.detailProfileId === line.content.id
-      && rel.reactTo === reactTo);
+      && line.reactTo === reactTo);
   };
 
   const composeRelations = ({
@@ -119,7 +119,7 @@ export const ProfileTree = memo(({
       detailProfileId: item.content.id,
       detailWrapperId,
       detailProfileType: isSnakeCase(detailType) ? detailType : snakeCase(detailType).slice(0, -1).toLocaleUpperCase(),
-      order: item.order ?? order + index,
+      order: item.order || order + index,
     };
 
     if (masterId === PROFILE_TYPES.MATCH_PROFILE) {
@@ -181,19 +181,6 @@ export const ProfileTree = memo(({
     setSectionData(sectionData);
   };
 
-  const removeLineAndUpdateOrder = (lines, indexOfRemovedLine) => lines.reduce((accumulator, currentValue) => {
-    const { order } = currentValue;
-
-    if (order < indexOfRemovedLine) return [...accumulator, currentValue];
-
-    // remove line from array
-    if (order === indexOfRemovedLine) return [...accumulator];
-
-    // decrease order value for rest of lines in array
-    return [...accumulator, { ...currentValue, order: order - 1 }];
-  },
-  []);
-
   const unlink = ({
     parentData: sectionData,
     setParentData,
@@ -231,8 +218,9 @@ export const ProfileTree = memo(({
       // set unlinked relations to component state
       setDeletedRelations(relsToDel);
     } else {
-      // remove unlinked line and update order value for added relations
-      const relsToAdd = removeLineAndUpdateOrder([...addedRelations], indexOfUnlinkedProfileInAddedProfiles);
+      const relsToAdd = [...addedRelations];
+
+      relsToAdd.splice(indexOfUnlinkedProfileInAddedProfiles, 1);
 
       // set added relations to form field
       onLink(relsToAdd);
@@ -241,7 +229,10 @@ export const ProfileTree = memo(({
       setAddedRelations(relsToAdd);
     }
 
-    const newSectionData = removeLineAndUpdateOrder([...sectionData], index);
+    const newSectionData = [...sectionData];
+
+    newSectionData.splice(index, 1);
+
     setParentData(newSectionData);
 
     const getNewProfileTreeData = function buildData(array, lineToCompare) {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->


## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Order field is not correctly set, rollback changes to fix he issue

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://issues.folio.org/browse/UIDATIMP-1571

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
