### PR TITLE
UIDATIMP-1585: Update unit tests after changes in stripes-smart-components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Refactor CSS away from `color()` function. (UIDATIMP-1577)
 * Match profile Settings: suppress checkboxes and checkbox actions. (UIDATIMP-1496)
 * Display missed options in the 'Existing holdings record field' section after creating match profile. (UIDATIMP-1579)
+* Update unit tests after changes in stripes-smart-components (UIDATIMP-1585)
 
 ### Bugs fixed:
 * Set per-tenant limit to retrieve the data. (UIDATIMP-1566)

--- a/src/settings/MARCFieldProtection/MARCFieldProtection.test.js
+++ b/src/settings/MARCFieldProtection/MARCFieldProtection.test.js
@@ -82,7 +82,7 @@ const stripesCustomProps = {
   connect: Component => props => (
     <Component
       {...props}
-      mutator={{}}
+      mutator={{ tenant: { replace: () => {} } }}
       resources={resources}
     />
   ),


### PR DESCRIPTION
Add `tenant` to `mutator` after recent [changes](https://github.com/folio-org/stripes-smart-components/commit/344c2afbfc1680a6bb8928b2d7a15edfef5dea53) in stripes-smart-components to prevent unit tests from failures.

https://issues.folio.org/browse/UIDATIMP-1585