### PR TITLE
UIDATIMP-1705: Migrate `react-intl` and `stripes` dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
   "rules": {
     "import/prefer-default-export": "off",
     "import/no-cycle": "off",
+    "react/forbid-prop-types": "off", // TODO: Investigate possibility of using PropTypes.shape instead of PropTypes.object
     "react/prop-types": [
       "error",
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features added:
 * `React v19`: refactor away from default props for functional components. (UIDATIMP-1634)
 * Add `required: true` to contributor and vendorDetail fields to the Order Mapping Profile. (UIDATIMP-1709)
+* *BREAKING* Migrate stripes dependencies to their Sunflower versions. (UIDATIMP-1705)
+* *BREAKING* Migrate `react-intl` to v7. (UIDATIMP-1706)
 
 ## [8.0.5](https://github.com/folio-org/ui-data-import/tree/v8.0.5) (2024-12-19)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/data-import",
-  "version": "8.0.5",
+  "version": "9.0.0",
   "description": "Data Import manager",
   "main": "src/index.js",
   "repository": "folio-org/ui-data-import",
@@ -16,23 +16,23 @@
     "lint": "eslint .",
     "lintfix": "eslint . --fix",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",
-    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-data-import ./translations/ui-data-import/compiled"
+    "formatjs-compile": "stripes translate compile"
   },
   "devDependencies": {
     "@babel/core": "^7.17.12",
     "@babel/eslint-parser": "^7.17.0",
     "@babel/plugin-transform-runtime": "^7.22.15",
-    "@folio/eslint-config-stripes": "^7.1.0",
-    "@folio/jest-config-stripes": "^2.0.0",
-    "@folio/stripes": "^9.2.2",
-    "@folio/stripes-cli": "^3.2.0",
-    "@folio/stripes-components": "^12.2.2",
-    "@folio/stripes-core": "^10.2.1",
-    "@folio/stripes-final-form": "^8.1.0",
-    "@folio/stripes-form": "^9.1.0",
-    "@folio/stripes-smart-components": "^9.2.1",
-    "@folio/stripes-testing": "^4.7.0",
-    "@formatjs/cli": "^6.1.3",
+    "@folio/eslint-config-stripes": "^8.0.0",
+    "@folio/jest-config-stripes": "^3.0.0",
+    "@folio/stripes": "^10.0.0",
+    "@folio/stripes-cli": "^4.0.0",
+    "@folio/stripes-components": "^13.0.0",
+    "@folio/stripes-core": "^11.0.0",
+    "@folio/stripes-final-form": "^9.0.0",
+    "@folio/stripes-form": "^10.0.0",
+    "@folio/stripes-smart-components": "^10.0.0",
+    "@folio/stripes-testing": "^5.0.0",
+    "@formatjs/cli": "^6.6.0",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
     "eslint": "^7.32.0",
@@ -48,7 +48,7 @@
     "query-string": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-query": "^3.39.2",
     "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
@@ -56,8 +56,8 @@
     "redux": "^4.0.5"
   },
   "dependencies": {
-    "@folio/stripes-acq-components": "~6.0.0",
-    "@folio/stripes-data-transfer-components": "^6.2.0",
+    "@folio/stripes-acq-components": "^7.0.0",
+    "@folio/stripes-data-transfer-components": "^7.0.0",
     "classnames": "^2.2.5",
     "dom-helpers": "^5.2.0",
     "final-form": "^4.18.2",
@@ -69,9 +69,9 @@
     "redux-form": "^8.3.7"
   },
   "peerDependencies": {
-    "@folio/stripes": "^9.2.2",
+    "@folio/stripes": "^10.0.0",
     "react": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
@@ -81,7 +81,7 @@
     "moment": "~2.29.4"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-organization": "^5.2.0"
+    "@folio/plugin-find-organization": "^6.0.0"
   },
   "stripes": {
     "stripesDeps": [

--- a/src/components/TextDate/TextDate.test.js
+++ b/src/components/TextDate/TextDate.test.js
@@ -183,15 +183,18 @@ describe('TextDate component', () => {
 
   describe('when double ckicking on calendar icon', () => {
     it('calendar should be closed', () => {
-      const { container } = renderTextDate(textDateProps(defaultTextDateProps));
+      const {
+        container,
+        getByTestId,
+      } = renderTextDate(textDateProps(defaultTextDateProps));
       const calendarIcon = container.querySelector('#datepicker-toggle-calendar-button-testId');
 
       fireEvent.click(calendarIcon);
 
       const calendarContainer = container.querySelector('.calendar');
-
       fireEvent.click(calendarContainer);
-      fireEvent.click(calendarIcon);
+
+      fireEvent.click(getByTestId('date-picker'));
 
       expect(calendarContainer).not.toBeVisible();
     });


### PR DESCRIPTION
## Links
[UIDATIMP-1705](https://folio-org.atlassian.net/browse/UIDATIMP-1705)
[UIDATIMP-1706](https://folio-org.atlassian.net/browse/UIDATIMP-1706)