### PR TITLE
UIDATIMP-1607: Remove `selected` column from associated profiles list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add permissions to data-import set to get incoming records. (UIDATIMP-1609)
 * Trim lead numbers in `fileName` field for sorting when split files is enabled. (UIDATIMP-1604)
 * "addedRelations" is not clearing after unlinking the update profile. (UIDATIMP-1603)
+* Remove `selected` column from associated profiles list. (UIDATIMP-1607)
 
 ## [7.1.0](https://github.com/folio-org/ui-data-import/tree/v7.1.0) (2024-03-22)
 

--- a/src/components/ProfileAssociator/AssociatedList.js
+++ b/src/components/ProfileAssociator/AssociatedList.js
@@ -60,9 +60,7 @@ export const AssociatedList = memo(({
   const sortDirection = sortOrderQuery.startsWith('-') ? SORT_TYPES.DESCENDING : SORT_TYPES.ASCENDING;
   const sortOrder = sortOrderQuery.replace(/^-/, '').replace(/,.*/, '');
   const sortTemplate = searchAndSortTemplate(intl);
-  let columns = isStatic && isMultiSelect ? ['selected', ...visibleColumns] : visibleColumns;
-
-  columns = !isStatic ? [...columns, 'unlink'] : columns;
+  const columns = !isStatic ? [...visibleColumns, 'unlink'] : visibleColumns;
 
   const descI = columns.findIndex(col => col === 'description');
 


### PR DESCRIPTION
## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
 * `Selected` column is not used in associated profiles list, so it'd be better to remove it.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
[UIDATIMP-1607](https://folio-org.atlassian.net/browse/UIDATIMP-1607)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

### Before
https://github.com/folio-org/ui-data-import/assets/85172747/705edbe9-50e8-46b2-aa64-b40faeadf339

### After
https://github.com/folio-org/ui-data-import/assets/85172747/6bd2efc5-3e8a-436f-9e6a-a9d131bb9be0