### PR TITLE
UIDATIMP-1727: Add `LCCN` accepted value for Product ID in Orders Field Mapping Profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [9.1.0] (IN PROGRESS)
 
 ### Features added:
-* Action profile: limit the list of linkable field mapping profiles based on FOLIO record type (UIDATIMP-1328)
+* Action profile: limit the list of linkable field mapping profiles based on FOLIO record type (UIDATIMP-1328).
+* Add "LCCN" accepted value for Product ID in Orders Field Mapping Profiles. (UIDATIMP-2737).
 
 ### Bugs fixed:
 * Place wrappers in right order to not lose any data after applying `flow()`. (UIDATIMP-1716)

--- a/src/settings/MappingProfiles/detailsSections/constants.js
+++ b/src/settings/MappingProfiles/detailsSections/constants.js
@@ -75,6 +75,7 @@ export const VENDOR_VISIBLE_COLUMNS = {
 };
 
 export const ALLOWED_PROD_ID_TYPE_NAMES = [
+  'LCCN',
   'ASIN',
   'CODEN',
   'DOI',


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
* To align with current options in the Orders app, we need to update the options for Product ID Type to include "LCCN" as an Accepted Value in Orders Field Mapping profiles for Data Import.

## Refs
[UIDATIMP-1727](https://folio-org.atlassian.net/browse/UIDATIMP-1727)
