### PR TITLE
UIDATIMP-1652: Add missing `source-storage.sourceRecords.get` permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Do not show "Leave the page" modal when view job profile from the list. (UIDATIMP-1615)
 * When navigating to the Invoice field mapping profile edit form the page crashes (UIDATIMP-1646)
 * Reset offset when open VievAllLogs page. (UIDATIMP-1645)
+* Add missing `source-storage.sourceRecords.get` permission. (UIDATIMP-1652)
 
 ## [7.1.8](https://github.com/folio-org/ui-data-import/tree/v7.1.8) (2024-05-09)
 

--- a/package.json
+++ b/package.json
@@ -209,7 +209,8 @@
           "source-storage.records.get",
           "ui-data-import.view",
           "ui-orders.orders.view",
-          "metadata-provider.incomingrecords.get"
+          "metadata-provider.incomingrecords.get",
+          "source-storage.sourceRecords.get"
         ],
         "visible": true
       },
@@ -225,7 +226,8 @@
           "metadata-provider.jobexecutions.get",
           "metadata-provider.logs.get",
           "source-storage.records.get",
-          "metadata-provider.incomingrecords.get"
+          "metadata-provider.incomingrecords.get",
+          "source-storage.sourceRecords.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
 * Add `source-storage.sourceRecords.get` permission to **Data import: Can view only** and **Data import: Can upload files, import, and view logs** in order to see SRS MARC logs. [Required permission to call the endpoint](https://github.com/folio-org/mod-source-record-storage/blob/fb4dc58066a0f7ae14671a3a56ea8fd0c815b209/descriptors/ModuleDescriptor-template.json#L159)

## Refs
[UIDATIMP-1652](https://folio-org.atlassian.net/browse/UIDATIMP-1652)