### PR TITLE
UIDATIMP-1715 make TextDate.test.js robust to March, 2025

### DIFF
--- a/src/components/TextDate/TextDate.test.js
+++ b/src/components/TextDate/TextDate.test.js
@@ -144,7 +144,7 @@ describe('TextDate component', () => {
 
       const calendarContainer = container.querySelector('.calendar');
 
-      fireEvent.click(getByText('23'));
+      fireEvent.click(getByText('20'));
 
       expect(calendarContainer).not.toBeVisible();
     });

--- a/src/components/TextDate/TextDate.test.js
+++ b/src/components/TextDate/TextDate.test.js
@@ -159,7 +159,7 @@ describe('TextDate component', () => {
       const calendarIcon = container.querySelector('#datepicker-toggle-calendar-button-testId');
 
       fireEvent.click(calendarIcon);
-      fireEvent.click(getByText('23'));
+      fireEvent.click(getByText('20'));
       const clearIcon = container.querySelector('#datepicker-clear-button-testId');
 
       expect(clearIcon).toBeDefined();


### PR DESCRIPTION
TEXTDATE
Who is it in the test that calls on me?
I see a test fail when clicking two-three.
Cry "TextDate". Speak. TextDate is turned to hear.

SOOTHSAYER
Beware the twenty-third of February, twenty-twenty-five!

TEXTDATE
What rot is that?

BRUTUS
A soothsayer bids you, beware February 23.

TEXTDATE
But only in the year two-oh-two-five?
Set him before me. Let me see his face.

CASSIUS
Fellow, come from the throng. Look upon TextDate.

TEXTDATE
What sayst though to me now? Speak once again.

SOOTHSAYER
This is kind of fun, actually. March 2023, not a leap year, starts on a Saturday, so when we show a calendar in a US-English locale where the week starts on a Sunday, that means we will include six dates from the previous month, and during March, 2025, that means we will include February 23-28. This test is written like "Click the 23!" without specifying anything else, it's just plain "Click the 23!" and so the calendar chooses the current month of the current year. And since we've already noted that "23" shows up twice, the test will fail because it expects to find one element but gets a list of two elements instead. This can (and will) only happen during the month of March during a non-leap year when March starts on the last day of the week. The last time this happened was 2014 and it won't happen again until 2031. All you gotta do to fix it is choose a value less than 23 and it will work reliably during any month, any year. But beware February 23-28th!

TEXTDATE
This is so silly. Click the twenty. Pass.

[Exeunt.]

Refs [UIDATIMP-1715](https://folio-org.atlassian.net/browse/UIDATIMP-1715)