### PR TITLE
UIDATIMP-1731: Create a capability: Data import: Delete authority records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features added:
 * Replace moment with day.js (UIDATIMP-1714)
 * Fix failed unit tests. (UIDATIM-1767)
+* Create a capability: Data import: Delete authority records. (UIDATIMP-1731)
 
 ### Bugs fixed:
 * Fix translation for select placeholder. (UIDATIMP-1756)

--- a/package.json
+++ b/package.json
@@ -451,6 +451,12 @@
           "tags.collection.get"
         ],
         "visible": true
+      },
+      {
+        "permissionName": "ui-data-import.authority-records-delete.execute",
+        "displayName": "Data import: Delete authority records",
+        "visible": true,
+        "subPermissions": []
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -453,7 +453,7 @@
         "visible": true
       },
       {
-        "permissionName": "ui-data-import.authority-records-delete.execute",
+        "permissionName": "ui-data-import.authority-records.delete",
         "displayName": "Data import: Delete authority records",
         "visible": true,
         "subPermissions": []


### PR DESCRIPTION
The result will be:
* `UI-Data-Import Authority-Records-Delete — Execute (Procedural)`

## Link
[UIDATIMP-1731](https://folio-org.atlassian.net/browse/UIDATIMP-1731)