### PR TITLE
UIDATIMP-1578: Add title for each page in Data import  settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Update unit tests after changes in stripes-smart-components. (UIDATIMP-1585)
 * Mock ResizeObserver to fix failed tests. (UIDATIMP-1586)
 * Make changes in requests for Log Details. (UIDATIMP-1558)
+* Set Data Import settings HTML page title this format - `<<App name>> settings - <<selected page name>> - FOLIO` (UIDATIMP-1578)
 
 ### Bugs fixed:
 * Set per-tenant limit to retrieve the data. (UIDATIMP-1566)

--- a/src/components/ListView/ListView.js
+++ b/src/components/ListView/ListView.js
@@ -2,7 +2,10 @@ import React, {
   Component,
   createRef,
 } from 'react';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  injectIntl,
+} from 'react-intl';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import {
@@ -15,7 +18,10 @@ import {
   ConfirmationModal,
 } from '@folio/stripes/components';
 import { buildUrl } from '@folio/stripes/smart-components';
-import { stripesShape } from '@folio/stripes/core';
+import {
+  TitleManager,
+  stripesShape,
+} from '@folio/stripes/core';
 import { listTemplate } from '@folio/stripes-data-transfer-components';
 
 import {
@@ -32,6 +38,7 @@ import { SearchAndSort } from '../SearchAndSort';
 import { ActionMenu } from '../ActionMenu';
 import { createNetworkMessage } from '../Callout';
 
+@injectIntl
 export class ListView extends Component {
   static propTypes = {
     stripes: stripesShape.isRequired,
@@ -66,6 +73,7 @@ export class ListView extends Component {
     columnWidths: PropTypes.object.isRequired,
     initialValues: PropTypes.object.isRequired,
     renderHeaders: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
     isFullScreen: PropTypes.bool,
     defaultSort: PropTypes.string,
   };
@@ -224,6 +232,7 @@ export class ListView extends Component {
       isFullScreen,
       defaultSort,
       nonInteractiveHeaders,
+      intl,
     } = this.props;
     const { showRestoreModal } = this.state;
 
@@ -245,6 +254,10 @@ export class ListView extends Component {
       >
         {props => (
           <>
+            <TitleManager
+              page={intl.formatMessage({ id: 'ui-data-import.settings.dataImport.title' })}
+              record={intl.formatMessage({ id: `ui-data-import.settings.${ENTITY_KEY}.title` })}
+            />
             <SearchAndSort
               objectName={objectName}
               finishedResourceName={ENTITY_KEY}

--- a/src/settings/ActionProfiles/ActionProfilesForm.js
+++ b/src/settings/ActionProfiles/ActionProfilesForm.js
@@ -18,6 +18,7 @@ import {
 import {
   useStripes,
   checkIfUserInCentralTenant,
+  TitleManager,
 } from '@folio/stripes/core';
 import {
   Headline,
@@ -214,6 +215,11 @@ export const ActionProfilesFormComponent = ({
         onSubmit={onSubmit}
         onCancel={onCancel}
       >
+        <TitleManager
+          prefix={`${formatMessage({ id: 'ui-data-import.settings.dataImport.title' })} - `}
+          page={formatMessage({ id: 'ui-data-import.settings.actionProfiles.title' })}
+          record={`${formatMessage({ id: `ui-data-import.${layerType}` })} ${profile.name}`}
+        />
         <Headline
           size="xx-large"
           tag="h2"

--- a/src/settings/ActionProfiles/ViewActionProfile/ViewActionProfile.js
+++ b/src/settings/ActionProfiles/ViewActionProfile/ViewActionProfile.js
@@ -1,7 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  injectIntl,
+} from 'react-intl';
 import { get } from 'lodash';
 
 import {
@@ -53,6 +56,7 @@ import {
 
 import sharedCss from '../../../shared.css';
 
+@injectIntl
 @stripesConnect
 @withTags
 @withRouter
@@ -95,6 +99,7 @@ export class ViewActionProfile extends Component {
     tagsEnabled: PropTypes.bool,
     onClose: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
     ENTITY_KEY: PropTypes.string, // eslint-disable-line
     actionMenuItems: PropTypes.arrayOf(PropTypes.string), // eslint-disable-line
     accordionStatusRef: PropTypes.object,
@@ -202,6 +207,7 @@ export class ViewActionProfile extends Component {
       history,
       location,
       accordionStatusRef,
+      intl,
     } = this.props;
     const { showDeleteConfirmation } = this.state;
     const {
@@ -248,7 +254,11 @@ export class ViewActionProfile extends Component {
           renderHeader={this.renderPaneHeader}
           id="view-action-profile-pane"
         >
-          <TitleManager record={actionProfile.name} />
+          <TitleManager
+            prefix={`${intl.formatMessage({ id: 'ui-data-import.settings.dataImport.title' })} - `}
+            page={intl.formatMessage({ id: 'ui-data-import.settings.actionProfiles.title' })}
+            record={actionProfile.name}
+          />
           <Headline
             className={sharedCss.headline}
             data-test-headline

--- a/src/settings/DataImportSettings/DataImportSettings.js
+++ b/src/settings/DataImportSettings/DataImportSettings.js
@@ -3,12 +3,16 @@ import React, {
   createRef,
 } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  injectIntl,
+} from 'react-intl';
 
 import { Settings } from '@folio/stripes/smart-components';
 import { InfoPopover } from '@folio/stripes/components';
 import {
   stripesShape,
+  TitleManager,
   withRoot,
 } from '@folio/stripes/core';
 
@@ -26,11 +30,13 @@ import {
 
 import css from './DataImportSettings.css';
 
+@injectIntl
 @withRoot
 export class DataImportSettings extends Component {
   static propTypes = {
     stripes: stripesShape.isRequired,
     root: PropTypes.shape({ addReducer: PropTypes.func.isRequired }).isRequired,
+    intl: PropTypes.object.isRequired,
   };
 
   constructor(props) {
@@ -111,13 +117,15 @@ export class DataImportSettings extends Component {
 
   render() {
     return (
-      <Settings
-        {...this.props}
-        paneTitleRef={this.paneTitleRef}
-        navPaneWidth="15%"
-        sections={this.sections}
-        paneTitle={generateSettingsLabel('index.paneTitle')}
-      />
+      <TitleManager page={this.props.intl.formatMessage({ id: 'ui-data-import.settings.dataImport.title' })}>
+        <Settings
+          {...this.props}
+          paneTitleRef={this.paneTitleRef}
+          navPaneWidth="15%"
+          sections={this.sections}
+          paneTitle={generateSettingsLabel('index.paneTitle')}
+        />
+      </TitleManager>
     );
   }
 }

--- a/src/settings/FileExtensions/FileExtensionForm.js
+++ b/src/settings/FileExtensions/FileExtensionForm.js
@@ -1,9 +1,13 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  useIntl,
+} from 'react-intl';
 import { Field } from 'react-final-form';
 import { identity } from 'lodash';
 
+import { TitleManager } from '@folio/stripes/core';
 import {
   Headline,
   TextArea,
@@ -48,6 +52,7 @@ export const FileExtensionFormComponent = ({
   transitionToParams,
   baseUrl,
 }) => {
+  const { formatMessage } = useIntl();
   const isEditMode = Boolean(initialValues.id);
 
   const [dataTypesRequired, setDataTypesRequired] = useState(isEditMode ? !initialValues.importBlocked : true);
@@ -85,6 +90,10 @@ export const FileExtensionFormComponent = ({
     ? initialValues.extension
     : <FormattedMessage id="ui-data-import.settings.fileExtension.newMapping" />;
 
+  const pageTitle = isEditMode
+    ? `${formatMessage({ id: 'ui-data-import.edit' })} ${initialValues.extension}`
+    : formatMessage({ id: 'ui-data-import.create' });
+
   const onSubmit = async event => {
     await handleProfileSave(handleSubmit, form.reset, transitionToParams, baseUrl)(event);
   };
@@ -100,6 +109,11 @@ export const FileExtensionFormComponent = ({
         onSubmit={onSubmit}
         onCancel={onCancel}
       >
+        <TitleManager
+          prefix={`${formatMessage({ id: 'ui-data-import.settings.dataImport.title' })} - `}
+          page={formatMessage({ id: 'ui-data-import.settings.fileExtensions.title' })}
+          record={pageTitle}
+        />
         <Headline
           size="xx-large"
           tag="h2"

--- a/src/settings/FileExtensions/ViewFileExtension/ViewFileExtension.js
+++ b/src/settings/FileExtensions/ViewFileExtension/ViewFileExtension.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  injectIntl,
+} from 'react-intl';
 
 import {
   TitleManager,
@@ -36,6 +39,7 @@ import {
 
 import sharedCss from '../../../shared.css';
 
+@injectIntl
 @stripesConnect
 export class ViewFileExtension extends Component {
   static manifest = Object.freeze({
@@ -80,6 +84,7 @@ export class ViewFileExtension extends Component {
     ]).isRequired,
     onClose: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
     ENTITY_KEY: PropTypes.string, // eslint-disable-line
     actionMenuItems: PropTypes.arrayOf(PropTypes.string), // eslint-disable-line
   };
@@ -168,6 +173,7 @@ export class ViewFileExtension extends Component {
     const {
       history,
       location,
+      intl,
     } = this.props;
     const { showDeleteConfirmation } = this.state;
 
@@ -185,7 +191,11 @@ export class ViewFileExtension extends Component {
           renderHeader={this.renderPaneHeader}
           id="view-file-extension-pane"
         >
-          <TitleManager record={record.extension} />
+          <TitleManager
+            prefix={`${intl.formatMessage({ id: 'ui-data-import.settings.dataImport.title' })} - `}
+            page={intl.formatMessage({ id: 'ui-data-import.settings.fileExtensions.title' })}
+            record={record.extension}
+          />
           <Headline
             data-test-headline
             size="xx-large"

--- a/src/settings/JobProfiles/JobProfilesForm.js
+++ b/src/settings/JobProfiles/JobProfilesForm.js
@@ -9,7 +9,10 @@ import {
   useDispatch,
 } from 'react-redux';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  useIntl,
+} from 'react-intl';
 import { Field } from 'react-final-form';
 import {
   get,
@@ -33,7 +36,10 @@ import {
   FullScreenForm,
 } from '@folio/stripes-data-transfer-components';
 import stripesFinalForm from '@folio/stripes/final-form';
-import { stripesConnect } from '@folio/stripes/core';
+import {
+  TitleManager,
+  stripesConnect,
+} from '@folio/stripes/core';
 
 import {
   EditKeyShortcutsWrapper,
@@ -128,6 +134,8 @@ export const JobProfilesFormComponent = memo(({
     },
     [isLayerCreate, resources.profileSnapshots.records],
   );
+
+  const { formatMessage } = useIntl();
 
   const dispatch = useDispatch();
   const currentJobProfileTreeContent = useSelector(state => {
@@ -276,6 +284,11 @@ export const JobProfilesFormComponent = memo(({
           onCancel();
         }}
       >
+        <TitleManager
+          prefix={`${formatMessage({ id: 'ui-data-import.settings.dataImport.title' })} - `}
+          page={formatMessage({ id: 'ui-data-import.settings.jobProfiles.title' })}
+          record={`${formatMessage({ id: `ui-data-import.${layerType}` })} ${profile.name}`}
+        />
         <Headline
           size="xx-large"
           tag="h2"

--- a/src/settings/JobProfiles/ViewJobProfile/ViewJobProfile.js
+++ b/src/settings/JobProfiles/ViewJobProfile/ViewJobProfile.js
@@ -5,7 +5,10 @@ import React, {
   useMemo,
 } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, useIntl } from 'react-intl';
+import {
+  FormattedMessage,
+  useIntl,
+} from 'react-intl';
 import { get } from 'lodash';
 
 import {
@@ -352,7 +355,11 @@ const ViewJobProfileComponent = props => {
         renderHeader={renderPaneHeader}
         id="view-job-profile-pane"
       >
-        <TitleManager record={jobProfileRecord.name} />
+        <TitleManager
+          prefix={`${formatMessage({ id: 'ui-data-import.settings.dataImport.title' })} - `}
+          page={formatMessage({ id: 'ui-data-import.settings.jobProfiles.title' })}
+          record={jobProfileRecord?.name}
+        />
         <Headline
           className={sharedCss.headline}
           data-test-headline

--- a/src/settings/MARCFieldProtection/MARCFieldProtection.js
+++ b/src/settings/MARCFieldProtection/MARCFieldProtection.js
@@ -14,7 +14,10 @@ import {
   injectIntl,
 } from 'react-intl';
 
-import { withStripes } from '@folio/stripes/core';
+import {
+  TitleManager,
+  withStripes,
+} from '@folio/stripes/core';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 import { TextField } from '@folio/stripes/components';
 
@@ -246,27 +249,32 @@ export class MARCFieldProtection extends Component {
     };
 
     return (
-      <this.connectedControlledVocab
-        id="marc-field-protection"
-        baseUrl="field-protection-settings/marc"
-        records="marcFieldProtectionSettings"
-        label={intl.formatMessage({ id: 'ui-data-import.settings.marcFieldProtection.title' })}
-        labelSingular={<FormattedMessage id="ui-data-import.settings.marcFieldProtection.title" />}
-        objectLabel={<FormattedMessage id="ui-data-import.settings.marcFieldProtection.title" />}
-        listFormLabel={<FormattedMessage id="ui-data-import.settings.marcFieldProtection.listFormHeader" />}
-        columnMapping={columnMapping}
-        formatter={formatter}
-        readOnlyFields={readOnlyFields}
-        visibleFields={visibleFields}
-        hiddenFields={hiddenFields}
-        actionSuppressor={actionSuppressor}
-        itemTemplate={itemTemplate}
-        sortby="field"
-        validate={this.validateFields}
-        stripes={stripes}
-        fieldComponents={this.getFieldComponents()}
-        editable={hasPerm}
-      />
+      <TitleManager
+        page={intl.formatMessage({ id: 'ui-data-import.settings.dataImport.title' })}
+        record={intl.formatMessage({ id: 'ui-data-import.settings.marcFieldProtection.title' })}
+      >
+        <this.connectedControlledVocab
+          id="marc-field-protection"
+          baseUrl="field-protection-settings/marc"
+          records="marcFieldProtectionSettings"
+          label={intl.formatMessage({ id: 'ui-data-import.settings.marcFieldProtection.title' })}
+          labelSingular={<FormattedMessage id="ui-data-import.settings.marcFieldProtection.title" />}
+          objectLabel={<FormattedMessage id="ui-data-import.settings.marcFieldProtection.title" />}
+          listFormLabel={<FormattedMessage id="ui-data-import.settings.marcFieldProtection.listFormHeader" />}
+          columnMapping={columnMapping}
+          formatter={formatter}
+          readOnlyFields={readOnlyFields}
+          visibleFields={visibleFields}
+          hiddenFields={hiddenFields}
+          actionSuppressor={actionSuppressor}
+          itemTemplate={itemTemplate}
+          sortby="field"
+          validate={this.validateFields}
+          stripes={stripes}
+          fieldComponents={this.getFieldComponents()}
+          editable={hasPerm}
+        />
+      </TitleManager>
     );
   }
 }

--- a/src/settings/MappingProfiles/MappingProfilesForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm.js
@@ -22,6 +22,7 @@ import stripesForm from '@folio/stripes/form';
 import {
   useStripes,
   checkIfUserInCentralTenant,
+  TitleManager,
 } from '@folio/stripes/core';
 import {
   Headline,
@@ -348,6 +349,11 @@ export const MappingProfilesFormComponent = ({
           onCancel={onCancel}
           contentClassName={styles.mappingForm}
         >
+          <TitleManager
+            prefix={`${formatMessage({ id: 'ui-data-import.settings.dataImport.title' })} - `}
+            page={formatMessage({ id: 'ui-data-import.settings.mappingProfiles.title' })}
+            record={`${formatMessage({ id: `ui-data-import.${layerType}` })} ${profile.name}`}
+          />
           <Headline
             data-test-header-title
             id="profile-headline"

--- a/src/settings/MappingProfiles/ViewMappingProfile/ViewMappingProfile.js
+++ b/src/settings/MappingProfiles/ViewMappingProfile/ViewMappingProfile.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  injectIntl,
+} from 'react-intl';
 
 import {
   AppIcon,
@@ -67,6 +70,7 @@ import {
 
 import sharedCss from '../../../shared.css';
 
+@injectIntl
 @stripesConnect
 @withTags
 export class ViewMappingProfile extends Component {
@@ -109,6 +113,7 @@ export class ViewMappingProfile extends Component {
     tagsEnabled: PropTypes.bool,
     onClose: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
     ENTITY_KEY: PropTypes.string, // eslint-disable-line
     actionMenuItems: PropTypes.arrayOf(PropTypes.string), // eslint-disable-line
     accordionStatusRef: PropTypes.object,
@@ -222,6 +227,7 @@ export class ViewMappingProfile extends Component {
       history,
       location,
       accordionStatusRef,
+      intl,
     } = this.props;
     const { showDeleteConfirmation } = this.state;
 
@@ -293,7 +299,11 @@ export class ViewMappingProfile extends Component {
           renderHeader={this.renderPaneHeader}
           centerContent={false}
         >
-          <TitleManager record={name} />
+          <TitleManager
+            prefix={`${intl.formatMessage({ id: 'ui-data-import.settings.dataImport.title' })} - `}
+            page={intl.formatMessage({ id: 'ui-data-import.settings.mappingProfiles.title' })}
+            record={name}
+          />
           <Headline
             className={sharedCss.headline}
             data-test-headline

--- a/src/settings/MatchProfiles/MatchProfilesForm.js
+++ b/src/settings/MatchProfiles/MatchProfilesForm.js
@@ -19,6 +19,7 @@ import {
 
 import stripesFinalForm from '@folio/stripes/final-form';
 
+import { TitleManager } from '@folio/stripes/core';
 import {
   Headline,
   AccordionSet,
@@ -291,6 +292,11 @@ export const MatchProfilesFormComponent = memo(({
         onSubmit={onSubmit}
         onCancel={onCancel}
       >
+        <TitleManager
+          prefix={`${formatMessage({ id: 'ui-data-import.settings.dataImport.title' })} - `}
+          page={formatMessage({ id: 'ui-data-import.settings.matchProfiles.title' })}
+          record={`${formatMessage({ id: `ui-data-import.${layerType}` })} ${profile.name}`}
+        />
         <Headline
           size="xx-large"
           tag="h2"

--- a/src/settings/MatchProfiles/ViewMatchProfile/ViewMatchProfile.js
+++ b/src/settings/MatchProfiles/ViewMatchProfile/ViewMatchProfile.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  injectIntl,
+} from 'react-intl';
 import { get } from 'lodash';
 
 import {
@@ -55,6 +58,7 @@ import {
 import sharedCss from '../../../shared.css';
 import styles from '../MatchProfiles.css';
 
+@injectIntl
 @stripesConnect
 @withTags
 export class ViewMatchProfile extends Component {
@@ -97,6 +101,7 @@ export class ViewMatchProfile extends Component {
     tagsEnabled: PropTypes.bool,
     onClose: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
     parentResources: PropTypes.object,
     ENTITY_KEY: PropTypes.string, // eslint-disable-line
     actionMenuItems: PropTypes.arrayOf(PropTypes.string), // eslint-disable-line
@@ -207,6 +212,7 @@ export class ViewMatchProfile extends Component {
       history,
       location,
       accordionStatusRef,
+      intl,
     } = this.props;
     const { showDeleteConfirmation } = this.state;
 
@@ -247,7 +253,11 @@ export class ViewMatchProfile extends Component {
           fluidContentWidth
           id="view-match-profile-pane"
         >
-          <TitleManager record={matchProfile.name} />
+          <TitleManager
+            prefix={`${intl.formatMessage({ id: 'ui-data-import.settings.dataImport.title' })} - `}
+            page={intl.formatMessage({ id: 'ui-data-import.settings.matchProfiles.title' })}
+            record={matchProfile.name}
+          />
           <Headline
             className={sharedCss.headline}
             data-test-headline

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -209,6 +209,7 @@
   "settings.table.checkboxAll": "select all items",
   "settings.action.add": "Add",
   "settings.index.paneTitle": "Data import",
+  "settings.dataImport.title": "Data import settings",
   "settings.getStarted": "Click here to get started",
   "settings.profiles": "Profiles",
   "settings.learnMore": "Learn more",


### PR DESCRIPTION
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Added `Inventory settings - <<selected page name>> - FOLIO` title for each page
* When view the profile, the title is in format `Inventory settings - <<selected page name>> - <<profile name>> - FOLIO`
* When create a new profile, the title is in format `Inventory settings - <<selected page name>> - Create - FOLIO`
* When edit an existing profile, the title is in format `Inventory settings - <<selected page name>> - Edit <<profile name>> - FOLIO`
* When duplicate an existing profile, the title is in format `Inventory settings - <<selected page name>> - Duplicate <<profile name>> - FOLIO`

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
[UIDATIMP-1578](https://issues.folio.org/browse/UIDATIMP-1578)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-data-import/assets/85172747/15f409dc-011e-448c-a3ad-5ff0e329df9f

