### PR TITLE
UIDATIMP-1675: Display placeholder in `Job profile` and `User` filters on the View all page after clicking on `Reset all` button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed:
 * Invoice field mapping profile: cannot check export to accounting checkbox. (UIDATIMP-1671)
+* Display placeholder in `Job profile` and `User` filters on the `View all` page after clicking on `Reset all` button. (UIDATIMP-1675)
 
 ## [8.0.0](https://github.com/folio-org/ui-data-import/tree/v8.0.0) (2024-10-31)
 

--- a/src/routes/ViewAllLogs/ViewAllLogsFilters.js
+++ b/src/routes/ViewAllLogs/ViewAllLogsFilters.js
@@ -2,13 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import moment from 'moment';
-import { uniqBy } from 'lodash';
+import {
+  isEmpty,
+  uniqBy,
+} from 'lodash';
 
 import {
   AccordionSet,
   Accordion,
   FilterAccordionHeader,
   Selection,
+  OptionSegment,
 } from '@folio/stripes/components';
 import {
   createClearFilterHandler,
@@ -82,6 +86,12 @@ const ViewAllLogsFilters = ({
     return dataOptions.filter(option => new RegExp(value, 'i').test(option.label));
   };
 
+  const formatter = ({ option, searchTerm }) => {
+    return !isEmpty(option?.value)
+      ? <OptionSegment searchTerm={searchTerm}>{option.label}</OptionSegment>
+      : null;
+  };
+
   return (
     <div data-test-filter-logs>
       <AccordionSet>
@@ -133,6 +143,7 @@ const ViewAllLogsFilters = ({
                   onChange={onChangeSelectionFilter(onChange, FILTERS.JOB_PROFILE)}
                   placeholder={placeholder}
                   onFilter={onFilter}
+                  formatter={formatter}
                 />
               )}
             </FormattedMessage>
@@ -155,6 +166,7 @@ const ViewAllLogsFilters = ({
                   onChange={onChangeSelectionFilter(onChange, FILTERS.USER)}
                   placeholder={placeholder}
                   onFilter={onFilter}
+                  formatter={formatter}
                 />
               )}
             </FormattedMessage>


### PR DESCRIPTION
## Purpose
* Display placeholder in `Job profile` and `User` filters on the `View all` page after clicking on `Reset all` button.

## Approach
* Added `formatter` prop to filters. When user clicks "Reset all" or resets particular filter then display placeholder.

## Refs
[UIDATIMP-1675](https://folio-org.atlassian.net/browse/UIDATIMP-1675)

## Screenshots
https://github.com/user-attachments/assets/b1514d49-a100-409f-bcf6-2c17e6742ed3