### PR TITLE
UIDATIMP-1686: Replace `_/proxy/tenants/${tenant}/modules` request with `stripes.discovery.modules` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bugs fixed:
 * Allow central tenant to create action profile for Orders and Invoices. (UIDATIMP-1679)
 * Allow central tenant to create filed mapping profile for Orders and Invoices. (UIDATIMP-1685)
+* Replace `_/proxy/tenants/${tenant}/modules` with `stripes.discovery.modules` object. (UIDATIMP-1686)
 
 ## [8.0.2](https://github.com/folio-org/ui-data-import/tree/v8.0.2) (2024-11-21)
 

--- a/src/settings/MatchProfiles/MatchProfiles.js
+++ b/src/settings/MatchProfiles/MatchProfiles.js
@@ -237,16 +237,6 @@ export class MatchProfiles extends Component {
         staticFallback: { params: {} },
       },
     },
-    modules: {
-      type: 'okapi',
-      path: (queryParams, pathComponents, resourceData, logger, props) => {
-        const { stripes: { okapi: { tenant } } } = props;
-
-        return `_/proxy/tenants/${tenant}/modules`;
-      },
-      throwErrors: false,
-      GET: { params: { full: true } },
-    },
   });
 
   static propTypes = {
@@ -308,17 +298,17 @@ export class MatchProfiles extends Component {
   };
 
   async componentDidUpdate(prevProps) {
-    if (!isEqual(prevProps.resources.modules, this.props.resources.modules)
-      && !isEmpty(this.props.resources.modules.records)) {
+    if (!isEqual(prevProps.stripes.discovery.modules, this.props.stripes.discovery.modules)
+      && !isEmpty(this.props.stripes.discovery.modules)) {
       const {
         stripes,
         stripes: { okapi },
-        resources: { modules: { records } },
+        stripes: { discovery: { modules } },
       } = this.props;
 
-      const inventoryModuleVersion = getModuleVersion(records, 'Inventory Storage Module');
-      const ordersModuleVersion = getModuleVersion(records, 'Orders Business Logic Module');
-      const invoiceModuleVersion = getModuleVersion(records, 'Invoice business logic module');
+      const inventoryModuleVersion = getModuleVersion(modules, 'Inventory Storage Module');
+      const ordersModuleVersion = getModuleVersion(modules, 'Orders Business Logic Module');
+      const invoiceModuleVersion = getModuleVersion(modules, 'Invoice business logic module');
 
       const requestsToInstance = INSTANCE_RESOURCE_PATHS.map(path => fetchJsonSchema(path, inventoryModuleVersion, okapi));
       const requestsToHoldings = HOLDINGS_RESOURCE_PATHS.map(path => fetchJsonSchema(path, inventoryModuleVersion, okapi));

--- a/src/utils/fetchJsonShemas.js
+++ b/src/utils/fetchJsonShemas.js
@@ -1,7 +1,7 @@
 export const getModuleVersion = (modules, moduleName) => {
-  const version = modules.find(module => module.name === moduleName);
+  const version = Object.keys(modules).find(key => modules[key] === moduleName);
 
-  return version ? version.id : undefined;
+  return version || undefined;
 };
 
 export const fetchJsonSchema = async (path, module, okapi) => {

--- a/src/utils/tests/fetchJsonSchemas.test.js
+++ b/src/utils/tests/fetchJsonSchemas.test.js
@@ -9,15 +9,12 @@ import { STATUS_CODES } from '../constants';
 
 describe('getModuleVersion function', () => {
   it('returns module version of a module with given name', () => {
-    const testModules = [{
-      name: 'module1',
-      id: 'testId1',
-    }, {
-      name: 'module2',
-      id: 'testId2',
-    }];
+    const testModules = {
+      testId1: 'module1',
+      testId2: 'module2',
+    };
 
-    expect(getModuleVersion(testModules, 'module2')).toBe(testModules[1].id);
+    expect(getModuleVersion(testModules, 'module2')).toBe('testId2');
     expect(getModuleVersion(testModules, 'module3')).toBeUndefined();
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
While troubleshooting an issue in the Eureka-bugfest environment, we ran across a [bit of code in ui-data-import](https://github.com/folio-org/ui-data-import/blame/f7b36a39ac5db4e3a5d71f42f120f101e97f1009/src/settings/MatchProfiles/MatchProfiles.js#L240-L249) that queries Okapi for the tenant’s currently-installed modules with a manifest like:
`_/proxy/tenants/${tenant}/modules`;
This same data is available on stripes at stripes.discovery.modules . The discovery process in Eureka is quite different than in legacy FOLIO, with different endpoints etc etc, but all that logic is consolidated within stripes-core at present. If we can leverage the discovery data attached to stripes instead of making a query, then we can keep it that way and avoid the need for Eureka-specific code to pollute ui-data-import.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Get rid of `_/proxy/tenants/${tenant}/modules` request in Match profiles and get data from `stripes.discovery.modules` object.

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://folio-org.atlassian.net/browse/UIDATIMP-1686

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
