### PR TITLE
UIDATIMP-1577 Refactor css away from color() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Field mapping profile Settings: suppress checkboxes and checkbox actions. (UIDATIMP-1498)
 * Job profile Settings: suppress checkboxes and checkbox actions. (UIDATIMP-1495)
 * Change path for holdingsRecord.json. (UIDATIMP-1576)
+* Refactor CSS away from `color()` function. (UIDATIMP-1577)
 
 ### Bugs fixed:
 * Set per-tenant limit to retrieve the data. (UIDATIMP-1566)

--- a/src/components/Jobs/components/Job/Job.css
+++ b/src/components/Jobs/components/Job/Job.css
@@ -26,7 +26,7 @@
 
   &.deletingInProgress {
     border-color: var(--danger);
-    background-color: color(var(--error) alpha(-90%));
+    background-color: oklch(from var(--error) l c h / 10%);
 
     & .deleteIcon {
       display: none;
@@ -36,7 +36,7 @@
   .fileItemDanger {
     padding-right: 60px;
     border-color: var(--danger);
-    background-color: color(var(--error) alpha(-90%));
+    background-color: oklch(from var(--error) l c h / 10%);
   }
 }
 

--- a/src/components/RecordTypesSelect/RecordTypesSelect.css
+++ b/src/components/RecordTypesSelect/RecordTypesSelect.css
@@ -51,7 +51,7 @@
 }
 
 .clickableItem:hover {
-  background-color: color(var(--primary) whiteness(30%))
+  background-color: hwb(from var(--primary) h 30% b);
 }
 
 .disabledItem {

--- a/src/components/UploadingJobsDisplay/components/FileItem/FileItem.css
+++ b/src/components/UploadingJobsDisplay/components/FileItem/FileItem.css
@@ -11,7 +11,7 @@
 .fileItemDanger {
   padding-right: 60px;
   border-color: var(--danger);
-  background-color: color(var(--error) alpha(-90%));
+  background-color: oklch(from var(--error) l c h / 10%);
 }
 
 .fileItemUploading {


### PR DESCRIPTION
https://issues.folio.org/browse/UIDATIMP-1577

In the future, we would like to remove one of our out-dated postcss-plugins - `postcss-color-function` - the native `color()` function has changed since then - it is no longer used for color manipulations or blending.

The functionality has been replaced in spec by CSS color-module 5's [relative color syntax](https://developer.chrome.com/blog/css-relative-color-syntax).

This will require the work from https://github.com/folio-org/stripes-webpack/pull/133 for firefox support.