### PR TITLE
UIDATIMP-1764 always navigate to unguardable routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Change history for ui-data-import
 
-## [10.1.0] (IN PROGRESS)
+## [11.0.0] (IN PROGRESS)
 
 ### Features added:
 * Replace moment with day.js (UIDATIMP-1714)
 
 ### Bugs fixed:
 * Fix translation for select placeholder. (UIDATIMP-1756)
+* Always allow redirect to `/logout` on session termination. (UIDATIMP-1764)
 
 ## [10.0.0](https://github.com/folio-org/ui-data-import/tree/v10.0.0) (2026-04-15)
 [Full Changelog](https://github.com/folio-org/ui-data-import/compare/v9.0.2...v10.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/data-import",
-  "version": "10.0.1",
+  "version": "11.0.0",
   "description": "Data Import manager",
   "main": "src/index.js",
   "repository": "folio-org/ui-data-import",
@@ -24,10 +24,10 @@
     "@babel/plugin-transform-runtime": "^7.22.15",
     "@folio/eslint-config-stripes": "^8.0.0",
     "@folio/jest-config-stripes": "^3.0.0",
-    "@folio/stripes": "^10.1.0",
+    "@folio/stripes": "^10.2.0",
     "@folio/stripes-cli": "^4.0.0",
     "@folio/stripes-components": "^13.1.0",
-    "@folio/stripes-core": "^11.1.0",
+    "@folio/stripes-core": "^11.2.0",
     "@folio/stripes-final-form": "^9.0.0",
     "@folio/stripes-form": "^10.0.0",
     "@folio/stripes-smart-components": "^10.1.0",
@@ -68,7 +68,7 @@
     "redux-form": "^8.3.7"
   },
   "peerDependencies": {
-    "@folio/stripes": "^10.1.0",
+    "@folio/stripes": "^10.2.0",
     "react": "^18.2.0",
     "react-intl": "^7.1.5",
     "react-redux": "^8.0.5",

--- a/src/components/UploadingJobsDisplay/UploadingJobsDisplay.js
+++ b/src/components/UploadingJobsDisplay/UploadingJobsDisplay.js
@@ -19,6 +19,7 @@ import {
   stripesShape,
   withOkapiKy,
   checkIfUserInCentralTenant,
+  isGuardable,
 } from '@folio/stripes/core';
 import {
   Pane,
@@ -171,7 +172,20 @@ class UploadingJobsDisplayComponent extends Component {
     return null;
   };
 
-  handleNavigation = nextLocation => {
+  /**
+   * handleNavigation
+   * Prompt the user to confirm navigation away from an in-progress upload.
+   * Returns true to navigate; false to stay at the current location.
+   *
+   * @param {string} nextLocation
+   * @returns {boolean} true when navigation is allowed; false to prevent it
+   */
+  handleNavigation = (nextLocation) => {
+    // some nav (e.g. to `/logout` when a session ends) cannot be guarded
+    if (!isGuardable(nextLocation.pathname)) {
+      return true;
+    }
+
     const { location } = this.props;
 
     const jobProfilePathRegExp = /job-profile(?:\/view)?/g;
@@ -554,7 +568,7 @@ class UploadingJobsDisplayComponent extends Component {
     const dataTypeQuery = dataTypes.length > 0
       ? `(${dataTypes.map(dataType => `"${dataType}"`).join(' OR ')})`
       : '';
-    
+
     const shouldHideDefaultCreateHoldingProfile = checkIfUserInCentralTenant(this.props.stripes);
 
     this.setState({


### PR DESCRIPTION
Sometimes, navigation cannot be guarded (as when navigating to `/logout` when a session times out). Call `stripes-core::isGuardable()` to determine whether the route may be guarded or if navigation is obligatory.

Do not show a "Stay here?" prompt for those obligatory routes.

Refs [UIDATIMP-1764](https://folio-org.atlassian.net/browse/UIDATIMP-1764), [STRIPES-1026](https://folio-org.atlassian.net/browse/STRIPES-1026)