### PR TITLE
UIDATIMP-1619: The 'Error' status is not displayed in "Error" column for the same row as Items with status "No action" (follow-up)

### DIFF
--- a/src/routes/JobSummary/components/RecordsTable.js
+++ b/src/routes/JobSummary/components/RecordsTable.js
@@ -305,9 +305,10 @@ export const RecordsTable = ({
         );
       }
 
-      if (isEmpty(relatedItemInfo) && relatedHoldingsInfo?.some(holding => holding.error)) {
+      if (isEmpty(relatedItemInfo) && !relatedHoldingsInfo?.some(holding => holding.error)) {
         return (
           <ErrorCell
+            error={error}
             sortedItemData={relatedHoldingsInfo?.map(holding => [holding])}
           />
         );
@@ -317,6 +318,7 @@ export const RecordsTable = ({
 
       return (
         <ErrorCell
+          error={error}
           sortedItemData={sortedItemData}
         />
       );

--- a/src/routes/JobSummary/components/cells/ErrorCell.js
+++ b/src/routes/JobSummary/components/cells/ErrorCell.js
@@ -8,19 +8,22 @@ import {
 } from '../utils';
 
 export const ErrorCell = ({
+  error,
   sortedItemData,
 }) => {
   if (!isEmpty(sortedItemData)) {
     return fillCellWithNoValues(sortedItemData, true);
   }
 
-  return <BaseLineCell><FormattedMessage id="ui-data-import.error" /></BaseLineCell>;
+  return error ? <BaseLineCell><FormattedMessage id="ui-data-import.error" /></BaseLineCell> : '';
 };
 
 ErrorCell.propTypes = {
+  error: PropTypes.string,
   sortedItemData: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)),
 };
 
 ErrorCell.defaultProps = {
+  error: '',
   sortedItemData: [],
 };

--- a/src/routes/JobSummary/components/cells/tests/ErrorCell.test.js
+++ b/src/routes/JobSummary/components/cells/tests/ErrorCell.test.js
@@ -20,9 +20,10 @@ const sortedItemDataProp = [
   }]
 ];
 
-const renderErrorCell = ({ sortedItemData } = {}) => {
+const renderErrorCell = ({ error = '', sortedItemData }) => {
   const component = (
     <ErrorCell
+      error={error}
       sortedItemData={sortedItemData}
     />
   );
@@ -32,14 +33,14 @@ const renderErrorCell = ({ sortedItemData } = {}) => {
 
 describe('ErrorCell component', () => {
   it('should be rendered with no axe errors', async () => {
-    const { container } = renderErrorCell();
+    const { container } = renderErrorCell({ error: 'test error' });
 
     await runAxeTest({ rootNode: container });
   });
 
   describe('when error was occurred', () => {
     it('should render error message', () => {
-      const { getByText } = renderErrorCell();
+      const { getByText } = renderErrorCell({ error: 'test error' });
 
       expect(getByText('Error')).toBeInTheDocument();
     });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* If there's no error in `ErrorCell` component we should return an empty string

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
[UIDATIMP-1619](https://folio-org.atlassian.net/browse/UIDATIMP-1619)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-data-import/assets/85172747/ed347ffc-5581-4760-ad28-54fed28485f0

