### PR TITLE
UIDATIMP-1634: Refactor away from default props for functional components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change history for ui-data-import
 
-## [8.0.2] (IN PROGRESS)
+## [8.1.0] (IN PROGRESS)
+
+### Features added:
+* `React v19`: refactor away from default props for functional components. (UIDATIMP-1634)
 
 ### Bugs fixed:
 * Display placeholder in `Job profile` and `User` filters on the `View all` page after clicking on `Reset all` button. (UIDATIMP-1675)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features added:
 * `React v19`: refactor away from default props for functional components. (UIDATIMP-1634)
 
+## [8.0.2] (IN PROGRESS)
+
 ### Bugs fixed:
 * Display placeholder in `Job profile` and `User` filters on the `View all` page after clicking on `Reset all` button. (UIDATIMP-1675)
 

--- a/src/settings/JobProfiles/ViewJobProfile/ViewJobProfile.js
+++ b/src/settings/JobProfiles/ViewJobProfile/ViewJobProfile.js
@@ -105,6 +105,12 @@ const jobPartsCellFormatter = record => (
   />
 );
 
+const DEFAULT_ACTION_ITEMS = [
+  'edit',
+  'duplicate',
+  'delete',
+];
+
 const ViewJobProfileComponent = props => {
   const {
     resources,
@@ -116,7 +122,7 @@ const ViewJobProfileComponent = props => {
     location,
     onDelete,
     onClose,
-    actionMenuItems,
+    actionMenuItems = DEFAULT_ACTION_ITEMS,
     accordionStatusRef,
   } = props;
 
@@ -239,7 +245,11 @@ const ViewJobProfileComponent = props => {
     return (
       <ActionMenu
         entity={{
-          props,
+          props: {
+            ...props,
+            actionMenuItems,
+            ENTITY_KEY: ENTITY_KEYS.JOB_PROFILES,
+          },
           showRunConfirmation: () => setShowRunConfirmation(true),
           showDeleteConfirmation: () => setShowDeleteConfirmation(true),
         }}
@@ -633,15 +643,6 @@ ViewJobProfileComponent.propTypes = {
   ENTITY_KEY: PropTypes.string, // eslint-disable-line
   actionMenuItems: PropTypes.arrayOf(PropTypes.string), // eslint-disable-line
   accordionStatusRef: PropTypes.object,
-};
-
-ViewJobProfileComponent.defaultProps = {
-  ENTITY_KEY: ENTITY_KEYS.JOB_PROFILES,
-  actionMenuItems: [
-    'edit',
-    'duplicate',
-    'delete',
-  ],
 };
 
 export const ViewJobProfile = compose(


### PR DESCRIPTION
## Purpose
* `defaultProps` will be removed from function components in place of ES6 default parameters. Class components will continue to support `defaultProps` since there is no ES6 alternative.

## Approach
* Removed `defaultProps` in `ViewJobProfileComponent` component

## Refs
[UIDATIMP-1634](https://folio-org.atlassian.net/browse/UIDATIMP-1634)
