### PR TITLE
UIDATIMP-1685: Allow central tenant to create filed mapping profile for Orders and Invoices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bugs fixed:
 * Allow central tenant to create action profile for Orders and Invoices. (UIDATIMP-1679)
+* Allow central tenant to create filed mapping profile for Orders and Invoices. (UIDATIMP-1685)
 
 ## [8.0.2](https://github.com/folio-org/ui-data-import/tree/v8.0.2) (2024-11-21)
 

--- a/src/settings/MappingProfiles/MappingProfilesForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm.js
@@ -143,10 +143,11 @@ export const MappingProfilesFormComponent = ({
     dispatch(change(formName, 'profile.mappingDetails', newMappingDetails));
   };
 
-
   const MAPPING_PROFILES_FORM_FOLIO_RECORD_TYPES = isUserInCentralTenant ?
     pick(INITIAL_FOLIO_RECORD_TYPES, [
       FOLIO_RECORD_TYPES.INSTANCE.type,
+      FOLIO_RECORD_TYPES.ORDER.type,
+      FOLIO_RECORD_TYPES.INVOICE.type,
       FOLIO_RECORD_TYPES.MARC_BIBLIOGRAPHIC.type,
       FOLIO_RECORD_TYPES.MARC_AUTHORITY.type,
     ]) : INITIAL_FOLIO_RECORD_TYPES;

--- a/src/settings/MappingProfiles/tests/MappingProfilesForm.test.js
+++ b/src/settings/MappingProfiles/tests/MappingProfilesForm.test.js
@@ -156,7 +156,7 @@ describe('MappingProfilesForm component', () => {
   });
 
   describe('when user is in central tenant', () => {
-    it('should render "Instance", "MARC Bibliographic" and "MARC Authority" folio record types', () => {
+    it('should render "Instance", "Order", "Invoice", "MARC Bibliographic" and "MARC Authority" folio record types', () => {
       spyOnCheckIfUserInCentralTenant.mockReturnValue(true);
 
       const { container } = renderMappingProfilesForm(mappingProfilesFormProps);
@@ -165,11 +165,11 @@ describe('MappingProfilesForm component', () => {
 
       expect(within(folioRecordTypesContainer).queryByText('Holdings')).not.toBeInTheDocument();
       expect(within(folioRecordTypesContainer).queryByText('Item')).not.toBeInTheDocument();
-      expect(within(folioRecordTypesContainer).queryByText('Order')).not.toBeInTheDocument();
-      expect(within(folioRecordTypesContainer).queryByText('Invoice')).not.toBeInTheDocument();
       expect(within(folioRecordTypesContainer).queryByText('MARC Holdings')).not.toBeInTheDocument();
 
       expect(within(folioRecordTypesContainer).getByText('Instance')).toBeInTheDocument();
+      expect(within(folioRecordTypesContainer).queryByText('Order')).toBeInTheDocument();
+      expect(within(folioRecordTypesContainer).queryByText('Invoice')).toBeInTheDocument();
       expect(within(folioRecordTypesContainer).getByText('MARC Bibliographic')).toBeInTheDocument();
       expect(within(folioRecordTypesContainer).getByText('MARC Authority')).toBeInTheDocument();
     });


### PR DESCRIPTION
## Purpose
* Allow central tenant to create filed mapping profile for Orders and Invoices

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
[UIDATIMP-1685](https://folio-org.atlassian.net/browse/UIDATIMP-1685)

## Screenshots
![image](https://github.com/user-attachments/assets/b1efee22-e486-456c-9527-1b4513a23f3b)

