### PR TITLE
UIDATIMP-1714: Replace moment with day.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [10.1.0] (IN PROGRESS)
 
+### Features added:
+* Replace moment with day.js (UIDATIMP-1714)
+
 ### Bugs fixed:
 * Fix translation for select placeholder. (UIDATIMP-1756)
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "final-form": "^4.18.2",
     "inflected": "^2.0.4",
     "lodash": "^4.18.0",
-    "moment": "~2.29.4",
     "prop-types": "^15.6.0",
     "react-final-form": "^6.3.0",
     "redux-form": "^8.3.7"
@@ -76,9 +75,6 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.5"
-  },
-  "resolutions": {
-    "moment": "~2.29.4"
   },
   "optionalDependencies": {
     "@folio/plugin-find-organization": "^6.0.0"

--- a/src/components/MatchCriterion/edit/IncomingSectionStatic/StaticValueDateRange.js
+++ b/src/components/MatchCriterion/edit/IncomingSectionStatic/StaticValueDateRange.js
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'react-final-form';
-import moment from 'moment';
 
 import {
   Layout,
   Datepicker,
   Headline,
+  dayjs,
 } from '@folio/stripes/components';
 
 import { isFieldPristine } from '../../../../utils';
@@ -18,8 +18,8 @@ const DATE_FORMAT = 'YYYY-MM-DD';
 
 export const StaticValueDateRange = ({ repeatableIndex }) => {
   const getDatesEqualState = (initialDate, newDate) => {
-    const initialFormattedDate = moment.utc(initialDate, DATE_FORMAT).format();
-    const newFormattedDate = moment.utc(newDate, DATE_FORMAT).format();
+    const initialFormattedDate = dayjs.utc(initialDate, DATE_FORMAT).format();
+    const newFormattedDate = dayjs.utc(newDate, DATE_FORMAT).format();
 
     return isFieldPristine(initialFormattedDate, newFormattedDate);
   };

--- a/src/routes/ViewAllLogs/ViewAllLogsFilters.js
+++ b/src/routes/ViewAllLogs/ViewAllLogsFilters.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import moment from 'moment';
 import {
   isEmpty,
   uniqBy,
@@ -13,6 +12,7 @@ import {
   FilterAccordionHeader,
   Selection,
   OptionSegment,
+  dayjs,
 } from '@folio/stripes/components';
 import {
   createClearFilterHandler,
@@ -36,8 +36,8 @@ const getDateRange = filterValue => {
 
   if (filterValue) {
     const [startDateString, endDateString] = filterValue[0].split(':');
-    const endDate = moment.utc(endDateString);
-    const startDate = moment.utc(startDateString);
+    const endDate = dayjs.utc(endDateString);
+    const startDate = dayjs.utc(startDateString);
 
     dateRange = {
       startDate: startDate.isValid()
@@ -53,7 +53,7 @@ const getDateRange = filterValue => {
 };
 
 const getDateFilter = (startDate, endDate) => {
-  const endDateCorrected = moment.utc(endDate).add(1, 'days').format(DATE_FORMAT);
+  const endDateCorrected = dayjs.utc(endDate).add(1, 'days').format(DATE_FORMAT);
 
   return `${startDate}:${endDateCorrected}`;
 };

--- a/src/utils/formValidators.js
+++ b/src/utils/formValidators.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import moment from 'moment';
 import { FormattedMessage } from 'react-intl';
-
 import { isEmpty } from 'lodash';
+
+import { dayjs } from '@folio/stripes/components';
 
 import { getTrimmedValue } from './getTrimmedValue';
 
@@ -265,7 +265,7 @@ export const validateMARCWithDate = (value, isRemoveValueProhibited) => {
 
     if (dates) {
       const DATE_FORMAT = 'YYYY-MM-DD';
-      const isValidDate = dates.every(date => moment(date, DATE_FORMAT, true).isValid());
+      const isValidDate = dates.every(date => dayjs(date, DATE_FORMAT, true).isValid());
 
       if (!isValidDate) {
         return <FormattedMessage id="ui-data-import.validation.syntaxError" />;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIDATIMP-630: Refine an identifier matching for Instances
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color palette 
  does not provide enough contrast for certain classes of visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Applications should import dayjs from stripes-components and do not need to maintain their own dependency.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 
 Bad:
  Made a dark color of #333, a medium color of #ccc
 
 Good:
  This introduces three abstract contrast levels that developers can
  use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Replace `moment` with `dayjs` from stripes-components

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDATIMP-630
-->
https://folio-org.atlassian.net/browse/UIDATIMP-1714

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
