### PR TITLE
UIDATIMP-1691: Fixed progress bar goes above 100% when job is stuck in running column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bugs fixed:
 * Trigger file selection window to open after click `Choose other files to upload` button. (UIDATIMP-1683)
+* Fixed progress bar goes above 100% when job is stuck in running column. (UIDATIMP-1691)
 
 ## [8.0.4](https://github.com/folio-org/ui-data-import/tree/v8.0.4) (2024-12-06)
 

--- a/src/components/Jobs/components/Job/Job.js
+++ b/src/components/Jobs/components/Job/Job.js
@@ -275,6 +275,7 @@ const JobComponent = ({
   const jobMeta = jobMetaTypes[uiStatus](job);
   const dateLabelId = `ui-data-import.${jobMeta.dateLabel}Running`;
   const isDeletionInProgress = showCancelJobModal || deletionInProgress;
+  const currentProgress = current <= 100 ? current : 100;
 
   return (
     <li
@@ -343,7 +344,7 @@ const JobComponent = ({
                 tagName="div"
               />
               <Progress
-                current={current}
+                current={currentProgress}
                 total={total}
               />
             </>


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
In rare cases, the progress bar goes above 100% when a job is stuck in the running column. It would be better to fix this on the BE side, but was decided to add check on UI and show 100% if BE sends progress over 100.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Show 100% if current progress is > 100.

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://folio-org.atlassian.net/browse/UIDATIMP-1691

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
