### PR TITLE
UIDATIMP-1619: The 'Error' status is not displayed in "Error" column for the same row as Items with status "No action"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Perform sorting by last name first, instead of first name in 'Updated by' column. (UIDATIMP-1613)
 * Allow to search profiles using `*`. (UIDATIMP-1605)
 * Remove `selected` column from associated profiles list. (UIDATIMP-1607)
+* The 'Error' status is not displayed in "Error" column for the same row as Items with status "No action". (UIDATIMP-1619)
 
 ## [7.1.1](https://github.com/folio-org/ui-data-import/tree/v7.1.1) (2024-04-11)
 

--- a/src/routes/JobSummary/components/RecordsTable.js
+++ b/src/routes/JobSummary/components/RecordsTable.js
@@ -179,9 +179,9 @@ export const RecordsTable = ({
       relatedItemInfo = [],
     }) => {
       const instanceId = relatedInstanceInfo.idList[0];
-      const isGeneralItemError = isGeneralItemsError(relatedItemInfo);
+      const isSingleItemError = isGeneralItemsError(relatedItemInfo);
 
-      if (isGeneralItemError) {
+      if (isSingleItemError) {
         return (
           <BaseLineCell>
             <FormattedMessage id="ui-data-import.logLight.actionStatus.noAction" />
@@ -293,11 +293,11 @@ export const RecordsTable = ({
       relatedPoLineInfo = {},
       relatedInvoiceLineInfo = {},
     }) => {
-      const isGeneralItemError = isGeneralItemsError(relatedItemInfo);
-      const isGeneralError = relatedInstanceInfo.error || relatedAuthorityInfo.error
+      const isSingleItemError = isGeneralItemsError(relatedItemInfo);
+      const isGeneralError = error || relatedInstanceInfo.error || relatedAuthorityInfo.error
         || relatedPoLineInfo.error || relatedInvoiceLineInfo.error;
 
-      if (isGeneralItemError || isGeneralError) {
+      if (isSingleItemError || isGeneralError) {
         return (
           <BaseLineCell>
             <FormattedMessage id="ui-data-import.error" />
@@ -305,11 +305,10 @@ export const RecordsTable = ({
         );
       }
 
-      if (isEmpty(relatedItemInfo) && relatedHoldingsInfo?.some(item => item.error)) {
+      if (isEmpty(relatedItemInfo) && relatedHoldingsInfo?.some(holding => holding.error)) {
         return (
           <ErrorCell
-            error={error}
-            sortedItemData={relatedHoldingsInfo?.map(item => [item])}
+            sortedItemData={relatedHoldingsInfo?.map(holding => [holding])}
           />
         );
       }
@@ -318,7 +317,6 @@ export const RecordsTable = ({
 
       return (
         <ErrorCell
-          error={error}
           sortedItemData={sortedItemData}
         />
       );

--- a/src/routes/JobSummary/components/cells/ErrorCell.js
+++ b/src/routes/JobSummary/components/cells/ErrorCell.js
@@ -8,22 +8,19 @@ import {
 } from '../utils';
 
 export const ErrorCell = ({
-  error,
   sortedItemData,
 }) => {
-  if (error && !isEmpty(sortedItemData)) {
+  if (!isEmpty(sortedItemData)) {
     return fillCellWithNoValues(sortedItemData, true);
   }
 
-  return error ? <BaseLineCell><FormattedMessage id="ui-data-import.error" /></BaseLineCell> : '';
+  return <BaseLineCell><FormattedMessage id="ui-data-import.error" /></BaseLineCell>;
 };
 
 ErrorCell.propTypes = {
-  error: PropTypes.string,
   sortedItemData: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)),
 };
 
 ErrorCell.defaultProps = {
-  error: '',
   sortedItemData: [],
 };

--- a/src/routes/JobSummary/components/cells/HoldingsCell.js
+++ b/src/routes/JobSummary/components/cells/HoldingsCell.js
@@ -34,7 +34,9 @@ export const HoldingsCell = ({
     const isHotlink = isPathCorrect && (holdings.actionStatus === RECORD_ACTION_STATUS.CREATED
         || holdings.actionStatus === RECORD_ACTION_STATUS.UPDATED);
 
-    const spacing = !isDiscarded ? Array.from({ length: itemForHoldingsCount }, (_, i) => <br key={i} />) : <br />;
+    const spacing = !isDiscarded
+      ? Array.from({ length: itemForHoldingsCount }, (_, i) => <br key={i} />)
+      : <br />;
 
     return (
       <div key={index} style={{ paddingBottom: '7px' }}>

--- a/src/routes/JobSummary/components/cells/tests/ErrorCell.test.js
+++ b/src/routes/JobSummary/components/cells/tests/ErrorCell.test.js
@@ -20,10 +20,9 @@ const sortedItemDataProp = [
   }]
 ];
 
-const renderErrorCell = ({ error = '', sortedItemData }) => {
+const renderErrorCell = ({ sortedItemData } = {}) => {
   const component = (
     <ErrorCell
-      error={error}
       sortedItemData={sortedItemData}
     />
   );
@@ -33,14 +32,14 @@ const renderErrorCell = ({ error = '', sortedItemData }) => {
 
 describe('ErrorCell component', () => {
   it('should be rendered with no axe errors', async () => {
-    const { container } = renderErrorCell({ error: 'test error' });
+    const { container } = renderErrorCell();
 
     await runAxeTest({ rootNode: container });
   });
 
-  describe('when error was occured', () => {
+  describe('when error was occurred', () => {
     it('should render error message', () => {
-      const { getByText } = renderErrorCell({ error: 'test error' });
+      const { getByText } = renderErrorCell();
 
       expect(getByText('Error')).toBeInTheDocument();
     });
@@ -48,7 +47,6 @@ describe('ErrorCell component', () => {
     describe('when item has an error', () => {
       it('should render error message', () => {
         const { getByText } = renderErrorCell({
-          error: 'test error',
           sortedItemData: sortedItemDataProp,
         });
 


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
The 'Error' status is not displayed in "Error" column for the same row as Items with status "No action".

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- the root 'error' could be empty but some entities could still contain an error, so removed check for the root `error`.

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://folio-org.atlassian.net/browse/UIDATIMP-1619

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
<img width="1018" alt="Screenshot 2024-04-17 at 23 57 36" src="https://github.com/folio-org/ui-data-import/assets/55138456/d25b9912-d1f8-4507-884a-09d0ab3e0210">
