### PR TITLE
UIDATIMP-1576: Change path for holdingsRecord.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Action profile Settings: suppress checkboxes and checkbox actions. (UIDATIMP-1497)
 * Field mapping profile Settings: suppress checkboxes and checkbox actions. (UIDATIMP-1498)
 * Job profile Settings: suppress checkboxes and checkbox actions. (UIDATIMP-1495)
+* Change path for holdingsRecord.json. (UIDATIMP-1576)
 
 ### Bugs fixed:
 * Set per-tenant limit to retrieve the data. (UIDATIMP-1566)

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -422,7 +422,7 @@ export const ACQ_DATA_RESOURCE_PATHS = [
 
 export const HOLDINGS_RESOURCE_PATHS = [
   'raml-util/schemas/metadata.schema',
-  'holdingsrecord.json',
+  'holdings-storage/holdingsRecord.json',
 ];
 
 export const ITEM_RESOURCE_PATHS = [


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* Since `holdingsRecord.json` has been moved to `holdings-storage/holdingsRecord.json` we need to change path on UI respectively

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
[UIDATIMP-1576](https://issues.folio.org/browse/UIDATIMP-1576)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://github.com/folio-org/ui-data-import/assets/85172747/8f4b9109-7f8e-4c93-a2b0-a8baecd570a2)

