### PR TITLE
UIDATIMP-1521: Not able to use system generated Match profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Job summary: error column does not display errors (UIDATIMP-1590)
 * Handle empty marc mapping label (UIDATIMP-1592)
 * Update style of Incoming Record button to match other buttons (UIDATIMP-1594)
+* Not able to use system generated Match profiles (UIDATIMP-1521)
 
 ## [7.0.5](https://github.com/folio-org/ui-data-import/tree/v7.0.5) (2023-12-06)
 

--- a/src/settings/MatchProfiles/MatchProfiles.js
+++ b/src/settings/MatchProfiles/MatchProfiles.js
@@ -22,8 +22,6 @@ import {
   INVOICE_RESOURCE_PATHS,
   ACQ_DATA_RESOURCE_PATHS,
   FIND_ALL_CQL,
-  OCLC_MATCH_EXISTING_SRS_RECORD_ID,
-  OCLC_MATCH_NO_SRS_RECORD_ID,
   getIdentifierTypes,
 } from '../../utils';
 import { ListView } from '../../components';
@@ -174,8 +172,7 @@ export const matchProfilesShape = {
         const search = _r?.query?.query;
         const sortQuery = sort ? `sortBy ${getSortQuery(sortMap, sort)}` : '';
         const searchQuery = search ? `AND ${getSearchQuery(queryTemplate, search)}` : '';
-        const withoutDefaultProfiles = `AND (id<>(${OCLC_MATCH_EXISTING_SRS_RECORD_ID} AND ${OCLC_MATCH_NO_SRS_RECORD_ID}))`;
-        const query = `${props.filterParams?.manifest?.query || FIND_ALL_CQL} ${withoutDefaultProfiles} ${searchQuery} ${sortQuery}`;
+        const query = `${props.filterParams?.manifest?.query || FIND_ALL_CQL} ${searchQuery} ${sortQuery}`;
 
         return { query };
       },

--- a/src/settings/MatchProfiles/MatchProfiles.test.js
+++ b/src/settings/MatchProfiles/MatchProfiles.test.js
@@ -17,11 +17,7 @@ import {
   translationsProperties,
 } from '../../../test/jest/helpers';
 
-import {
-  FIND_ALL_CQL,
-  OCLC_MATCH_EXISTING_SRS_RECORD_ID,
-  OCLC_MATCH_NO_SRS_RECORD_ID,
-} from '../../utils';
+import { FIND_ALL_CQL } from '../../utils';
 import { matchProfilesShape } from '.';
 import { MatchProfiles } from './MatchProfiles';
 
@@ -105,7 +101,7 @@ describe('MatchProfiles component', () => {
   describe('query string', () => {
     describe('when sort and query params are set', () => {
       it('should return correct query string', () => {
-        const expectedQuery = `propsQuery AND (id<>(${OCLC_MATCH_EXISTING_SRS_RECORD_ID} AND ${OCLC_MATCH_NO_SRS_RECORD_ID})) AND (
+        const expectedQuery = `propsQuery AND (
   name="testQuery*" OR
   existingRecordType="testQuery*" OR
   field="testQuery*" OR
@@ -130,11 +126,10 @@ describe('MatchProfiles component', () => {
 
     describe('when sort and query params are not set', () => {
       it('should return correct query string', () => {
-        const expectedQuery = `${FIND_ALL_CQL} AND (id<>(${OCLC_MATCH_EXISTING_SRS_RECORD_ID} AND ${OCLC_MATCH_NO_SRS_RECORD_ID}))`;
         const props = { filterParams: { manifest: { query: null } } };
         const { query } = matchProfilesShape.manifest.records.params(null, null, null, null, props);
 
-        expect(query.trim()).toEqual(expectedQuery);
+        expect(query.trim()).toEqual(FIND_ALL_CQL);
       });
     });
   });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
System should be updated to allow Default Inventory Single Record Match profiles to be:

- Viewable
- Linkable to Job Profiles
- but NOT be Editable

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Remove filtered by id default match profiles from the query.

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://folio-org.atlassian.net/browse/UIDATIMP-1521
## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
<img width="1510" alt="Screenshot 2024-03-07 at 17 38 33" src="https://github.com/folio-org/ui-data-import/assets/55138456/b00b1268-d039-4452-834e-47ef888df92f">
<img width="628" alt="Screenshot 2024-03-07 at 17 40 55" src="https://github.com/folio-org/ui-data-import/assets/55138456/2f53a4f6-460d-4b19-9149-6fe97d175fa8">
