### PR TITLE
UIDATIMP-1756: Fix translation for select placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-data-import
 
+## [10.1.0] (IN PROGRESS)
+
+### Bugs fixed:
+* Fix translation for select placeholder. (UIDATIMP-1756)
+
 ## [10.0.0](https://github.com/folio-org/ui-data-import/tree/v10.0.0) (2026-04-15)
 [Full Changelog](https://github.com/folio-org/ui-data-import/compare/v9.0.2...v10.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/data-import",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "Data Import manager",
   "main": "src/index.js",
   "repository": "folio-org/ui-data-import",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/data-import",
-  "version": "10.1.0",
+  "version": "10.0.1",
   "description": "Data Import manager",
   "main": "src/index.js",
   "repository": "folio-org/ui-data-import",

--- a/src/components/BooleanActionField/BooleanActionField.test.js
+++ b/src/components/BooleanActionField/BooleanActionField.test.js
@@ -53,7 +53,7 @@ describe('Boolean action field component', () => {
     it('then component should render default placeholder', () => {
       const { getByText } = renderBooleanActionField({});
 
-      expect(getByText('Select сheckbox field mapping')).toBeDefined();
+      expect(getByText('Select checkbox field mapping')).toBeDefined();
     });
   });
 

--- a/translations/ui-data-import/en.json
+++ b/translations/ui-data-import/en.json
@@ -564,7 +564,7 @@
   "settings.mappingProfiles.map.wrapper.fundDistributionSource.useFundDistributionFieldMappings": "Use fund distribution field mappings",
   "settings.mappingProfiles.map.administrativeData.field.discoverySuppress": "Suppress from discovery",
   "settings.mappingProfiles.map.administrativeData.field.setForDeletion": "Set for deletion",
-  "settings.mappingProfiles.map.administrativeData.field.selectCheckboxFieldMapping": "Select сheckbox field mapping",
+  "settings.mappingProfiles.map.administrativeData.field.selectCheckboxFieldMapping": "Select checkbox field mapping",
   "settings.mappingProfiles.map.administrativeData.field.markAllAffectedRecords":"Mark for all affected records",
   "settings.mappingProfiles.map.administrativeData.field.unmarkAllAffectedRecords":"Unmark for all affected records",
   "settings.mappingProfiles.map.administrativeData.field.keepAllAffectedRecords":"Keep the existing value for all affected records",


### PR DESCRIPTION
## Links
[UIDATIMP-1756](https://folio-org.atlassian.net/browse/UIDATIMP-1756)

* `Select checkbox field mapping` translation contained “c“ as a Cyrillic character, not a latin one.
It causes autotests failures.