### PR TITLE
UIDATIMP-1633: Changes made during duplication of a job with a match profile are not saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed:
 * Remove `selected` column from associated profiles list. (UIDATIMP-1607)
 * Do not show "Leave the page" modal when view job profile from the list. (UIDATIMP-1615)
+* Changes made during duplication of a job with a match profile are not saved. (UIDATIMP-1633)
 
 ## [7.1.6](https://github.com/folio-org/ui-data-import/tree/v7.1.6) (2024-05-02)
 

--- a/src/settings/JobProfiles/JobProfilesForm.js
+++ b/src/settings/JobProfiles/JobProfilesForm.js
@@ -175,10 +175,43 @@ export const JobProfilesFormComponent = memo(({
   }, [childWrappers]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    const contentData = !isLayerCreate ? childWrappers : [];
-    const getData = !isEmpty(currentJobProfileTreeContent) ? currentJobProfileTreeContent : contentData;
+    const removeKeys = (obj, keys) => {
+      let index;
+      for (const prop in obj) {
+        if (Object.hasOwn(obj, prop)) {
+          switch (typeof (obj[prop])) {
+            case 'object':
+              index = keys.indexOf(prop);
+              if (index > -1) {
+                delete obj[prop];
+              } else {
+                removeKeys(obj[prop], keys);
+              }
+              break;
+            default:
+              index = keys.indexOf(prop);
+              if (index > -1) {
+                delete obj[prop];
+              }
+              break;
+          }
+        }
+      }
+    };
 
-    setProfileTreeData(getData);
+    const contentData = !isLayerCreate ? childWrappers : [];
+    const treeData = !isEmpty(currentJobProfileTreeContent) ? currentJobProfileTreeContent : contentData;
+
+    // af far as new profileWrapperId should be created for new profiles
+    // it is needed to omit these fields during duplication because it copies
+    // data from the original job profile
+    const massageTreeData = () => (isLayerDuplicate
+      ? treeData.forEach(obj => removeKeys(obj, ['profileWrapperId']))
+      : treeData);
+
+    massageTreeData();
+
+    setProfileTreeData(treeData);
   }, [isLayerCreate, childWrappers]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
When you duplicate a job profile that has a match profile and then add more than one action, when you save that job, one of the actions isn’t saved.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Omit `profileWrapperId` fields for profiles that have been duplicated

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://folio-org.atlassian.net/browse/UIDATIMP-1633

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
